### PR TITLE
add support for PHPUnit 7+

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,9 @@
               <file>src/PHPUnit_AgileResultPrinter.php</file>
               <file>src/PHPUnit_AgileExceptionWrapper.php</file>
               <file>src/PHPUnit_AgileTestCase.php</file>
+              <file>src/PHPUnit7_AgileResultPrinter.php</file>
+              <file>src/PHPUnit7_AgileExceptionWrapper.php</file>
+              <file>src/PHPUnit7_AgileTestCase.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/PHPUnit7_AgileExceptionWrapper.php
+++ b/src/PHPUnit7_AgileExceptionWrapper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace atk4\core;
+
+/**
+ * Generic PHPUnit exception wrapper for ATK4 repos.
+ */
+class PHPUnit7_AgileExceptionWrapper extends \PHPUnit\Framework\Exception
+{
+    /** @var \Exception Previous exception */
+    public $previous;
+
+    /**
+     * Constructor.
+     *
+     * @param string     $message
+     * @param int        $code
+     * @param \Exception $previous
+     */
+    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    {
+        $this->previous = $previous;
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/PHPUnit7_AgileResultPrinter.php
+++ b/src/PHPUnit7_AgileResultPrinter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace atk4\core;
+
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\TextUI\ResultPrinter;
+
+/**
+ * Generic ResultPrinter for PHPUnit tests of ATK4 repos.
+ */
+class PHPUnit7_AgileResultPrinter extends  ResultPrinter
+{
+    /**
+     * Prints trace info.
+     *
+     * @param \PHPUnit_Framework_TestFailure $defect
+     */
+
+    protected function printDefectTrace(TestFailure $defect): void
+    {
+        $e = $defect->thrownException();
+        if (!$e instanceof \atk4\core\PHPUnit7_AgileExceptionWrapper) {
+            parent::printDefectTrace($defect);
+            return;
+        }
+        $this->write((string) $e);
+
+        $p = $e->getPrevious();
+
+        if ($p instanceof \atk4\core\Exception) {
+            $this->write($p->getColorfulText());
+        }
+    }
+}

--- a/src/PHPUnit7_AgileResultPrinter.php
+++ b/src/PHPUnit7_AgileResultPrinter.php
@@ -8,19 +8,19 @@ use PHPUnit\TextUI\ResultPrinter;
 /**
  * Generic ResultPrinter for PHPUnit tests of ATK4 repos.
  */
-class PHPUnit7_AgileResultPrinter extends  ResultPrinter
+class PHPUnit7_AgileResultPrinter extends ResultPrinter
 {
     /**
      * Prints trace info.
      *
      * @param \PHPUnit_Framework_TestFailure $defect
      */
-
     protected function printDefectTrace(TestFailure $defect): void
     {
         $e = $defect->thrownException();
         if (!$e instanceof \atk4\core\PHPUnit7_AgileExceptionWrapper) {
             parent::printDefectTrace($defect);
+
             return;
         }
         $this->write((string) $e);

--- a/src/PHPUnit7_AgileTestCase.php
+++ b/src/PHPUnit7_AgileTestCase.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PHPUnit7_AgileTestCase extends TestCase
 {
-    function runBare(): void
+    public function runBare(): void
     {
         try {
             parent::runBare();

--- a/src/PHPUnit7_AgileTestCase.php
+++ b/src/PHPUnit7_AgileTestCase.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace atk4\core;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Generic TestCase for PHPUnit tests for ATK4 repos.
+ */
+class PHPUnit7_AgileTestCase extends TestCase
+{
+    function runBare(): void
+    {
+        try {
+            parent::runBare();
+        } catch (\Exception $e) {
+            throw new PHPUnit7_AgileExceptionWrapper($e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Calls protected method.
+     *
+     * NOTE: this method must only be used for low-level functionality, not
+     * for general test-scripts.
+     *
+     * @param object $obj
+     * @param string $name
+     * @param array  $args
+     *
+     * @return mixed
+     */
+    public function callProtected($obj, $name, array $args = [])
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($obj, $args);
+    }
+
+    /**
+     * Returns protected property value.
+     *
+     * NOTE: this method must only be used for low-level functionality, not
+     * for general test-scripts.
+     *
+     * @param object $obj
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getProtected($obj, $name)
+    {
+        $class = new \ReflectionClass($obj);
+        $method = $class->getProperty($name);
+        $method->setAccessible(true);
+
+        return $method->getValue($obj);
+    }
+}


### PR DESCRIPTION
Using different namespaces now, so not compatible.

Usage: phpunit.xml

``` xml
<phpunit colors="true" bootstrap="tests/bootstrap.php" printerClass="atk4\core\PHPUnit7_AgileResultPrinter">
```

Usage: Test.php

``` php
use atk4\core\PHPUnit7_AgileTestCase;

class Test extends PHPUnit7_AgileTestCase {
```