### PR TITLE
Feature/add class specification tests

### DIFF
--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -5,7 +5,6 @@ namespace atk4\core\tests;
 use atk4\core\AppScopeTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\FactoryTrait;
-
 use atk4\core\HookBreaker as HB;
 
 /**

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -6,6 +6,8 @@ use atk4\core\AppScopeTrait;
 use atk4\core\DIContainerTrait;
 use atk4\core\FactoryTrait;
 
+use atk4\core\HookBreaker as HB;
+
 /**
  * @coversDefaultClass \atk4\core\FactoryTrait
  */
@@ -58,6 +60,9 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
         $class = $m->normalizeClassName('a\b\MyClass', 'Prefix');
         $this->assertEquals('Prefix\a\b\MyClass', $class);
 
+        $class = $m->normalizeClassName(\atk\data\Persistence::class, 'Prefix');
+        $this->assertEquals('Prefix\atk\data\Persistence', $class);
+
         // With Application Prefixing
         $m = new FactoryAppScopeMock();
         $m->app = new FactoryTestAppMock();
@@ -99,6 +104,15 @@ class FactoryTraitTest extends \PHPUnit_Framework_TestCase
         // as class name
         $m1 = $m->factory('atk4\core\tests\FactoryMock');
         $this->assertEquals('atk4\core\tests\FactoryMock', get_class($m1));
+
+        $m1 = $m->factory(\atk4\core\tests\FactoryMock::class);
+        $this->assertEquals('atk4\core\tests\FactoryMock', get_class($m1));
+
+        $m1 = $m->factory(FactoryMock::class);
+        $this->assertEquals('atk4\core\tests\FactoryMock', get_class($m1));
+
+        $m1 = $m->factory(HB::class, ['ok']);
+        $this->assertEquals('atk4\core\HookBreaker', get_class($m1));
 
         $m1 = $m->factory(['atk4\core\tests\FactoryMock']);
         $this->assertEquals('atk4\core\tests\FactoryMock', get_class($m1));


### PR DESCRIPTION
I'm trying to address this issue:

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/453929/50385443-88852400-06cd-11e9-9356-f172f9bb449d.png">

popping from this code:

``` php
<?php
namespace saasty\Model\Saasty;
use saasty\Model;

class Addon extends Model\Model
{
    public $table = 'saasty_addon';

    public function init()
    {
        parent::init();
        $this->addField('name', ['required' => true, 'type' => 'string']);

        // skip fields

        $this->hasOne('ugly_app_id', Model\App::class);
    }
}
```

Possible cause:

https://github.com/atk4/ui/blob/develop/src/App.php#L360