### PR TITLE
Feature/no special treatment for injected arrays

### DIFF
--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -55,9 +55,8 @@ trait DIContainerTrait
                 if ($passively && $this->$key !== null) {
                     continue;
                 }
-                if (is_array($val)) {
-                    $this->$key = array_merge(isset($this->$key) && is_array($this->$key) ? $this->$key : [], $val);
-                } elseif ($val !== null) {
+
+                if ($val !== null) {
                     $this->$key = $val;
                 }
             } else {

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -409,13 +409,13 @@ class SeedTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test seed property merging
+     * Test seed property merging.
      */
     public function testPropertyMerging()
     {
         $s1 = $this->factory(
-            ['atk4/core/tests/SeedDITestMock', 'foo'=>['Button', 'icon'=>'red']], 
-            ['foo'=>['Label', 'red']]);
+            ['atk4/core/tests/SeedDITestMock', 'foo'=>['Button', 'icon'=>'red']],
+            ['foo'=> ['Label', 'red']]);
 
         $this->assertEquals(['Button', 'icon'=>'red'], $s1->foo);
 
@@ -423,8 +423,6 @@ class SeedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['Message', 'detail'=>'blah'], $s1->foo);
     }
-
-
 }
 
 class SeedTestMock
@@ -454,7 +452,6 @@ class ViewTestMock extends SeedTestMock
     public function setDefaults($properties = [], $passively = false)
     {
         if ($properties['foo']) {
-
             if ($passively) {
                 $this->foo = array_merge($properties['foo'], $this->foo);
             } else {
@@ -462,6 +459,7 @@ class ViewTestMock extends SeedTestMock
             }
             unset($properties['foo']);
         }
+
         return $this->_setDefaults($properties, $passively);
     }
 }


### PR DESCRIPTION
When DIContainerTrait was originally implemented, it had a special treatment for arrays, e.g:

``` php
$app->add('Button', 'class'=>['blue']);
```

Instead of replacing value of the $class property, the contents would be merged. Unfortunately this has a major impact on the way how "seeds" work, for example here:

``` php
$app->add('MyWidget', 'title'=>['MyTitle', 'hello world']);
```

If MyWidget already defines title property it won't be replaced with new seed instead it will be merged causing 'MyTitle' to be sent as constructor argument.

There are many cases where array merging is bad and only a single case where it's beneficial, so I'm making array injection consistent with other values and will provide a special treatment for the $class property merging inside views.

I have supplied a test-script which can be used to refactor View's `setDefaults` method in a test-script within this PR

 - [ ] Check if any documentation should be removed / amended.