### PR TITLE
Feature/add html console exception output

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -159,14 +159,14 @@ class Exception extends \Exception
     }
 
     /**
-     * Similar to getColorfulText() but will use raw HTML for outputting colors
+     * Similar to getColorfulText() but will use raw HTML for outputting colors.
      *
      * @return string
      */
     public function getHTMLText()
     {
         $output = "--[ Agile Toolkit Exception ]---------------------------\n";
-        $output .= get_class($this).": <font color='pink'><b>".$this->getMessage()."</b></font>".
+        $output .= get_class($this).": <font color='pink'><b>".$this->getMessage().'</b></font>'.
             ($this->getCode() ? ' [code: '.$this->getCode().']' : '');
 
         foreach ($this->params as $key => $val) {
@@ -196,12 +196,12 @@ class Exception extends \Exception
 
             $line = str_pad(@$call['line'], 4, ' ', STR_PAD_LEFT);
 
-            $output .= "\n<font color='cyan'>".$file."</font>";
-            $output .= ":<font color='pink'>".$line."</font>";
+            $output .= "\n<font color='cyan'>".$file.'</font>';
+            $output .= ":<font color='pink'>".$line.'</font>';
 
             if (isset($call['object'])) {
                 $name = (!isset($call['object']->name)) ? get_class($call['object']) : $call['object']->name;
-                $output .= " - <font color='yellow'>".$name."</font>";
+                $output .= " - <font color='yellow'>".$name.'</font>';
             }
 
             $output .= " <font color='gray'>";
@@ -209,7 +209,7 @@ class Exception extends \Exception
             if (isset($call['class'])) {
                 $output .= $call['class'].'::';
             }
-            $output .='</font>';
+            $output .= '</font>';
 
             if ($escape_frame) {
                 $output .= "<font color='pink'>".$call['function'].'</font>';
@@ -230,7 +230,7 @@ class Exception extends \Exception
 
         if ($p = $this->getPrevious()) {
             $output .= "\n\nCaused by Previous Exception:\n";
-            $output .= get_class($p).": <font color='pink'>".$p->getMessage()."</font>".
+            $output .= get_class($p).": <font color='pink'>".$p->getMessage().'</font>'.
                 ($p->getCode() ? ' [code: '.$p->getCode().']' : '');
         }
 

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -34,6 +34,12 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/PrevError/', $ret);
         $this->assertRegExp('/333/', $ret);
 
+        // get console HTLM
+        $ret = $m->getHTMLText();
+        $this->assertRegExp('/TestIt/', $ret);
+        $this->assertRegExp('/PrevError/', $ret);
+        $this->assertRegExp('/333/', $ret);
+
         // get colorful text
         $ret = $m->getHTML();
         $this->assertRegExp('/TestIt/', $ret);


### PR DESCRIPTION
Currently we have getColorfulText() (ANSI) and getHTML (semantic ui html). This PR also addsn getHTMLText() method which is a combination of both - it looks like the console output but uses raw HTML for `<font color>`. This method is used by atk4/ui console.