### PR TITLE
setDefaults should ignore numeric keys otherwise we can get exception…

### DIFF
--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -50,6 +50,11 @@ trait DIContainerTrait
         }
 
         foreach ($properties as $key => $val) {
+            // ignore numeric keys
+            if (is_numeric($key)) {
+                continue;
+            }
+
             if (property_exists($this, $key)) {
                 if (is_array($val)) {
                     $this->$key = array_merge(isset($this->$key) && is_array($this->$key) ? $this->$key : [], $val);

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -50,9 +50,13 @@ trait DIContainerTrait
         }
 
         foreach ($properties as $key => $val) {
-            // ignore numeric keys
             if (is_numeric($key)) {
-                continue;
+                throw new Exception([
+                    'Numeric property names are not allowed',
+                    'object'  => $this,
+                    'property'=> $key,
+                    'value'   => $val,
+                ]);
             }
 
             if (property_exists($this, $key)) {

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -2,7 +2,6 @@
 
 namespace atk4\core\tests;
 
-use atk4\core\AppScopeTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\FactoryTrait;
 
@@ -34,17 +33,17 @@ class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test properties
+     * Test properties.
      */
     public function testProperties()
     {
         $m = new FactoryDIMock();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar']);
-        $this->assertEquals([$m->a,$m->b,$m->c], ['foo','BBB','bar']);
+        $this->assertEquals([$m->a, $m->b, $m->c], ['foo', 'BBB', 'bar']);
 
         $m->setDefaults(['a' => null, 'c' => false]);
-        $this->assertEquals([$m->a,$m->b,$m->c], ['foo','BBB',false]);
+        $this->assertEquals([$m->a, $m->b, $m->c], ['foo', 'BBB', false]);
     }
 }
 

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -17,7 +17,7 @@ class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testException1()
     {
-        $m = new FactoryDIMock();
+        $m = new FactoryDIMock2();
         $m->setDefaults([5 => 'qwerty']);
     }
 
@@ -28,7 +28,7 @@ class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testException2()
     {
-        $m = new FactoryDIMock();
+        $m = new FactoryDIMock2();
         $m->setDefaults(['not_exist' => 'qwerty']);
     }
 
@@ -37,7 +37,7 @@ class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
      */
     public function testProperties()
     {
-        $m = new FactoryDIMock();
+        $m = new FactoryDIMock2();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar']);
         $this->assertEquals([$m->a, $m->b, $m->c], ['foo', 'BBB', 'bar']);
@@ -48,7 +48,7 @@ class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
 }
 
 // @codingStandardsIgnoreStart
-class FactoryDIMock
+class FactoryDIMock2
 {
     use FactoryTrait;
     use DIContainerTrait;

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace atk4\core\tests;
+
+use atk4\core\AppScopeTrait;
+use atk4\core\DIContainerTrait;
+use atk4\core\FactoryTrait;
+
+/**
+ * @coversDefaultClass \atk4\core\DIContainerTrait
+ */
+class DIContainerTraitTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Do not allow numeric property names (array keys).
+     *
+     * @expectedException     Exception
+     */
+    public function testException1()
+    {
+        $m = new FactoryDIMock();
+        $m->setDefaults([5 => 'qwerty']);
+    }
+
+    /**
+     * Do not allow non existant property names (array keys).
+     *
+     * @expectedException     Exception
+     */
+    public function testException2()
+    {
+        $m = new FactoryDIMock();
+        $m->setDefaults(['not_exist' => 'qwerty']);
+    }
+
+    /**
+     * Test properties
+     */
+    public function testProperties()
+    {
+        $m = new FactoryDIMock();
+
+        $m->setDefaults(['a' => 'foo', 'c' => 'bar']);
+        $this->assertEquals([$m->a,$m->b,$m->c], ['foo','BBB','bar']);
+
+        $m->setDefaults(['a' => null, 'c' => false]);
+        $this->assertEquals([$m->a,$m->b,$m->c], ['foo','BBB',false]);
+    }
+}
+
+// @codingStandardsIgnoreStart
+class FactoryDIMock
+{
+    use FactoryTrait;
+    use DIContainerTrait;
+
+    public $a = 'AAA';
+    public $b = 'BBB';
+    public $c;
+}
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
setDefaults should ignore numeric keys otherwise we can get exceptions like these:

```
atk4\core\Exception: Property for specified object is not defined
             object: Object atk4\data\Model
           property: 0
              value: "user"
```