### PR TITLE
use $app->logger and send errors there rather than app itself

### DIFF
--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -48,8 +48,8 @@ trait DebugTrait
 
         // if debug is enabled, then log it
         if ($this->debug) {
-            if (isset($this->app) && $this->app instanceof \Psr\Log\LoggerInterface) {
-                $this->app->log('debug', $message, $context);
+            if (isset($this->app) && isset($this->app->logger) && $this->app->logger instanceof \Psr\Log\LoggerInterface) {
+                $this->app->logger->log('debug', $message, $context);
             } else {
                 $this->_echo_stderr('['.get_class($this)."]: $message\n");
             }
@@ -69,8 +69,8 @@ trait DebugTrait
      */
     public function log($level, $message, $context = [])
     {
-        if (isset($this->app) && $this->app instanceof \Psr\Log\LoggerInterface) {
-            $this->app->log($level, $message, $context);
+        if (isset($this->app) && isset($this->app->logger) && $this->app->logger instanceof \Psr\Log\LoggerInterface) {
+            $this->app->logger->log($level, $message, $context);
         } else {
             $this->_echo_stderr("$message\n");
         }

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -52,6 +52,7 @@ class DebugTraitTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputString('');
 
         $app = new DebugAppMock();
+        $app->logger = $app;
 
         $m = new DebugMock();
         $m->app = $app;
@@ -75,6 +76,7 @@ class DebugTraitTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputString('');
 
         $app = new DebugAppMock();
+        $app->logger = $app;
 
         $m = new DebugMock();
         $m->app = $app;
@@ -125,6 +127,7 @@ class DebugTraitTest extends \PHPUnit_Framework_TestCase
         $app = new DebugAppMock();
 
         $m = new DebugMock();
+        $app->logger = $app;
         $m->app = $app;
 
         $this->triggerDebugTraceChange($m, 'test1'); // difference is 1 line between calls
@@ -169,6 +172,7 @@ class DebugAppMock implements \Psr\Log\LoggerInterface
     use \Psr\Log\LoggerTrait;
 
     public $log;
+    public $logger;
 
     public function log($level, $message, array $context = [])
     {


### PR DESCRIPTION
This way it's possible for `Console` in Agile UI to temporarily set itself as a logger.