### PR TITLE
Feature/minor fixes

### DIFF
--- a/docs/exception.rst
+++ b/docs/exception.rst
@@ -46,12 +46,16 @@ Since the exception is backwards compatible, it will contain message, code
 and previous exception as any normal PHP excetpion would, but to get the
 parameters you would need to use:
 
-
 .. php:method:: getParams()
 
     Return array that lists all params collected by exception.
 
 Some param values may be objects.
+
+.. php:method:: setMessage($message)
+
+    Change message (subject) of a current exception. Primary use is for
+localization purposes.
 
 
 Output Formatting

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -42,6 +42,16 @@ class Exception extends \Exception
         $this->trace2 = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
     }
 
+    /**
+     * Change message (subject) of a current exception. Primary use is
+     * for localization purposes.
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+        return $this;
+    }
+
     public function getMyTrace()
     {
         return $this->trace2;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -18,6 +18,7 @@ class Exception extends \Exception
      */
     private $params = [];
 
+    /** @var array */
     public $trace2; // because PHP's use of final() sucks!
 
     /**
@@ -45,6 +46,10 @@ class Exception extends \Exception
     /**
      * Change message (subject) of a current exception. Primary use is
      * for localization purposes.
+     *
+     * @param string $message
+     *
+     * @return $this
      */
     public function setMessage($message)
     {
@@ -53,6 +58,11 @@ class Exception extends \Exception
         return $this;
     }
 
+    /**
+     * Return trace array.
+     *
+     * @return array
+     */
     public function getMyTrace()
     {
         return $this->trace2;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -49,6 +49,7 @@ class Exception extends \Exception
     public function setMessage($message)
     {
         $this->message = $message;
+
         return $this;
     }
 

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -23,9 +23,10 @@ trait FactoryTrait
     public function factory($object, $defaults = [])
     {
         if (is_object($object)) {
-            foreach($defaults as $key=>$value) {
+            foreach ($defaults as $key=>$value) {
                 $object->$key = $value;
             }
+
             return $object;
         }
 

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -23,6 +23,9 @@ trait FactoryTrait
     public function factory($object, $defaults = [])
     {
         if (is_object($object)) {
+            foreach($defaults as $key=>$value) {
+                $object->$key = $value;
+            }
             return $object;
         }
 

--- a/src/InitializerTrait.php
+++ b/src/InitializerTrait.php
@@ -27,6 +27,9 @@ trait InitializerTrait
      */
     public function init()
     {
+        if ($this->_initialized) {
+            throw new Exception(['Attempting to initialize twice', 'this'=>$this]);
+        }
         $this->_initialized = true;
     }
 }


### PR DESCRIPTION
 - $exception->setMessage() is now possible. Can be useful to alter error message when we re-throwing it or for localization.
 - factory($object, $defaults) now works consistently with factory($string, $defaults)
 - adding some object into multiple containers won't execute init() again.