### PR TITLE
Feature/add psysh command e

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
         </blacklist>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
+            <exclude>
+              <file>./src/PsyshE.php</file>
+            </exclude>
         </whitelist>
     </filter>
     <testsuites>

--- a/src/PHPUnit_AgileTestCase.php
+++ b/src/PHPUnit_AgileTestCase.php
@@ -15,7 +15,7 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * NOTE: this method must only be used for low-level functionality, not
-     * for general test-scripts
+     * for general test-scripts.
      */
     public function callProtected($obj, $name, array $args = [])
     {
@@ -28,7 +28,7 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
 
     /**
      * NOTE: this method must only be used for low-level functionality, not
-     * for general test-scripts
+     * for general test-scripts.
      */
     public function getProtected($obj, $name)
     {

--- a/src/PsyshE.php
+++ b/src/PsyshE.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace atk4\core;
 
-/**
+/*
  * Extend Psysh to display ATK Exceptions nicely by adding into
  * ~/.config/psysh/config.php
  *
@@ -12,23 +13,23 @@ namespace atk4\core;
  * include '/path/to/atk4/core/PsyshE.php';
  *
  * If Agile Exception is thrown, you can get a nice output
- * by typing 
+ * by typing
  *
  * >>> e
  *
  */
 
-use Psy\Context;
 use Psy\Command\TraceCommand;
+use Psy\Context;
 use Psy\ContextAware;
 use Psy\Output\ShellOutput;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PsyshE extends TraceCommand implements ContextAware {
+class PsyshE extends TraceCommand implements ContextAware
+{
     protected $context;
+
     public function setContext(Context $context)
     {
         $this->context = $context;
@@ -65,5 +66,4 @@ HELP
         });
          */
     }
-
 }

--- a/src/PsyshE.php
+++ b/src/PsyshE.php
@@ -1,0 +1,69 @@
+<?php
+namespace atk4\core;
+
+/**
+ * Extend Psysh to display ATK Exceptions nicely by adding into
+ * ~/.config/psysh/config.php
+ *
+ * return [ 'commands' => [ new \atk4\core\PsyshE  ] ];
+ *
+ * If this file fails to load, add this line above return:
+ *
+ * include '/path/to/atk4/core/PsyshE.php';
+ *
+ * If Agile Exception is thrown, you can get a nice output
+ * by typing 
+ *
+ * >>> e
+ *
+ */
+
+use Psy\Context;
+use Psy\Command\TraceCommand;
+use Psy\ContextAware;
+use Psy\Output\ShellOutput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PsyshE extends TraceCommand implements ContextAware {
+    protected $context;
+    public function setContext(Context $context)
+    {
+        $this->context = $context;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('e')
+            ->setDescription('Nicely display Agile Exceptions')
+            ->setHelp(
+                <<<'HELP'
+Display ATK exceptions nicely
+HELP
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $exception = $this->context->getLastException();
+        if (!$exception instanceof \atk4\core\Exception) {
+            throw new \InvalidArgumentException('Last exception wasn\'t Agile Exception. use wtf');
+        }
+        $output->write($exception->getColorfulText());
+        /*
+        $count     = $input->getOption('verbose') ? PHP_INT_MAX : pow(2, max(0, (strlen($incredulity) - 1)));
+
+        $trace     = $this->getBacktrace($exception, $count);
+        $shell = $this->getApplication();
+        $output->page(function ($output) use ($exception, $trace, $shell) {
+            $shell->renderException($exception, $output);
+            $output->writeln('--');
+            $output->write($trace, true, ShellOutput::NUMBER_LINES);
+        });
+         */
+    }
+
+}


### PR DESCRIPTION
Psysh has a command 'wtf' that shows backtrace form the last uncaught exception. Unfortunately it does not look as good as Agile Exceptions colorful exceptions. 


![screen shot 2016-10-18 at 15 19 42](https://cloud.githubusercontent.com/assets/453929/19481591/5156fc38-9546-11e6-9dd8-a56aa54e298e.png)

This PR adds class which can be added to Psysh and will enable command "e". It show great rendering of Agile Exceptions:

![screen shot 2016-10-18 at 15 18 34](https://cloud.githubusercontent.com/assets/453929/19481621/6c51f92a-9546-11e6-8f6b-1012c01e5cd9.png)
