### PR TITLE
Add default class name fallback for addToWithClassName method

### DIFF
--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -112,15 +112,15 @@ trait StaticAddToTrait
                 $seed = [$seed];
             }
 
-            $cl = reset($seed);
-            if (key($seed) !== 0) {
-                throw new Exception('Class name in seed is not defined');
-            }
-
             if (isset($parent->_factoryTrait)) {
-                $object = $parent->factory($seed);
+                $object = $parent->factory($parent->mergeSeeds($seed, [static::class]));
             } else {
-                unset($seed[key($seed)]);
+                $cl = reset($seed);
+                if (key($seed) === 0) {
+                    unset($seed[key($seed)]);
+                } else {
+                    $cl = static::class;
+                }
                 $object = new $cl(...$seed);
             }
         }


### PR DESCRIPTION
PR done - but analyse first if `static::class` or `self::class` or none (no PR) should be used.

If used from static code, then `static::class` is perfect.

But if used from some method like:
```
public function add($seed) {
    return static::addToWithClassName($this, $seed);
}
```
on extended class like `CRUD`, then `$crud->add(['ui' => 'something'])` will create `CRUD` instance instead of `View`.

There should be probably no default class.