### PR TITLE
Feature/refactor factory and seed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 after_script:
     - echo $TRAVIS_PHP_VERSION
     - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "Sending coverage report"; vendor/bin/test-reporter; fi
+    - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then echo "Sending coveralls report"; vendor/bin/coveralls -v; fi
 
 script:
     - if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.0" ]]; then NC="--no-coverage"; fi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/atk4/core/badges/gpa.svg)](https://codeclimate.com/github/atk4/core)
 [![StyleCI](https://styleci.io/repos/57242416/shield)](https://styleci.io/repos/57242416)
 [![Test Coverage](https://codeclimate.com/github/atk4/core/badges/coverage.svg)](https://codeclimate.com/github/atk4/core/coverage)
+[![Coverage Status](https://coveralls.io/repos/github/atk4/core/badge.svg)](https://coveralls.io/github/atk4/core)
 [![Issue Count](https://codeclimate.com/github/atk4/core/badges/issue_count.svg)](https://codeclimate.com/github/atk4/core)
 
 [![License](https://poser.pugx.org/atk4/core/license)](https://packagist.org/packages/atk4/core)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "satooshi/php-coveralls": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,9 @@
             <directory suffix=".php">./src</directory>
             <exclude>
               <file>./src/PsyshE.php</file>
+              <file>src/PHPUnit_AgileResultPrinter.php</file>
+              <file>src/PHPUnit_AgileExceptionWrapper.php</file>
+              <file>src/PHPUnit_AgileTestCase.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -42,9 +42,8 @@ trait DIContainerTrait
      * developer to pass Dependency Injector Container.
      *
      * @param array $properties
-     * @param bool  $strict     - should we raise exceptions?
      */
-    public function setDefaults($properties = [], $strict = false)
+    public function setDefaults($properties = [])
     {
         if ($properties === null) {
             $properties = [];
@@ -58,30 +57,26 @@ trait DIContainerTrait
                     $this->$key = $val;
                 }
             } else {
-                $this->setMissingProperty($key, $val, $strict);
+                $this->setMissingProperty($key, $val);
             }
         }
     }
 
     /**
      * Sets object property.
-     * Throws exception if $strict.
+     * Throws exception
      *
      * @param mixed $key
      * @param mixed $value
      * @param bool  $strict
      */
-    protected function setMissingProperty($key, $value, $strict = false)
+    protected function setMissingProperty($key, $value)
     {
-        if ($strict) {
-            throw new Exception([
-                'Property for specified object is not defined',
-                'object'  => $this,
-                'property'=> $key,
-                'value'   => $value,
-            ]);
-        }
-
-        $this->key = $value;
+        throw new Exception([
+            'Property for specified object is not defined',
+            'object'  => $this,
+            'property'=> $key,
+            'value'   => $value,
+        ]);
     }
 }

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -64,7 +64,7 @@ trait DIContainerTrait
 
     /**
      * Sets object property.
-     * Throws exception
+     * Throws exception.
      *
      * @param mixed $key
      * @param mixed $value

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -19,7 +19,7 @@ trait FactoryTrait
      * Argument $defaults has the same effect as the seed, but allows you to separate
      * out initialization for convenience, e.g. factory(['Button', 'label']); is same as
      * factory('Button', ['label']). Second argument may not affect the class, so it's
-     * safer. 
+     * safer.
      *
      * @param mixed $seed
      * @param array $defaults
@@ -47,11 +47,12 @@ trait FactoryTrait
         $arguments = array_merge($arguments1, $arguments2);
 
         $injection = array_filter(
-            array_merge($defaults, $seed), 
-            function($o) { return !is_numeric($o); }, 
+            array_merge($defaults, $seed),
+            function ($o) {
+                return !is_numeric($o);
+            },
             ARRAY_FILTER_USE_KEY
         );
-
 
         // If object is passed to us, we can ignore arguments, but we need to inject defaults
         if (is_object($object)) {
@@ -61,8 +62,8 @@ trait FactoryTrait
                 } else {
                     throw new Exception([
                         'factory() requested to inject some properties into existing object that does not use \atk4\core\DIContainerTrait',
-                        'object'=>$object,
-                        'injection'=>$injection
+                        'object'   => $object,
+                        'injection'=> $injection,
                     ]);
                 }
             }
@@ -70,13 +71,12 @@ trait FactoryTrait
             return $object;
         }
 
-
         $class = $this->normalizeClassName($object);
 
         if (!$class) {
             throw new Exception([
                 'Class name was not specified by the seed',
-                'seed'=>$seed
+                'seed'=> $seed,
             ]);
         }
 
@@ -88,10 +88,10 @@ trait FactoryTrait
             } else {
                 throw new Exception([
                     'factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait',
-                    'object'=>$object,
-                    'class'=>$class,
-                    'seed'=>$seed,
-                    'injection'=>$injection
+                    'object'   => $object,
+                    'class'    => $class,
+                    'seed'     => $seed,
+                    'injection'=> $injection,
                 ]);
             }
         }

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -12,56 +12,91 @@ trait FactoryTrait
     public $_factoryTrait = true;
 
     /**
-     * Creates and returns new object.
-     * If object is passed as $object parameter, then same object is returned.
+     * Given a Seed (see doc) as a first argument, will create object of a corresponding
+     * class, call constructor with numerical arguments of a seed and inject key/value
+     * arguments.
      *
-     * @param mixed $object
+     * Argument $defaults has the same effect as the seed, but allows you to separate
+     * out initialization for convenience, e.g. factory(['Button', 'label']); is same as
+     * factory('Button', ['label']). Second argument may not affect the class, so it's
+     * safer. 
+     *
+     * @param mixed $seed
      * @param array $defaults
      *
      * @return object
      */
-    public function factory($object, $defaults = [])
+    public function factory($seed, $defaults = [])
     {
         if ($defaults === null) {
             $defaults = [];
         }
 
-        if (is_object($object)) {
+        if (!$seed) {
+            throw new Exception(['Incorrect seed given, try [\'ClassName\']', 'seed'=>$seed]);
+        }
 
-            // If object implements DIContainerTrait we can inject some
-            // of the properties without causing harm
-            if (is_array($defaults) && isset($object->_DIContainerTrait)) {
-                $object->setDefaults($defaults);
+        if (!is_array($seed)) {
+            $seed = [$seed];
+        }
+
+        $arguments1 = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY);
+        $arguments2 = array_filter($defaults, 'is_numeric', ARRAY_FILTER_USE_KEY);
+
+        $object = array_shift($arguments1);
+        $arguments = array_merge($arguments1, $arguments2);
+
+        $injection = array_filter(
+            array_merge($defaults, $seed), 
+            function($o) { return !is_numeric($o); }, 
+            ARRAY_FILTER_USE_KEY
+        );
+
+
+        // If object is passed to us, we can ignore arguments, but we need to inject defaults
+        if (is_object($object)) {
+            if ($injection) {
+                if (isset($object->_DIContainerTrait)) {
+                    $object->setDefaults($injection);
+                } else {
+                    throw new Exception([
+                        'factory() requested to inject some properties into existing object that does not use \atk4\core\DIContainerTrait',
+                        'object'=>$object,
+                        'injection'=>$injection
+                    ]);
+                }
             }
 
             return $object;
         }
 
-        if (is_array($object)) {
-            if (!isset($object[0])) {
-                throw new Exception([
-                    'Object factory definition must use ["class name or object", "x"=>"y"] form',
-                    'object'   => $object,
-                    'defaults' => $defaults,
-                ]);
-            }
-            $class = $object[0];
-            unset($object[0]);
 
-            return $this->factory($class, array_merge($object, $defaults));
-        }
+        $class = $this->normalizeClassName($object);
 
-        if (!is_string($object)) {
+        if (!$class) {
             throw new Exception([
-                'Factory arguments are incorrect',
-                'object'   => $object,
-                'defaults' => $defaults,
+                'Class name was not specified by the seed',
+                'seed'=>$seed
             ]);
         }
 
-        $object = $this->normalizeClassName($object);
+        $object = new $class(...$arguments);
 
-        return $this->factory(new $object(), $defaults);
+        if ($injection) {
+            if (isset($object->_DIContainerTrait)) {
+                $object->setDefaults($injection);
+            } else {
+                throw new Exception([
+                    'factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait',
+                    'object'=>$object,
+                    'class'=>$class,
+                    'seed'=>$seed,
+                    'injection'=>$injection
+                ]);
+            }
+        }
+
+        return $object;
     }
 
     /**

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -137,7 +137,7 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
      * Object factory can not add not defined properties.
      * Receive as class name.
      *
-     * IMPORANT: this no longer throws exception, see https://github.com/atk4/core/issues/46
+     * @expectedException     Exception
      */
     public function testParametersException1()
     {
@@ -150,7 +150,7 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
      * Object factory can not add not defined properties.
      * Receive as object.
      *
-     * IMPORANT: this no longer throws exception, see https://github.com/atk4/core/issues/46
+     * @expectedException     Exception
      */
     public function testParametersException2()
     {

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace atk4\core\tests;
+
+use atk4\core\DIContainerTrait;
+use atk4\core\FactoryTrait;
+
+/**
+ * @coversDefaultClass \atk4\core\FactoryTrait
+ */
+class SeedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test constructor.
+     */
+    use FactoryTrait;
+    public function testBasic()
+    {
+        $s1 = $this->factory('atk4/core/tests/SeedTestMock');
+        $this->assertEmpty($s1->args);
+
+        $s1 = $this->factory(new SeedTestMock());
+        $this->assertEmpty($s1->args);
+
+        $s1 = $this->factory(new SeedTestMock('hello', 'world'));
+        $this->assertEquals(['hello', 'world'], $s1->args);
+
+        $s1 = $this->factory(['atk4/core/tests/SeedTestMock']);
+        $this->assertEmpty($s1->args);
+    }
+
+    public function testArguments()
+    {
+        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello']);
+        $this->assertEquals(['hello'], $s1->args);
+
+        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello', 'world']);
+        $this->assertEquals(['hello', 'world'], $s1->args);
+
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo'=>'bar', 'world']);
+        $this->assertEquals(['hello', 'world'], $s1->args);
+        $this->assertEquals('bar', $s1->foo);
+    }
+
+    public function testDefaults()
+    {
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo'=>'bar', 'world'], ['more', 'baz'=>'', 'args']);
+        $this->assertEquals(['hello', 'world', 'more', 'args'], $s1->args);
+        $this->assertEquals('bar', $s1->foo);
+        $this->assertEquals('', $s1->baz);
+    }
+
+    public function testDefaultsObject()
+    {
+        $s1 = $this->factory([new SeedDITestMock(), 'foo'=>'bar'], ['baz'=>'', 'foo'=>'default']);
+        $this->assertEquals('bar', $s1->foo);
+        $this->assertEquals('', $s1->baz);
+    }
+
+    /**
+     * @expectedException     Exception
+     */
+    public function testMystBeDI()
+    {
+        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello', 'foo'=>'bar', 'world']);
+    }
+
+    /**
+     * @expectedException     Exception
+     */
+    public function testMustHaveProperty()
+    {
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'xxx'=>'bar', 'world']);
+    }
+
+
+    /**
+     * @expectedException     Exception
+     */
+    public function testGiveClassFirst()
+    {
+        $s1 = $this->factory(['foo'=>'bar'], ['atk4/core/tests/SeedDITestMock']);
+    }
+}
+
+
+class SeedTestMock {
+
+    public $args = null;
+    public $foo = null;
+    public $baz = 0;
+
+    function __construct(...$args) {
+        $this->args = $args;
+    }
+
+}
+
+class SeedDITestMock extends SeedTestMock {
+    use DIContainerTrait;
+}

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -10,10 +10,11 @@ use atk4\core\FactoryTrait;
  */
 class SeedTest extends \PHPUnit_Framework_TestCase
 {
-    /**
+    /*
      * Test constructor.
      */
     use FactoryTrait;
+
     public function testBasic()
     {
         $s1 = $this->factory('atk4/core/tests/SeedTestMock');
@@ -73,7 +74,6 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'xxx'=>'bar', 'world']);
     }
 
-
     /**
      * @expectedException     Exception
      */
@@ -83,19 +83,19 @@ class SeedTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-
-class SeedTestMock {
-
+class SeedTestMock
+{
     public $args = null;
     public $foo = null;
     public $baz = 0;
 
-    function __construct(...$args) {
+    public function __construct(...$args)
+    {
         $this->args = $args;
     }
-
 }
 
-class SeedDITestMock extends SeedTestMock {
+class SeedDITestMock extends SeedTestMock
+{
     use DIContainerTrait;
 }


### PR DESCRIPTION
The changes to clean-up Seed will be scheduled for the 1.3 release of Agile Core and will also require Agile Data and Agile UI updates.

The biggest change that the new format implies is a more straightforward way to handle arguments. Previously:


``` php
$app->add(['Button', 'this is label']); 
```

It was unclear on how the label is handled at all. The new behaviour will perform:

``` php
$button = new Button('this is label');
```

And further extensions to the argument scan be implemented through variable arguments on a constructor. This is also much more consistent with:

``` php
$app->add(new Button('this is label'));
```

But this format clearly does not have ability to inject any properties, although someone who uses object like that would prefer to set properties manually anyway.



Additionally implemented Coveralls integration.
