### PR TITLE
Shorten exception trace

### DIFF
--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -86,10 +86,9 @@ TEXT;
 
         $in_atk = true;
         $escape_frame = false;
-        $tokens = [];
-        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
-        $trace_count = count($trace);
-        foreach ($trace as $index => $call) {
+        $short_trace = $this->getStackTrace(true);
+        $is_shortened = end($short_trace) && key($short_trace) !== 0;
+        foreach ($short_trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
@@ -97,6 +96,7 @@ TEXT;
                 $in_atk = false;
             }
 
+            $tokens = [];
             $tokens['{FILE}'] = $call['file_formatted'];
             $tokens['{LINE}'] = $call['line_formatted'];
             $tokens['{OBJECT}'] = null !== $call['object_formatted'] ? " - \e[0;32m".$call['object_formatted']."\e[0m" : '';
@@ -113,10 +113,15 @@ TEXT;
                     $args[] = static::toSafeString($arg);
                 }
 
-                $tokens['{FUNCTION_ARGS}'] = PHP_EOL.str_repeat(' ', 40)."\e[0;31m(".implode(', ', $args).')';
+                $tokens['{FUNCTION_ARGS}'] = "\e[0;31m(".PHP_EOL.str_repeat(' ', 40).implode(','.PHP_EOL.str_repeat(' ', 40), $args).')';
             }
 
             $this->output .= $this->replaceTokens($tokens, $text);
+        }
+
+        if ($is_shortened) {
+            $this->output .= '...
+            ';
         }
     }
 

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -128,7 +128,7 @@ TEXT;
 
         $this->output .= PHP_EOL."\e[1;45mCaused by Previous Exception:\e[0m".PHP_EOL;
 
-        $this->output .= (string) (new static($this->exception->getPrevious()));
+        $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
         $this->output .= <<<TEXT
 \e[1;31m--
 \e[0m

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -31,7 +31,7 @@ TEXT
 
     protected function processParams(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -50,7 +50,7 @@ TEXT
 
     protected function processSolutions(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -87,7 +87,7 @@ TEXT;
         $in_atk = true;
         $escape_frame = false;
         $tokens = [];
-        $trace = $this->is_atk_exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
+        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -89,7 +89,7 @@ TEXT;
         $short_trace = $this->getStackTrace(true);
         $is_shortened = end($short_trace) && key($short_trace) !== 0;
         foreach ($short_trace as $index => $call) {
-            $call = $this->parseCallTraceObject($call);
+            $call = $this->parseStackTraceCall($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
                 $escape_frame = true;

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -137,7 +137,7 @@ class HTML extends RendererAbstract
         $short_trace = $this->getStackTrace(true);
         $is_shortened = end($short_trace) && key($short_trace) !== 0;
         foreach ($short_trace as $index => $call) {
-            $call = $this->parseCallTraceObject($call);
+            $call = $this->parseStackTraceCall($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
                 $escape_frame = true;

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -25,7 +25,7 @@ class HTML extends RendererAbstract
                 <i class="warning sign icon"></i>
                 <div class="content">
                     <div class="header">{TITLE}</div>
-                    {CLASS} {CODE}
+                    {CLASS} {CODE}:
                     {MESSAGE}
                 </div>
             </div>

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -190,6 +190,6 @@ class HTML extends RendererAbstract
             </div>
         ';
 
-        $this->output .= (string) (new static($this->exception->getPrevious()));
+        $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
     }
 }

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -34,7 +34,7 @@ class HTML extends RendererAbstract
 
     protected function processParams(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -75,7 +75,7 @@ class HTML extends RendererAbstract
 
     protected function processSolutions(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -135,7 +135,7 @@ class HTML extends RendererAbstract
         $in_atk = true;
         $escape_frame = false;
         $tokens_trace = [];
-        $trace = $this->is_atk_exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
+        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -134,7 +134,7 @@ class HTML extends RendererAbstract
 
         $in_atk = true;
         $escape_frame = false;
-        $tokens_trace = [];
+        $tokens = [];
         $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
@@ -145,14 +145,14 @@ class HTML extends RendererAbstract
                 $in_atk = false;
             }
 
-            $tokens_trace['{INDEX}'] = $trace_count - $index;
-            $tokens_trace['{FILE_LINE}'] = empty(trim($call['file_formatted'])) ? '' : $call['file_formatted'].':'.$call['line_formatted'];
-            $tokens_trace['{OBJECT}'] = false !== $call['object'] ? $call['object_formatted'] : '-';
-            $tokens_trace['{CLASS}'] = false !== $call['class'] ? $call['class'].'::' : '';
-            $tokens_trace['{CSS_CLASS}'] = $escape_frame ? 'negative' : '';
+            $tokens['{INDEX}'] = $trace_count - $index;
+            $tokens['{FILE_LINE}'] = empty(trim($call['file_formatted'])) ? '' : $call['file_formatted'].':'.$call['line_formatted'];
+            $tokens['{OBJECT}'] = false !== $call['object'] ? $call['object_formatted'] : '-';
+            $tokens['{CLASS}'] = false !== $call['class'] ? $call['class'].'::' : '';
+            $tokens['{CSS_CLASS}'] = $escape_frame ? 'negative' : '';
 
-            $tokens_trace['{FUNCTION}'] = $call['function'];
-            $tokens_trace['{FUNCTION_ARGS}'] = '()</td>';
+            $tokens['{FUNCTION}'] = $call['function'];
+            $tokens['{FUNCTION_ARGS}'] = '()</td>';
 
             if ($escape_frame) {
                 $escape_frame = false;
@@ -163,7 +163,7 @@ class HTML extends RendererAbstract
                 }
 
                 if (!empty($args)) {
-                    $tokens_trace['{FUNCTION_ARGS}'] = "
+                    $tokens['{FUNCTION_ARGS}'] = "
                             </td>
                         </tr>
                         <tr class='negative'>
@@ -174,7 +174,7 @@ class HTML extends RendererAbstract
                 }
             }
 
-            $this->output .= $this->replaceTokens($tokens_trace, $text);
+            $this->output .= $this->replaceTokens($tokens, $text);
         }
     }
 

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -93,10 +93,9 @@ HTML;
 
         $in_atk = true;
         $escape_frame = false;
-        $tokens = [];
-        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
-        $trace_count = count($trace);
-        foreach ($trace as $index => $call) {
+        $short_trace = $this->getStackTrace(true);
+        $is_shortened = end($short_trace) && key($short_trace) !== 0;
+        foreach ($short_trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
@@ -104,6 +103,7 @@ HTML;
                 $in_atk = false;
             }
 
+            $tokens = [];
             $tokens['{FILE}'] = $call['file_formatted'];
             $tokens['{LINE}'] = $call['line_formatted'];
             $tokens['{OBJECT}'] = null !== $call['object'] ? " - <span style='color:yellow'>".$call['object_formatted'].'</span>' : '';
@@ -121,10 +121,15 @@ HTML;
                     $args[] = static::toSafeString($arg);
                 }
 
-                $tokens['{FUNCTION_ARGS}'] = PHP_EOL.str_repeat(' ', 40).'('.implode(', ', $args).')';
+                $tokens['{FUNCTION_ARGS}'] = '('.PHP_EOL.str_repeat(' ', 40).implode(','.PHP_EOL.str_repeat(' ', 40), $args).')';
             }
 
             $this->output .= $this->replaceTokens($tokens, $text);
+        }
+
+        if ($is_shortened) {
+            $this->output .= '...
+            ';
         }
     }
 

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -136,6 +136,6 @@ HTML;
 
         $this->output .= PHP_EOL.'Caused by Previous Exception:'.PHP_EOL;
 
-        $this->output .= (string) (new static($this->exception->getPrevious()));
+        $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
     }
 }

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -32,7 +32,7 @@ HTML
 
     protected function processParams(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -56,7 +56,7 @@ HTML
 
     protected function processSolutions(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -94,7 +94,7 @@ HTML;
         $in_atk = true;
         $escape_frame = false;
         $tokens_trace = [];
-        $trace = $this->is_atk_exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
+        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -87,7 +87,7 @@ HTML;
     protected function processStackTraceInternal(): void
     {
         $text = <<<'HTML'
-<span color='cyan'>{FILE}</span>:<span color='pink'>{LINE}</span>{OBJECT} <span color='gray'>{CLASS}<span style="color:{FUNCTION_COLOR}">{FUNCTION}<span style='color:pink'>{FUNCTION_ARGS}</span></span>
+<span color='cyan'>{FILE}</span>:<span color='pink'>{LINE}</span>{OBJECT} <span color='gray'>{CLASS}<span style="color:{FUNCTION_COLOR}">{FUNCTION}<span style='color:pink'>{FUNCTION_ARGS}</span></span></span>
 
 HTML;
 

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -96,7 +96,7 @@ HTML;
         $short_trace = $this->getStackTrace(true);
         $is_shortened = end($short_trace) && key($short_trace) !== 0;
         foreach ($short_trace as $index => $call) {
-            $call = $this->parseCallTraceObject($call);
+            $call = $this->parseStackTraceCall($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
                 $escape_frame = true;

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -93,7 +93,7 @@ HTML;
 
         $in_atk = true;
         $escape_frame = false;
-        $tokens_trace = [];
+        $tokens = [];
         $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
@@ -104,14 +104,14 @@ HTML;
                 $in_atk = false;
             }
 
-            $tokens_trace['{FILE}'] = $call['file_formatted'];
-            $tokens_trace['{LINE}'] = $call['line_formatted'];
-            $tokens_trace['{OBJECT}'] = null !== $call['object'] ? " - <span style='color:yellow'>".$call['object_formatted'].'</span>' : '';
-            $tokens_trace['{CLASS}'] = null !== $call['class'] ? $call['class'].'::' : '';
+            $tokens['{FILE}'] = $call['file_formatted'];
+            $tokens['{LINE}'] = $call['line_formatted'];
+            $tokens['{OBJECT}'] = null !== $call['object'] ? " - <span style='color:yellow'>".$call['object_formatted'].'</span>' : '';
+            $tokens['{CLASS}'] = null !== $call['class'] ? $call['class'].'::' : '';
 
-            $tokens_trace['{FUNCTION_COLOR}'] = $escape_frame ? 'pink' : 'gray';
-            $tokens_trace['{FUNCTION}'] = $call['function'];
-            $tokens_trace['{FUNCTION_ARGS}'] = '()';
+            $tokens['{FUNCTION_COLOR}'] = $escape_frame ? 'pink' : 'gray';
+            $tokens['{FUNCTION}'] = $call['function'];
+            $tokens['{FUNCTION_ARGS}'] = '()';
 
             if ($escape_frame) {
                 $escape_frame = false;
@@ -121,10 +121,10 @@ HTML;
                     $args[] = static::toSafeString($arg);
                 }
 
-                $tokens_trace['{FUNCTION_ARGS}'] = PHP_EOL.str_repeat(' ', 40).'('.implode(', ', $args).')';
+                $tokens['{FUNCTION_ARGS}'] = PHP_EOL.str_repeat(' ', 40).'('.implode(', ', $args).')';
             }
 
-            $this->output .= $this->replaceTokens($tokens_trace, $text);
+            $this->output .= $this->replaceTokens($tokens, $text);
         }
     }
 

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -81,9 +81,7 @@ HTML;
     {
         $in_atk = true;
         $escape_frame = false;
-        $tokens_trace = [];
-        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
-        $trace_count = count($trace);
+        $trace = $this->getStackTrace(false);
         foreach ($trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);
 

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -113,7 +113,7 @@ HTML;
             return;
         }
 
-        $previous = new static($this->exception->getPrevious());
+        $previous = new static($this->exception->getPrevious(), $this->adapter);
         $text = (string) $previous; // need to trigger processAll;
 
         $this->json['previous'] = $previous->json;

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -83,7 +83,7 @@ HTML;
         $escape_frame = false;
         $trace = $this->getStackTrace(false);
         foreach ($trace as $index => $call) {
-            $call = $this->parseCallTraceObject($call);
+            $call = $this->parseStackTraceCall($call);
 
             if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
                 $escape_frame = true;
@@ -117,7 +117,7 @@ HTML;
         $this->json['previous'] = $previous->json;
     }
 
-    protected function parseCallTraceObject($call): array
+    protected function parseStackTraceCall($call): array
     {
         return [
             'line'     => $call['line'] ?? '',

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -33,7 +33,7 @@ class JSON extends RendererAbstract
 
     protected function processParams(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -51,7 +51,7 @@ class JSON extends RendererAbstract
 
     protected function processSolutions(): void
     {
-        if (false === $this->is_atk_exception) {
+        if (!$this->exception instanceof Exception) {
             return;
         }
 
@@ -82,7 +82,7 @@ HTML;
         $in_atk = true;
         $escape_frame = false;
         $tokens_trace = [];
-        $trace = $this->is_atk_exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
+        $trace = $this->exception instanceof Exception ? $this->exception->getMyTrace() : $this->exception->getTrace();
         $trace_count = count($trace);
         foreach ($trace as $index => $call) {
             $call = $this->parseCallTraceObject($call);

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -19,17 +19,13 @@ abstract class RendererAbstract
     /** @var string */
     public $output = '';
 
-    /** @var bool */
-    public $is_atk_exception = false;
-
     /** @var ITranslatorAdapter|null */
     public $adapter;
 
-    public function __construct($exception, ?ITranslatorAdapter $adapter = null)
+    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null)
     {
         $this->adapter = $adapter;
         $this->exception = $exception;
-        $this->is_atk_exception = $exception instanceof Exception;
     }
 
     abstract protected function processHeader(): void;
@@ -61,7 +57,7 @@ abstract class RendererAbstract
             return $this->output;
         } catch (\Throwable $e) {
             // fallback if Exception occur in renderer
-            return get_class($this->exception).' ['.$this->exception->getCode().'] Error:'.$this->_($this->exception->getMessage());
+            return get_class($this->exception).' ['.$this->exception->getCode().'] Error: '.$this->_($this->exception->getMessage());
         }
     }
 
@@ -115,7 +111,7 @@ abstract class RendererAbstract
      */
     protected function getExceptionTitle(): string
     {
-        return $this->is_atk_exception
+        return $this->exception instanceof Exception
             ? $this->exception->getCustomExceptionTitle()
             : static::getClassShortName($this->exception).' Error';
     }
@@ -125,7 +121,7 @@ abstract class RendererAbstract
      */
     protected function getExceptionName(): string
     {
-        return $this->is_atk_exception
+        return $this->exception instanceof Exception
             ? $this->exception->getCustomExceptionName()
             : get_class($this->exception);
     }

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -16,16 +16,20 @@ abstract class RendererAbstract
     /** @var \Throwable */
     public $exception;
 
+    /** @var \Throwable|null */
+    public $parent_exception;
+
     /** @var string */
     public $output = '';
 
     /** @var ITranslatorAdapter|null */
     public $adapter;
 
-    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null)
+    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null, \Throwable $parent_exception = null)
     {
         $this->adapter = $adapter;
         $this->exception = $exception;
+        $this->parent_exception = $parent_exception;
     }
 
     abstract protected function processHeader(): void;

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -141,27 +141,27 @@ abstract class RendererAbstract
             : $this->exception->getTrace();
         $trace = array_combine(range(count($trace) - 1, 0, -1), $trace);
 
-        if (!$shorten || $this->parent_exception === null) {
-            return $trace;
+        if ($shorten && $this->parent_exception !== null) {
+            $parent_trace = $this->parent_exception instanceof Exception
+                ? $this->parent_exception->getMyTrace()
+                : $this->parent_exception->getTrace();
+            $parent_trace = array_combine(range(count($parent_trace) - 1, 0, -1), $parent_trace);
+        } else {
+            $parent_trace = [];
         }
-
-        $parent_trace = $this->parent_exception instanceof Exception
-            ? $this->parent_exception->getMyTrace()
-            : $this->parent_exception->getTrace();
-        $parent_trace = array_combine(range(count($parent_trace) - 1, 0, -1), $parent_trace);
 
         $both_atk = $this->exception instanceof Exception && $this->parent_exception instanceof Exception;
         $c = min(count($trace), count($parent_trace));
         for ($i = 0; $i < $c; $i++) {
-            $cv = $trace[$i];
-            $pv = $parent_trace[$i];
+            $cv = $this->parseStackTraceCall($trace[$i]);
+            $pv = $this->parseStackTraceCall($parent_trace[$i]);
 
-            if (($cv['line'] ?? null) === ($pv['line'] ?? null)
-                    && ($cv['file'] ?? null) === ($pv['file'] ?? null)
-                    && ($cv['class'] ?? null) === ($pv['class'] ?? null)
-                    && (!$both_atk || ($cv['object'] ?? null) === ($pv['object'] ?? null))
-                    && ($cv['function'] ?? null) === ($pv['function'] ?? null)
-                    && (!$both_atk || ($cv['args'] ?? null) === ($pv['args'] ?? null))) {
+            if ($cv['line'] === $pv['line']
+                    && $cv['file'] === $pv['file']
+                    && $cv['class'] === $pv['class']
+                    && (!$both_atk || $cv['object'] === $pv['object'])
+                    && $cv['function'] === $pv['function']
+                    && (!$both_atk || $cv['args'] === $pv['args'])) {
                 unset($trace[$i]);
             } else {
                 break;

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -70,7 +70,7 @@ abstract class RendererAbstract
         return str_replace(array_keys($tokens), array_values($tokens), $text);
     }
 
-    protected function parseCallTraceObject($call): array
+    protected function parseStackTraceCall(array $call): array
     {
         $parsed = [
             'line'             => (string) ($call['line'] ?? ''),

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -166,9 +166,9 @@ class ExceptionTest extends TestCase
     public function testExceptionFallback(): void
     {
         $m = new ExceptionTestThrowError(['test']);
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error:test', $m->getHTML());
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error:test', $m->getHTMLText());
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error:test', $m->getColorfulText());
+        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getHTML());
+        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getHTMLText());
+        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getColorfulText());
         $this->assertEquals(
             json_encode(
                 [


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/2228672/78842220-ba73e400-79ff-11ea-98e4-27c317e2c0c7.png)

![image](https://user-images.githubusercontent.com/2228672/78884524-5a129000-7a5b-11ea-8533-9386dcc30cba.png)

After:
![image](https://user-images.githubusercontent.com/2228672/78842179-9d3f1580-79ff-11ea-9505-b249a780ed05.png)

![image](https://user-images.githubusercontent.com/2228672/78884462-3fd8b200-7a5b-11ea-8829-f725aac32568.png)

Example code:
```
    try {
        throw new \atk4\ui\Exception('source');
    } catch (\atk4\ui\Exception $ex) {
        throw new \Exception('parent', 0, $ex);
    }
```