### PR TITLE
Configuration Elements cannot be replaced

### DIFF
--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -94,7 +94,7 @@ trait ConfigTrait
             $configs[] = $tempConfig;
         }
 
-        $this->config = array_merge_recursive($this->config, ...$configs);
+        $this->config = array_replace_recursive($this->config, ...$configs);
 
         return $this;
     }


### PR DESCRIPTION
If multiple configuration files are used, a configuration item cannot be replaced.
e.g. Standard Configuration with User Configuration.
default: `$config['lang' => 'en'];`
user: `$config['lang' => 'de'];`
Calling `$obj->getConfig('lang')` returns an array `['en', 'de']`.
However, the string 'de' would be desired.
Is there a special reason why `array_merge_recursive` is used?
This can be prevented with `array_replace_recursive`.
Thanks in advance for an explanation.
