### PR TITLE
refactor normalizeClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![Build Status](https://travis-ci.org/atk4/core.png?branch=develop)](https://travis-ci.org/atk4/core)
 [![Code Climate](https://codeclimate.com/github/atk4/core/badges/gpa.svg)](https://codeclimate.com/github/atk4/core)
 [![StyleCI](https://styleci.io/repos/57242416/shield)](https://styleci.io/repos/57242416)
-[![Test Coverage](https://codeclimate.com/github/atk4/core/badges/coverage.svg)](https://codeclimate.com/github/atk4/core/coverage)
-[![Coverage Status](https://coveralls.io/repos/github/atk4/core/badge.svg)](https://coveralls.io/github/atk4/core)
 [![codecov](https://codecov.io/gh/atk4/core/branch/develop/graph/badge.svg)](https://codecov.io/gh/atk4/core)
 [![Issue Count](https://codeclimate.com/github/atk4/core/badges/issue_count.svg)](https://codeclimate.com/github/atk4/core)
 

--- a/docs/di.rst
+++ b/docs/di.rst
@@ -1,7 +1,9 @@
 
-===============================
-Dependency Injection Containers
-===============================
+==============================
+Dependency Injection Container
+==============================
+
+.. php:trait:: DIContainerTrait
 
 Agile Core implements basic support for Dependency Injection Container.
 

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -10,6 +10,177 @@ Introduction
 This trait can be used to dynamically create new objects by their class
 names. It also contains method for class name normalization.
 
+.. php:method:: factory($seed, $defaults = [])
+
+Creates and returns new object. If object is passed as $seed parameter,
+then same object is returned.
+
+Seed
+====
+
+In a conventional PHP, you can create and configure object before passing
+it onto another object. This action is called "dependency injecting".
+Consider this example::
+
+    $button = new Button('Label');
+    $button->icon = new Icon('book');
+    $button->action = new Action(..);
+
+Because Components can have many optional components, then setting them
+one-by-one is often inconvenient. Also may require to do it recursively,
+e.g. ``Action`` may have to be configured individually.
+
+On top of that, there are also namespaces to consider and quite often you would want to use
+\3rdparty\bootstrap\Button() instead of default button.
+
+Agile Core implements a mechanic to make that possible through using factory() method and
+specifying a seed argument::
+
+    $button = $this->factory(['Button', 'Label', 'icon'=>['book'], 'action'=>new Action(..)]);
+
+it has the same effect, but is shorter. Note that passing 'icon'=>['book'] will also
+use factory to initialize icon object.
+
+Seed Components
+---------------
+
+Class definition - passed as the ``$seed[0]`` and is the only mandatory component, e.g::
+
+    $button = $this->factory(['Button']);
+
+Any other numeric arguments will be passed as constructor arguments::
+
+    $button = $this->factory(['Button', 'My Label', 'red', 'big']);
+
+    // results in 
+
+    new Button('My Label', 'red', 'big');
+
+Finally any named values inside seed array will be assigned to class properties by using
+:php:meth:`DIContainerTrait::setDefaults`. 
+
+Factory uses `array_shift` to to separate class definition from other components.
+
+Factory Defaults
+----------------
+
+Array that lacks class is called defaults, e.g.::
+
+    $defaults = ['My Label', 'red', 'big', 'icon'=>'book'];
+
+You can pass defaults as second argument to :php:meth:`FactoryTrait::factory()`::
+
+    $button = $this->factory(['Button'], $defaults);
+
+Defaults is quite safe and will be often used for example in ``Model->addField($name, $defaults)``
+
+Precedence
+----------
+
+When both seed and defaults are used, then values inside "seed" will have precedence:
+
+ - for named arguments any value specified in "seed" will fully override identical valke from "default"
+ - for constructor argumens, the values specified in "seed" will be passed first, and "defaults" will go after.
+
+For arguments that are arrays (e.g. $view->class) value in seed will override value in default and then will
+be merged with existing property value::
+
+    class RedButton extends Button {
+        public $class = ['red'];
+    }
+
+    $button = $this->factory(['RedButton', 'class'=>['big']], ['class'=>['small']);
+
+    // $button->class == ['red', 'big']
+
+Namespace
+=========
+
+You might have noticed, that seeds do not specify namespace. This is because factroy relies on $app
+to normalize your class name. 
+
+.. php:method:: normalizeClassName($name, $prefix = null)
+
+Seed can use '/my/namespace/Class' where '/' are used instead of '\' to separate
+namespaces. This is because "\" when used within string have special properties
+and also to indicate that some modications may be applied.
+
+Normalize will never change string that contains '\' and will ignore any prefix
+instructons::
+
+    $button = $this->factory(['My\\Namespace\\RedButton'], null, 'other/prefix');
+
+A regular slashes, may be used in various combinations. Here are few things
+to consider:
+
+    - 3rd argument of factory() may specify a contextual prefix.
+    - Application may specify a global default prefix
+    - user may want to specify extra namespace to a class
+    - user may want to fully specify namespace
+
+.. _contextual_prefix:
+
+Contextual Prefix
+-----------------
+
+Methods such as `$form->addField()` or `$app->initLayout()` often use prefixing::
+
+    function initLayout($layout) {
+        $this->layout = $this->factory($layout, ['app'=>$this], 'Layout');
+    }
+
+The above method can then be used with string argument, array or even object and
+will still work consistently. If you specify 'Centered' layout, then it will
+be prefixed with 'Layout\Centered'.
+
+This is called Contextual Prefix and is used in various methods throughout
+Agile Toolkit:
+
+ - Form::addField('age', ['Hidden']); // uses FormField\Hidden class
+ - Table::addColumn('status', ['Checkbox']); // uses TableColumn\Checkbox class
+ - App::initLayout('Admin'); // uses Layout\Admin class
+
+Global Prefix
+-------------
+
+Application class may specify how to add a global namespace. For example,
+\atk4\ui\App will use prefix class name with "\atk4\ui\", unless, of course,
+you override that somehow.
+
+This is done, so that add-ons may intercept generation of Factory class and
+have control over the code like this::
+
+    $button = $this->add(['Button']);
+
+By substituting \atk4\ui\Button with a different button implementation. It's
+even possible to verify if class exists before prefixing or use routing maps,
+but that's up to the ``$this->app->normalizeClassNameApp()``
+
+How to properly use
+-------------------
+
+If you are building some new component that may have plug-ins inside a specific
+namespace, use this::
+
+    function addPlugin($name) {
+        $plugin = $this->factory($name, ['my_comp'=>$this], '/my/namespace/plugin');
+    }
+
+
+Use with add()
+==============
+
+:php:meth:`ContainerTrait::add()` will allow first argument to be Seed but only
+if the object also uses FactoryTrait. This exactly the case for Agile UI / View
+objects, so you can supply seed to add::
+
+    $view->add(['Button', 'class'=>['red']]);
+
+Method add() however only takes one argument and you cannot specify defaults or
+prefix.
+
+In most scenarios, you don't have to use factory() directly, simply use add()
+
 Properties
 ==========
 
@@ -18,29 +189,4 @@ None
 Methods
 =======
 
-.. php:method:: factory($object, $defaults = [])
-
-Creates and returns new object.
-If object is passed as $object parameter, then same object is returned.
-
-.. php:method:: normalizeClassName($name, $prefix = null)
-
-First normalize class name, then add specified prefix to
-class name if it's passed and not already added.
-Class name can contain namespace.
-
-If object is passed as $name parameter, then same object is returned.
-
-Example:: normalizeClassName('User','Model') == 'Model_User';
-
-If object also has an "AppScopeTrait" and if your application object contains
-a method 'normalizeClassName' then we will execute that. A typical use would 
-be if your application defines various routes how to route strings into
-class names permitting this syntax::
-
-    $obj = $this->add('MyClass');
-
-
-Application's normalizeClassName can prepend namespace which will then be
-passed into factory() method for instatination.
 

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -63,7 +63,7 @@ Finally any named values inside seed array will be assigned to class properties 
 Factory uses `array_shift` to separate class definition from other components.
 
 Factory Defaults
-----------------
+================
 
 Array that lacks class is called defaults, e.g.::
 
@@ -75,24 +75,40 @@ You can pass defaults as second argument to :php:meth:`FactoryTrait::factory()`:
 
 Defaults is quite safe and will be often used for example in ``Model->addField($name, $defaults)``
 
-Precedence
-----------
+Precedence and Usage
+--------------------
 
 When both seed and defaults are used, then values inside "seed" will have precedence:
 
  - for named arguments any value specified in "seed" will fully override identical value from "defaults"
  - for constructor arguments, the values specified in "seed" will be passed first, and "defaults" will go after.
 
-For arguments that are arrays (e.g. $view->class) value in seed will override value in "defaults" and then will
-be merged with existing property value::
+The next example will help you understand the precedence of different argument values. See my description below
+the example::
 
     class RedButton extends Button {
-        public $class = ['red'];
+        protected $icon = 'book';
+
+        function init() {
+            parent::init();
+
+            $this->icon = 'right arrow';
+        }
     }
 
-    $button = $this->factory(['RedButton', 'class'=>['big']], ['class'=>['small']);
+    $button = $this->factory(['RedButton', 'icon'=>'cake'], ['icon'=>'thumbs up']);
+    // Question: what would be $button->icon value here?
 
-    // $button->class == ['red', 'big']
+
+Factory will start by merging the parameters and will discover that icon is specified in the seed and is also
+mentioned in the second argument - $defaults. The seed takes precedence, so icon='cake'.
+
+Factory will then create instance of RedButton with a default icon 'book'. It will then execute :php:meth:`DIContainerTrait::setDefaults`
+with the `['icon'=>'cake']` which will change value of $icon to `cake`.
+
+The `cake` will be the final value of the example above. Even though `init()` method is set to change the value
+of icon, the `init()` method is only executed when object becomes part of RenderTree, but that's not happening
+here.
 
 Namespace
 =========
@@ -103,23 +119,70 @@ to normalize your class name.
 .. php:method:: normalizeClassName($name, $prefix = null)
 
 Seed can use '/my/namespace/Class' where '/' are used instead of '\' to separate
-namespaces. This is because "\" when used within string have special properties
-and also to indicate that some modications may be applied.
+namespaces. The '/' will be translated into '\' and they have exactly the same 
+meating::
 
-Normalize will never change string that contains '\' and will ignore any prefix
-instructons::
+    $button = $this->factory(['\My\Namespace\RedButton'], null, 'other/prefix');
 
-    $button = $this->factory(['My\\Namespace\\RedButton'], null, 'other/prefix');
+    // same as
+
+    $button = $this->factory(['/My/Namespace/RedButton'], null, 'other/prefix');
 
 A regular slashes, may be used in various combinations. Here are few things
-to consider:
+to consider.
 
-    - 3rd argument of factory() may specify a contextual prefix.
-    - Application may specify a global default prefix
-    - user may want to specify extra namespace to a class
-    - user may want to fully specify namespace
+    - 3rd argument of factory() is called "Contextual Prefix" and is explained below.
+    - Application may change namespace with "Global Prefixing"
+    - User may want to specify extra namespace inside seed
+    - User may want to override namespace entirely
+
+Motivation
+----------
+
+I have created namespace prefixing as described here for the following reasons:
+
+ - PHP has capability to create class names out of strings, unlike compiled languages
+   that have type safety. I see that as a benefit and a feature of PHP so allowing
+   namespace logic can lift some extra thinking from you.
+
+ - Agile Toolkit is designed to be simple and powerful. The code which uses seeds
+   is very easy to read and understand even for non-programmers.
+
+ - Use of seeds have some great potential for extending. If someone is looking to
+   integrate Agile UI with Drupal, they might need a specific functionality out of
+   their 'Button' implementation. Use of seed allow integrator to substitute classes
+   and redirect button class to a different namespace. Alternatively you would have
+   to change "use" keywords making your code less portable.
+
+Features
+--------
+
+Class normalization and prefixing offer several good features to the rest of the
+framework:
+
+ - Allow to work with App and without App.
+ - Contextual prefixing is great for creating separate class namespaces: 'Checkbox' -> 'FormField/Checkbox'
+ - Namespace prefix "FormLayout" can be used for discovery of possible classes.
+ - Global prefixing logic can be quite sophisticated and implemented inside App.
+ - Use of forward slashes helps avoid errors 
 
 .. _contextual_prefix:
+
+Seed class
+----------
+
+Here are some Seed usage exmaples. First the basic usage where a class specified
+by you "Button" is converted into ``\atk4\ui\Button``::
+
+    // \atk4\ui\Button
+    $app->add(['Button', 'My Label']);
+
+    // \atk4\ui\Button\WithDropdown - (non-existant class)
+    $app->add(['Button\WithDropdown', 'My Label']);
+
+    // \MyNamespace\Button
+    $app->add(['\MyNamespace\Button', 'My Label']);
+
 
 Contextual Prefix
 -----------------
@@ -141,6 +204,42 @@ Agile Toolkit:
  - Table::addColumn('status', ['Checkbox']); // uses TableColumn\Checkbox class
  - App::initLayout('Admin'); // uses Layout\Admin class
 
+Here are some examples of contextual prefixing::
+
+    // \atk4\ui\FormField\Checkbox
+    $form = $app->add('Form');
+    $form->addField('agree_to_terms', 'Checkbox', 'I Agree to Terms of Service');
+
+    // \MyNamespace\Checkbox
+    $form = $app->add('Form');
+    $form->addField('agree_to_terms', '\MyNamespace\Checkbox', 'I Agree to Terms of Service');
+
+Specifying contextual prefix will still leave it up for global prefixing, but
+if you want to fully specify a namespace, then you can use ``\Prefix``. If
+you build your own component in your own namespace with some features, you can use
+this technique::
+
+    namespace my\auth;
+
+    class AuthController {
+        use FactoryTrait;    // implements $this->factory
+        use AppScopeTrait;   // links $this->app
+        use ContainerTrait;  // implements $this->add
+
+        function enableFeature($feature) {
+            return $this->add($this->factory($feature, ['myattr' => $this], '\my\auth\feature');
+        }
+    }
+
+To use this AuthController you would write::
+
+    $auth = $app->add('my\auth\AuthController');
+
+    // \my\auth\feature\facebook
+    $auth->enableFeature('facebook');
+
+This contextual prefixing avoids global prefixing.
+
 Global Prefix
 -------------
 
@@ -154,17 +253,21 @@ have control over the code like this::
     $button = $this->add(['Button']);
 
 By substituting \atk4\ui\Button with a different button implementation. It's
-even possible to verify if class exists before prefixing or use routing maps,
-but that's up to the ``$this->app->normalizeClassNameApp()``
+even possible to verify if class exists before prefixing or use routing maps.
+Neither Agile Core nor Agile UI implement such logic but you can build
+your own ``$this->app->normalizeClassNameApp()``. 
 
-How to properly use
--------------------
+The next example will replace all the ``Grid`` classes with the one you have
+implemented inside your own namespace::
 
-If you are building some new component that may have plug-ins inside a specific
-namespace, use this::
+    class MyApp extends \atk4\ui\App {
+        function normalizeClassNameApp($class) {
+            if ($class == 'Grid') {
+                return '\myextensions\Grid';
+            }
 
-    function addPlugin($name) {
-        $plugin = $this->factory($name, ['my_comp'=>$this], '/my/namespace/plugin');
+            return parent::normalizeClassNameApp($class);
+        }
     }
 
 
@@ -175,19 +278,10 @@ Use with add()
 if the object also uses FactoryTrait. This is exactly the case for Agile UI / View
 objects, so you can supply seed to add::
 
-    $view->add(['Button', 'class'=>['red']]);
+    $grid = $app->add(['Grid', 'toolbar'=>false']);
 
 Method add() however only takes one argument and you cannot specify defaults or
 prefix.
 
 In most scenarios, you don't have to use factory() directly, simply use add()
-
-Properties
-==========
-
-None
-
-Methods
-=======
-
 

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -13,7 +13,8 @@ names. It also contains method for class name normalization.
 .. php:method:: factory($seed, $defaults = [])
 
 Creates and returns new object. If object is passed as $seed parameter,
-then same object is returned.
+then same object is returned, but you can change some properties of this object by using
+$defaults array.
 
 Seed
 ====
@@ -33,7 +34,7 @@ e.g. ``Action`` may have to be configured individually.
 On top of that, there are also namespaces to consider and quite often you would want to use
 \3rdparty\bootstrap\Button() instead of default button.
 
-Agile Core implements a mechanic to make that possible through using factory() method and
+Agile Core implements a mechanism to make that possible through using factory() method and
 specifying a seed argument::
 
     $button = $this->factory(['Button', 'Label', 'icon'=>['book'], 'action'=>new Action(..)]);
@@ -52,14 +53,14 @@ Any other numeric arguments will be passed as constructor arguments::
 
     $button = $this->factory(['Button', 'My Label', 'red', 'big']);
 
-    // results in 
+    // results in
 
     new Button('My Label', 'red', 'big');
 
 Finally any named values inside seed array will be assigned to class properties by using
-:php:meth:`DIContainerTrait::setDefaults`. 
+:php:meth:`DIContainerTrait::setDefaults`.
 
-Factory uses `array_shift` to to separate class definition from other components.
+Factory uses `array_shift` to separate class definition from other components.
 
 Factory Defaults
 ----------------
@@ -79,10 +80,10 @@ Precedence
 
 When both seed and defaults are used, then values inside "seed" will have precedence:
 
- - for named arguments any value specified in "seed" will fully override identical valke from "default"
- - for constructor argumens, the values specified in "seed" will be passed first, and "defaults" will go after.
+ - for named arguments any value specified in "seed" will fully override identical value from "defaults"
+ - for constructor arguments, the values specified in "seed" will be passed first, and "defaults" will go after.
 
-For arguments that are arrays (e.g. $view->class) value in seed will override value in default and then will
+For arguments that are arrays (e.g. $view->class) value in seed will override value in "defaults" and then will
 be merged with existing property value::
 
     class RedButton extends Button {
@@ -96,8 +97,8 @@ be merged with existing property value::
 Namespace
 =========
 
-You might have noticed, that seeds do not specify namespace. This is because factroy relies on $app
-to normalize your class name. 
+You might have noticed, that seeds do not specify namespace. This is because factory relies on $app
+to normalize your class name.
 
 .. php:method:: normalizeClassName($name, $prefix = null)
 
@@ -171,7 +172,7 @@ Use with add()
 ==============
 
 :php:meth:`ContainerTrait::add()` will allow first argument to be Seed but only
-if the object also uses FactoryTrait. This exactly the case for Agile UI / View
+if the object also uses FactoryTrait. This is exactly the case for Agile UI / View
 objects, so you can supply seed to add::
 
     $view->add(['Button', 'class'=>['red']]);

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -119,7 +119,6 @@ trait FactoryTrait
      */
     public function normalizeClassName($name, $prefix = null)
     {
-
         if (!$name) {
             if (
                 isset($this->_appScopeTrait, $this->app)
@@ -138,8 +137,8 @@ trait FactoryTrait
         }
 
         if (
-            $name[0] != '/' 
-            && strpos($name, '\\') === false 
+            $name[0] != '/'
+            && strpos($name, '\\') === false
             && isset($this->_appScopeTrait, $this->app)
             && method_exists($this->app, 'normalizeClassNameApp')
         ) {

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -23,7 +23,7 @@ trait FactoryTrait
      *
      * @param mixed  $seed
      * @param array  $defaults
-     * @param string $prefix Optional prefix for class name
+     * @param string $prefix   Optional prefix for class name
      *
      * @return object
      */
@@ -133,7 +133,6 @@ trait FactoryTrait
 
         // Add prefix only if name doesn't start with / and name doesn't contain \\
         if ($name[0] != '/' && strpos($name, '\\') === false && $prefix) {
-
             $name = $prefix.'/'.$name;
         }
 

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -107,11 +107,11 @@ trait FactoryTrait
      * add prefix.
      *
      * Rule observed: If first character of class, or prefix is
-     * '/' then no more prefixing is done. Also after all the
+     * '/' or '\' then no more prefixing is done. Also after all the
      * prefixing took place, the slashes '/' will be replaced
-     * with '\\'.
+     * with '\'.
      *
-     * Example: normalizeClassName('User', 'Model') == 'Model\\User';
+     * Example: normalizeClassName('User', 'Model') == 'Model\User';
      *
      * @param mixed  $name   Name of class or object
      * @param string $prefix Optional prefix for class name
@@ -132,13 +132,13 @@ trait FactoryTrait
         }
 
         // Add prefix only if name doesn't start with / and name doesn't contain \\
-        if ($name[0] != '/' && strpos($name, '\\') === false && $prefix) {
-            $name = $prefix.'/'.$name;
+        if ($name[0] != '/' && $name[0] != '\\' && $prefix) {
+            $name = $prefix.'\\'.$name;
         }
 
         if (
             $name[0] != '/'
-            && strpos($name, '\\') === false
+            && $name[0] != '\\'
             && isset($this->_appScopeTrait, $this->app)
             && method_exists($this->app, 'normalizeClassNameApp')
         ) {

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -21,8 +21,9 @@ trait FactoryTrait
      * factory('Button', ['label']). Second argument may not affect the class, so it's
      * safer.
      *
-     * @param mixed $seed
-     * @param array $defaults
+     * @param mixed  $seed
+     * @param array  $defaults
+     * @param string $prefix Optional prefix for class name
      *
      * @return object
      */
@@ -102,7 +103,7 @@ trait FactoryTrait
     /**
      * First normalize class name, then add specified prefix to
      * class name. Finally if $app is defined, and has method
-     * `normalizeClassNameApp` it will also gets a chance to
+     * `normalizeClassNameApp` it will also get a chance to
      * add prefix.
      *
      * Rule observed: If first character of class, or prefix is
@@ -130,8 +131,8 @@ trait FactoryTrait
             return $name;
         }
 
+        // Add prefix only if name doesn't start with / and name doesn't contain \\
         if ($name[0] != '/' && strpos($name, '\\') === false && $prefix) {
-            // Add prefix
 
             $name = $prefix.'/'.$name;
         }

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -2,9 +2,9 @@
 
 namespace atk4\core\tests;
 
+use atk4\core\AppScopeTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\FactoryTrait;
-use atk4\core\AppScopeTrait;
 
 /**
  * @coversDefaultClass \atk4\core\FactoryTrait
@@ -189,7 +189,8 @@ class FactoryAppScopeMock
 
 class FactoryTestAppMock
 {
-    function normalizeClassNameApp($name) {
+    public function normalizeClassNameApp($name)
+    {
         return 'atk4/test/'.$name;
     }
 }

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -72,6 +72,9 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
 
         $class = $m->normalizeClassName('MyClass', null);
         $this->assertEquals('atk4\test\MyClass', $class);
+
+        $class = $m->normalizeClassName(null, null);
+        $this->assertEquals('atk4\test\View', $class);
     }
 
     /**
@@ -194,7 +197,10 @@ class FactoryTestAppMock
 {
     public function normalizeClassNameApp($name)
     {
-        return 'atk4/test/'.$name;
+        if (!$name) {
+            $name = 'View';
+        }
+        return 'atk4\test\\'.$name;
     }
 }
 // @codingStandardsIgnoreEnd

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -41,34 +41,37 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
 
         // parameter as namespaced string
         $class = $m->normalizeClassName('a\b\MyClass');
-        $this->assertEquals('a\\b\\MyClass', $class);
+        $this->assertEquals('a\b\MyClass', $class);
 
         $class = $m->normalizeClassName('a/b\MyClass');
-        $this->assertEquals('a\\b\\MyClass', $class);
+        $this->assertEquals('a\b\MyClass', $class);
 
         $class = $m->normalizeClassName('a/b/MyClass', 'Prefix');
-        $this->assertEquals('Prefix\\a\\b\\MyClass', $class);
+        $this->assertEquals('Prefix\a\b\MyClass', $class);
 
         $class = $m->normalizeClassName('/a/b/MyClass', 'Prefix');
-        $this->assertEquals('\\a\\b\\MyClass', $class);
+        $this->assertEquals('\a\b\MyClass', $class);
 
-        $class = $m->normalizeClassName('a\\b\\MyClass', 'Prefix');
-        $this->assertEquals('a\\b\\MyClass', $class);
+        $class = $m->normalizeClassName('\a\b\MyClass', 'Prefix');
+        $this->assertEquals('\a\b\MyClass', $class);
+
+        $class = $m->normalizeClassName('a\b\MyClass', 'Prefix');
+        $this->assertEquals('Prefix\a\b\MyClass', $class);
 
         // With Application Prefixing
         $m = new FactoryAppScopeMock();
         $m->app = new FactoryTestAppMock();
         $class = $m->normalizeClassName('MyClass', 'model');
-        $this->assertEquals('atk4\\test\\model\\MyClass', $class);
+        $this->assertEquals('atk4\test\model\MyClass', $class);
 
         $class = $m->normalizeClassName('/MyClass', 'model');
-        $this->assertEquals('\\MyClass', $class);
+        $this->assertEquals('\MyClass', $class);
 
         $class = $m->normalizeClassName('MyClass', '/model');
-        $this->assertEquals('\\model\\MyClass', $class);
+        $this->assertEquals('\model\MyClass', $class);
 
         $class = $m->normalizeClassName('MyClass', null);
-        $this->assertEquals('atk4\\test\\MyClass', $class);
+        $this->assertEquals('atk4\test\MyClass', $class);
     }
 
     /**

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -200,6 +200,7 @@ class FactoryTestAppMock
         if (!$name) {
             $name = 'View';
         }
+
         return 'atk4\test\\'.$name;
     }
 }

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -4,6 +4,7 @@ namespace atk4\core\tests;
 
 use atk4\core\DIContainerTrait;
 use atk4\core\FactoryTrait;
+use atk4\core\AppScopeTrait;
 
 /**
  * @coversDefaultClass \atk4\core\FactoryTrait
@@ -34,39 +35,40 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
     {
         $m = new FactoryMock();
 
-        // parameter as object
-        $class = $m->normalizeClassName(new FactoryMock());
-        $this->assertEquals(true, is_object($class));
-
         // parameter as simple string
         $class = $m->normalizeClassName('MyClass');
         $this->assertEquals('MyClass', $class);
 
         // parameter as namespaced string
         $class = $m->normalizeClassName('a\b\MyClass');
-        $this->assertEquals('a\b\MyClass', $class);
+        $this->assertEquals('a\\b\\MyClass', $class);
 
         $class = $m->normalizeClassName('a/b\MyClass');
-        $this->assertEquals('a\b\MyClass', $class);
+        $this->assertEquals('a\\b\\MyClass', $class);
 
-        $class = $m->normalizeClassName('a/b/MyClass');
-        $this->assertEquals('a\b\MyClass', $class);
+        $class = $m->normalizeClassName('a/b/MyClass', 'Prefix');
+        $this->assertEquals('Prefix\\a\\b\\MyClass', $class);
 
-        // with prefix
+        $class = $m->normalizeClassName('/a/b/MyClass', 'Prefix');
+        $this->assertEquals('\\a\\b\\MyClass', $class);
+
+        $class = $m->normalizeClassName('a\\b\\MyClass', 'Prefix');
+        $this->assertEquals('a\\b\\MyClass', $class);
+
+        // With Application Prefixing
+        $m = new FactoryAppScopeMock();
+        $m->app = new FactoryTestAppMock();
         $class = $m->normalizeClassName('MyClass', 'model');
-        $this->assertEquals('Model_MyClass', $class);
+        $this->assertEquals('atk4\\test\\model\\MyClass', $class);
 
-        $class = $m->normalizeClassName('a\b\MyClass', 'model');
-        $this->assertEquals('a\b\Model_MyClass', $class);
+        $class = $m->normalizeClassName('/MyClass', 'model');
+        $this->assertEquals('\\MyClass', $class);
 
-        $class = $m->normalizeClassName('a\b\My_Class', 'model');
-        $this->assertEquals('a\b\Model_My_Class', $class);
+        $class = $m->normalizeClassName('MyClass', '/model');
+        $this->assertEquals('\\model\\MyClass', $class);
 
-        $class = $m->normalizeClassName('a\b\Model_MyClass', 'model');
-        $this->assertEquals('a\b\Model_MyClass', $class);
-
-        $class = $m->normalizeClassName('a\b\model_MyClass', 'model');
-        $this->assertEquals('a\b\Model_model_MyClass', $class);
+        $class = $m->normalizeClassName('MyClass', null);
+        $this->assertEquals('atk4\\test\\MyClass', $class);
     }
 
     /**
@@ -178,5 +180,17 @@ class FactoryDIMock
     public $a = 'AAA';
     public $b = 'BBB';
     public $c;
+}
+class FactoryAppScopeMock
+{
+    use AppScopeTrait;
+    use FactoryTrait;
+}
+
+class FactoryTestAppMock
+{
+    function normalizeClassNameApp($name) {
+        return 'atk4/test/'.$name;
+    }
 }
 // @codingStandardsIgnoreEnd

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -43,6 +43,21 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $s1->foo);
     }
 
+    public function testPrefix()
+    {
+        // prefix could be fully specified (global)
+        $s1 = $this->factory('SeedTestMock', ['hello'], '/atk4/core/tests');
+        $this->assertEquals(['hello'], $s1->args);
+
+        // specifying prefix yourself will override, but only if you start with slash
+        $s1 = $this->factory('/atk4/core/tests/SeedTestMock', ['hello'], '/atk4/core/tests');
+        $this->assertEquals(['hello'], $s1->args);
+
+        // without slash, prefixes add up
+        $s1 = $this->factory('tests/SeedTestMock', ['hello'], '/atk4/core');
+        $this->assertEquals(['hello'], $s1->args);
+    }
+
     public function testDefaults()
     {
         $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo'=>'bar', 'world'], ['more', 'baz'=>'', 'args']);
@@ -98,4 +113,12 @@ class SeedTestMock
 class SeedDITestMock extends SeedTestMock
 {
     use DIContainerTrait;
+}
+
+class SeedAppPrefixMock 
+{
+    function normalizeClassNameApp($name, $prefix)
+    {
+        var_Dump($name, $prefix);
+    }
 }

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -115,10 +115,10 @@ class SeedDITestMock extends SeedTestMock
     use DIContainerTrait;
 }
 
-class SeedAppPrefixMock 
+class SeedAppPrefixMock
 {
-    function normalizeClassNameApp($name, $prefix)
+    public function normalizeClassNameApp($name, $prefix)
     {
-        var_Dump($name, $prefix);
+        var_dump($name, $prefix);
     }
 }


### PR DESCRIPTION
This is to make normalizeClassName work according to Agile UI / Agile Data logic and use of namespaces rather than using old atk4 way.

Please [see documentation inside](https://github.com/atk4/core/blob/f970b44891aa08d6121e0e4fd5955ba2bea8ad42/docs/factory.rst) for more information.