### PR TITLE
only do it for atk/core exception

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -149,11 +149,14 @@ class Exception extends \Exception
             $output .= "\n\033[0mCaused by Previous Exception:\n";
             $output .= "\033[1;31m".get_class($p).': '.$p->getMessage()."\033[0;31m".
                 ($p->getCode() ? ' [code: '.$p->getCode().']' : '');
+            if ($p instanceof \atk4\core\Exception) {
+                $output .= "\n+".str_replace("\n", "\n| ", $p->getColorfulText());
+            }
         }
 
         // next print params
 
-        $output .= "\n\033[1;31m--------------------------------------------------------\n";
+        $output .= "\n\033[1;31m-------------------------------------------------------\n";
 
         return $output."\033[0m";
     }


### PR DESCRIPTION
When exception is caused by another exception, which is "atk4\core" show that one in full detail. (at least in console)


<img width="870" alt="image" src="https://user-images.githubusercontent.com/453929/58053877-b2455880-7b50-11e9-938d-4a34621987c3.png">
