### PR TITLE
Improve debug backtrace by including object references

### DIFF
--- a/examples/test4.php
+++ b/examples/test4.php
@@ -1,6 +1,6 @@
 <?php
 
-require '.../vendor/autoload.php';
+require '../vendor/autoload.php';
 
 use atk4\core\Exception;
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -42,7 +42,7 @@ class Exception extends \Exception
         $this->trace2 = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
     }
 
-    function getMyTrace() 
+    public function getMyTrace()
     {
         return $this->trace2;
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -18,6 +18,8 @@ class Exception extends \Exception
      */
     private $params = [];
 
+    public $trace2; // because PHP's use of final() sucks!
+
     /**
      * Constructor.
      *
@@ -37,6 +39,12 @@ class Exception extends \Exception
         }
 
         parent::__construct($message, $code, $previous);
+        $this->trace2 = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
+    }
+
+    function getMyTrace() 
+    {
+        return $this->trace2;
     }
 
     /**

--- a/src/PHPUnit_AgileTestCase.php
+++ b/src/PHPUnit_AgileTestCase.php
@@ -15,7 +15,7 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * NOTE: this method must only be used for low-level functionality, not
-     * for general test-scripts
+     * for general test-scripts.
      */
     public function callProtected($obj, $name, array $args = [])
     {
@@ -28,7 +28,7 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * NOTE: this method must only be used for low-level functionality, not
-     * for general test-scripts
+     * for general test-scripts.
      */
     public function getProtected($obj, $name)
     {


### PR DESCRIPTION
Backtrace in default exception does not include "object". For us that means we won't be able to get "name" which makes debugging hard , as we don't see which object caused things.

This fix will implement custom backtrace which is compatible with ATK4.x.