### PR TITLE
Improve merging consistency for non-key arguments in factory()

### DIFF
--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -65,23 +65,45 @@ Factory uses `array_shift` to separate class definition from other components.
 Factory Defaults
 ================
 
+Defaults array takes place of $seed if $seed is missing components. $defaults is
+using identical format to seed, but it only can be array.
+
 Array that lacks class is called defaults, e.g.::
 
-    $defaults = ['My Label', 'red', 'big', 'icon'=>'book'];
+    $defaults = ['Label', 'My Label', 'big red', 'icon'=>'book'];
 
 You can pass defaults as second argument to :php:meth:`FactoryTrait::factory()`::
 
     $button = $this->factory(['Button'], $defaults);
 
-Defaults is quite safe and will be often used for example in ``Model->addField($name, $defaults)``
+Executing code above will result in 'Button' class being used with 'My Label' as a caption
+and 'big red' class and 'book' icon.
+
+You may also use ``null`` to skip an argument, for instance in the above example if you wish
+to change the label, but keep the class, use this::
+
+    $label = $this->factory([null, 'Other Label'], $defaults);
+
+Finally, if you pass key/value pair inside seed with a value of ``null`` then default value
+will still be used::
+
+    $label = $this->factory(['icon'=>null], $defaults);
+
+This will result icon=book. If you wish to disable icon, you should use ``false`` value::
+
+    $label = $this->factory(['icon'=>false], $defaults);
+
+With this it's handy to pass icon as an argument and don't worry if the null is used.
 
 Precedence and Usage
 --------------------
 
 When both seed and defaults are used, then values inside "seed" will have precedence:
 
- - for named arguments any value specified in "seed" will fully override identical value from "defaults"
- - for constructor arguments, the values specified in "seed" will be passed first, and "defaults" will go after.
+ - for named arguments any value specified in "seed" will fully override identical value from "defaults",
+   unless if the seed's value is "null".
+ - for constructor arguments, the non-null values specified in "seed" will replace corresponding
+   value from $defaults.
 
 The next example will help you understand the precedence of different argument values. See my description below
 the example::

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -35,7 +35,7 @@ trait FactoryTrait
 
         if (!$seed) {
             $seed = [];
-        } 
+        }
 
         if (!is_array($seed)) {
             $seed = [$seed];

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -34,8 +34,8 @@ trait FactoryTrait
         }
 
         if (!$seed) {
-            throw new Exception(['Incorrect seed given, try [\'ClassName\']', 'seed'=>$seed]);
-        }
+            $seed = [];
+        } 
 
         if (!is_array($seed)) {
             $seed = [$seed];

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -42,7 +42,9 @@ trait FactoryTrait
         }
 
         foreach ($seed as $key=>$value) {
-            $defaults[$key] = $value;
+            if ($value !== null) {
+                $defaults[$key] = $value;
+            }
         }
 
         $arguments = array_filter($defaults, 'is_numeric', ARRAY_FILTER_USE_KEY);

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -41,14 +41,16 @@ trait FactoryTrait
             $seed = [$seed];
         }
 
-        $arguments1 = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY);
-        $arguments2 = array_filter($defaults, 'is_numeric', ARRAY_FILTER_USE_KEY);
+        foreach ($seed as $key=>$value) {
+            $defaults[$key] = $value;
+        }
 
-        $object = array_shift($arguments1);
-        $arguments = array_merge($arguments1, $arguments2);
+        $arguments = array_filter($defaults, 'is_numeric', ARRAY_FILTER_USE_KEY);
+
+        $object = array_shift($arguments);
 
         $injection = array_filter(
-            array_merge($defaults, $seed),
+            $defaults,
             function ($o) {
                 return !is_numeric($o);
             },

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -92,7 +92,6 @@ class SeedTest extends \PHPUnit_Framework_TestCase
 
         $s1 = $this->factory([], ['atk4/core/tests/SeedDITestMock', 'test']);
         $this->assertEquals(['test'], $s1->args);
-
     }
 
     public function testDefaultsObject()
@@ -129,7 +128,6 @@ class SeedTest extends \PHPUnit_Framework_TestCase
     {
         $s1 = $this->factory([], ['foo' => 'bar']);
     }
-
 
     /**
      * @expectedException     Exception

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -84,6 +84,15 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertEquals(['more', 'world', 'args'], $s1->args);
         $this->assertEquals('bar', $s1->foo);
+
+        $s1 = $this->factory(null, ['atk4/core/tests/SeedDITestMock', 'more', 'foo'=>'bar', 'more', 'args']);
+        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $this->assertEquals(['more', 'more', 'args'], $s1->args);
+        $this->assertEquals('bar', $s1->foo);
+
+        $s1 = $this->factory([], ['atk4/core/tests/SeedDITestMock', 'test']);
+        $this->assertEquals(['test'], $s1->args);
+
     }
 
     public function testDefaultsObject()
@@ -113,12 +122,14 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['x', 'y'], $s1->args);
     }
 
+
     /**
      * @expectedException     Exception
      */
-    public function testSeedMustBe()
+    public function testClassMayNotBeEmpty()
     {
-        $s1 = $this->factory([], ['atk4/core/tests/SeedTestMock', 'hello']);
+        $s1 = $this->factory([''], ['atk4/core/tests/SeedDITestMock', 'test']);
+        $this->assertEquals(['test'], $s1->args);
     }
 
     /**

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -78,6 +78,14 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $s1->setDefaults(null);
     }
 
+    public function testNull()
+    {
+        $s1 = $this->factory([null, 'foo'=>null, null, 'world'], ['atk4/core/tests/SeedDITestMock', 'more', 'foo'=>'bar', 'more', 'args']);
+        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $this->assertEquals(['more', 'world', 'args'], $s1->args);
+        $this->assertEquals('bar', $s1->foo);
+    }
+
     public function testDefaultsObject()
     {
         $s1 = $this->factory([new SeedDITestMock(), 'foo'=>'bar'], ['baz'=>'', 'foo'=>'default']);
@@ -94,6 +102,16 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $o->foo = ['xx'];
         $s1 = $this->factory([$o, 'foo'=>['red']], ['foo'=>['big'], 'foo'=>'default']);
         $this->assertEquals(['xx', 'red'], $s1->foo);
+
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'world'], [null, 'more', 'more', 'args']);
+        $this->assertEquals(['hello', 'world', 'args'], $s1->args);
+
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', null, 'world'], [null, 'more', 'more', 'args']);
+        $this->assertEquals(['more', 'world', 'args'], $s1->args);
+
+        $s1 = $this->factory([new SeedDITestMock('x', 'y'), null, 'bar'], [null, 'foo', 'baz']);
+        $this->assertEquals(['x', 'y'], $s1->args);
+
     }
 
     /**

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -122,6 +122,14 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['x', 'y'], $s1->args);
     }
 
+    /**
+     * @expectedException     Exception
+     */
+    public function testSeedMustBe()
+    {
+        $s1 = $this->factory([], ['foo' => 'bar']);
+    }
+
 
     /**
      * @expectedException     Exception

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -111,7 +111,6 @@ class SeedTest extends \PHPUnit_Framework_TestCase
 
         $s1 = $this->factory([new SeedDITestMock('x', 'y'), null, 'bar'], [null, 'foo', 'baz']);
         $this->assertEquals(['x', 'y'], $s1->args);
-
     }
 
     /**

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -55,22 +55,23 @@ class SeedTest extends \PHPUnit_Framework_TestCase
     public function testPrefix()
     {
         // prefix could be fully specified (global)
-        $s1 = $this->factory('SeedTestMock', ['hello'], '/atk4/core/tests');
+        $s1 = $this->factory('SeedTestMock', [null, 'hello'], '/atk4/core/tests');
         $this->assertEquals(['hello'], $s1->args);
 
         // specifying prefix yourself will override, but only if you start with slash
-        $s1 = $this->factory('/atk4/core/tests/SeedTestMock', ['hello'], '/atk4/core/tests');
+        $s1 = $this->factory('/atk4/core/tests/SeedTestMock', [null, 'hello'], '/atk4/core/tests');
         $this->assertEquals(['hello'], $s1->args);
 
         // without slash, prefixes add up
-        $s1 = $this->factory('tests/SeedTestMock', ['hello'], '/atk4/core');
+        $s1 = $this->factory('tests/SeedTestMock', [null, 'hello'], '/atk4/core');
         $this->assertEquals(['hello'], $s1->args);
     }
 
     public function testDefaults()
     {
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo'=>'bar', 'world'], ['more', 'baz'=>'', 'args']);
-        $this->assertEquals(['hello', 'world', 'more', 'args'], $s1->args);
+        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo'=>'bar', 'world'], ['atk4/core/tests/SeedTestMock', 'more', 'baz'=>'', 'more', 'args']);
+        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $this->assertEquals(['hello', 'world', 'args'], $s1->args);
         $this->assertEquals('bar', $s1->foo);
         $this->assertEquals('', $s1->baz);
 
@@ -119,12 +120,10 @@ class SeedTest extends \PHPUnit_Framework_TestCase
         $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'xxx'=>'bar', 'world']);
     }
 
-    /**
-     * @expectedException     Exception
-     */
     public function testGiveClassFirst()
     {
         $s1 = $this->factory(['foo'=>'bar'], ['atk4/core/tests/SeedDITestMock']);
+        $this->assertTrue($s1 instanceof SeedDITestMock);
     }
 }
 


### PR DESCRIPTION
Currently, when you use numeric arguments in $seed and $defaults of factory() call, they are being merged:

``` php
$object1 = $factory(['Button', 'Hello'], ['Label', 'World']);
// $object1 initialized with new('Button', 'Hello', 'Label', 'World');
```

This makes very little sense so in this PR I'm changing the way how labels are merged. The same code as above would result in:

``` php
// $object1 initialized with new('Button', 'Hello');
```

If the seed is omitted, then defaults are used

``` php
$object1 = $factory([], ['Label', 'World']);
// $object1 initialized with new('Label', 'World');
```

Which can be quite useful inside components that allow component injection through seed. Let's take Form and it's $form->buttonSubmit. The init() code could do this:

``` php
$this->buttonSubmit = $this->factory($this->buttonSubmit, ['Button', 'Save', 'primary']);
```

This would allow anyone to initialize form like this:

``` php
$this->add('Form', ['buttonSubmit' => [null, 'Register', 'class'=>['big']]);
```