### PR TITLE
Add testing of reference passing

### DIFF
--- a/docs/hook.rst
+++ b/docs/hook.rst
@@ -170,6 +170,20 @@ prevent other call-backs from being executed::
 breakHook method is implemented by throwing a special exception
 that is then caught inside hook() method.
 
+Using references in hooks
+=========================
+
+In some cases you want hook to change certain value. For example
+when model value is set it may call normalization hook (methods
+will change $value)::
+
+    function set($field, $value) {
+        $this->hook('normalize', [&$value]);
+        $this->data[$field] = $value;
+    }
+
+    $m->addHook('normalize', function(&$a) { $a = trim($a); });
+
 Checking if hook has callbacks
 ==============================
 

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -163,6 +163,23 @@ class HookTraitTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testReferences() {
+        $obj = new HookMock();
+
+        $inc = function($obj, &$a) { 
+            $a++;
+        };
+
+        $obj->addHook('inc', $inc);
+        $v = 1;
+        $a = [&$v];
+        $obj->hook('inc', $a);
+
+        $this->assertEquals([2], $a);
+    }
+
+
+
     public function testDefaultMethod() {
         $obj = new HookMock();
         $obj->addHook('myCallback', $obj);

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -176,6 +176,19 @@ class HookTraitTest extends \PHPUnit_Framework_TestCase
         $obj->hook('inc', $a);
 
         $this->assertEquals([2], $a);
+
+
+        $obj = new HookMock();
+
+        $inc = function($obj, &$a) { 
+            $a++;
+        };
+
+        $v = 1;
+        $obj->addHook('inc', $inc);
+        $obj->hook('inc', [&$v]);
+
+        $this->assertEquals(2, $v);
     }
 
 


### PR DESCRIPTION
This adds test that would allow passing references into a hook:


    $o->addHook('inc', function(&$a){ $a++; });

    $arg = 1;
    $o->hook('normalize', [&$arg]);
    echo $arg;  // 2

