### PR TITLE
Address problem with shortener, creating identifiers that start with number

### DIFF
--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -209,7 +209,7 @@ trait ContainerTrait
             $rest = substr($desired, $left);
 
             if (!isset($this->app->unique_hashes[$key])) {
-                $this->app->unique_hashes[$key] = dechex(crc32($key));
+                $this->app->unique_hashes[$key] = '_'.dechex(crc32($key));
             }
             $desired = $this->app->unique_hashes[$key].'__'.$rest;
         }


### PR DESCRIPTION
Shortener cuts out portion of a long name and replaces it with a hex-value of a crc sum. Unfortunately, sometimes that hex number would start with a number resulting in identifier such as:

"7c2e2644__e_callbacklater"

Although it seems OK, form serializer does not accept such a key:

https://github.com/macek/jquery-serialize-object/blob/master/jquery.serialize-object.js#L31

and the field is simply ignored and not serialized.

This PR will prefix shortened variables with a '_':

"_7c2e2644__e_callbacklater". 