### PR TITLE
Remove custom alias/name for exception class

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -28,9 +28,6 @@ class Exception extends \Exception
     /** @var string */
     protected $custom_exception_title = 'Critical Error';
 
-    /** @var string The name of the Exception for custom naming */
-    protected $custom_exception_name = null;
-
     /**
      * Most exceptions would be a cause by some other exception, Agile
      * Core will encapsulate them and allow you to access them anyway.
@@ -212,16 +209,6 @@ class Exception extends \Exception
     public function getSolutions(): array
     {
         return $this->solutions;
-    }
-
-    /**
-     * Get the custom Exception name, if defined in $custom_exception_name.
-     *
-     * @return string
-     */
-    public function getCustomExceptionName(): string
-    {
-        return $this->custom_exception_name ?? get_class($this);
     }
 
     /**

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -11,7 +11,7 @@ class Console extends RendererAbstract
     protected function processHeader(): void
     {
         $title = $this->getExceptionTitle();
-        $class = $this->getExceptionName();
+        $class = get_class($this->exception);
 
         $tokens = [
             '{TITLE}'   => $title,

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -54,14 +54,11 @@ TEXT
             return;
         }
 
-        /** @var Exception $exception */
-        $exception = $this->exception;
-
-        if (0 === count($exception->getSolutions())) {
+        if (0 === count($this->exception->getSolutions())) {
             return;
         }
 
-        foreach ($exception->getSolutions() as $key => $val) {
+        foreach ($this->exception->getSolutions() as $key => $val) {
             $this->output .= PHP_EOL."\e[92mSolution: ".$val."\e[0m";
         }
     }

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -11,7 +11,7 @@ class HTML extends RendererAbstract
     protected function processHeader(): void
     {
         $title = $this->getExceptionTitle();
-        $class = $this->getExceptionName();
+        $class = get_class($this->exception);
 
         $tokens = [
             '{TITLE}'   => $title,

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -38,10 +38,7 @@ class HTML extends RendererAbstract
             return;
         }
 
-        /** @var Exception $exception */
-        $exception = $this->exception;
-
-        if (0 === count($exception->getParams())) {
+        if (0 === count($this->exception->getParams())) {
             return;
         }
 
@@ -56,7 +53,7 @@ class HTML extends RendererAbstract
             '{PARAMS}' => '',
         ];
         $text_inner = '<div class="ui segment"><b>{KEY}</b>:{VAL}</div>';
-        foreach ($exception->getParams() as $key => $val) {
+        foreach ($this->exception->getParams() as $key => $val) {
             $key = str_pad((string) $key, 19, ' ', STR_PAD_LEFT);
             $key = htmlentities($key);
             $val = htmlentities(static::toSafeString($val));

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -11,7 +11,7 @@ class HTMLText extends RendererAbstract
     protected function processHeader(): void
     {
         $title = $this->getExceptionTitle();
-        $class = $this->getExceptionName();
+        $class = get_class($this->exception);
 
         $tokens = [
             '{TITLE}'   => $title,

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -36,16 +36,13 @@ HTML
             return;
         }
 
-        /** @var Exception $exception */
-        $exception = $this->exception;
-
-        if (0 === count($exception->getParams())) {
+        if (0 === count($this->exception->getParams())) {
             return;
         }
 
         $this->output .= PHP_EOL.'<span style="color:cyan;">Exception params: </span>';
 
-        foreach ($exception->getParams() as $key => $val) {
+        foreach ($this->exception->getParams() as $key => $val) {
             $key = str_pad((string) $key, 19, ' ', STR_PAD_LEFT);
             $key = htmlentities($key);
             $val = htmlentities(static::toSafeString($val));

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -23,7 +23,7 @@ class JSON extends RendererAbstract
     protected function processHeader(): void
     {
         $title = $this->getExceptionTitle();
-        $class = $this->getExceptionName();
+        $class = get_class($this->exception);
 
         $this->json['code'] = $this->exception->getCode();
         $this->json['message'] = $this->_($this->exception->getMessage());

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -37,14 +37,11 @@ class JSON extends RendererAbstract
             return;
         }
 
-        /** @var Exception $exception */
-        $exception = $this->exception;
-
-        if (0 === count($exception->getParams())) {
+        if (0 === count($this->exception->getParams())) {
             return;
         }
 
-        foreach ($exception->getParams() as $key => $val) {
+        foreach ($this->exception->getParams() as $key => $val) {
             $this->json['params'][$key] = static::toSafeString($val);
         }
     }

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -13,10 +13,10 @@ abstract class RendererAbstract
 {
     use TranslatableTrait;
 
-    /** @var \Throwable */
+    /** @var \Throwable|Exception */
     public $exception;
 
-    /** @var \Throwable|null */
+    /** @var \Throwable|Exception|null */
     public $parent_exception;
 
     /** @var string */

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -105,29 +105,11 @@ abstract class RendererAbstract
         return (string) json_encode($val);
     }
 
-    protected static function getClassShortName(\Throwable $exception): string
-    {
-        return preg_replace('/.*\\\\/', '', get_class($exception));
-    }
-
-    /**
-     * @return string
-     */
     protected function getExceptionTitle(): string
     {
         return $this->exception instanceof Exception
             ? $this->exception->getCustomExceptionTitle()
-            : static::getClassShortName($this->exception).' Error';
-    }
-
-    /**
-     * @return string
-     */
-    protected function getExceptionName(): string
-    {
-        return $this->exception instanceof Exception
-            ? $this->exception->getCustomExceptionName()
-            : get_class($this->exception);
+            : 'Critical Error';
     }
 
     /**

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -139,44 +139,20 @@ class ExceptionTest extends TestCase
         $this->assertRegExp('/2nd Solution/', $ret);
     }
 
-    public function testCustomName(): void
-    {
-        $m = new ExceptionCustomName(
-            [
-                'Exception with custom name',
-            ]
-        );
-
-        $ret = $m->getColorfulText();
-        $this->assertRegExp('/CustomNameException/', $ret);
-
-        // get colorful text
-        $ret = $m->getHTML();
-        $this->assertRegExp('/CustomNameException/', $ret);
-
-        // get colorful text
-        $ret = $m->getHTMLText();
-        $this->assertRegExp('/CustomNameException/', $ret);
-
-        // get colorful text
-        $ret = $m->getJSON();
-        $this->assertRegExp('/CustomNameException/', $ret);
-    }
-
     public function testExceptionFallback(): void
     {
         $m = new ExceptionTestThrowError(['test']);
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getHTML());
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getHTMLText());
-        $this->assertEquals('atk4\core\tests\ExceptionTestThrowError [0] Error: test', $m->getColorfulText());
+        $this->assertEquals(ExceptionTestThrowError::class.' [0] Error: test', $m->getHTML());
+        $this->assertEquals(ExceptionTestThrowError::class.' [0] Error: test', $m->getHTMLText());
+        $this->assertEquals(ExceptionTestThrowError::class.' [0] Error: test', $m->getColorfulText());
         $this->assertEquals(
             json_encode(
                 [
                     'success'  => false,
                     'code'     => 0,
                     'message'  => 'Error during JSON renderer : test',
-                    'title'    => 'atk4\\core\\tests\\ExceptionTestThrowError',
-                    'class'    => 'atk4\\core\\tests\\ExceptionTestThrowError',
+                    'title'    => ExceptionTestThrowError::class,
+                    'class'    => ExceptionTestThrowError::class,
                     'params'   => [],
                     'solution' => [],
                     'trace'    => [],
@@ -203,17 +179,9 @@ class TrackableMock2
 // @codingStandardsIgnoreEnd
 
 // @codingStandardsIgnoreStart
-class ExceptionCustomName extends Exception
-{
-    protected $custom_exception_name = 'CustomNameException';
-}
-
-// @codingStandardsIgnoreEnd
-
-// @codingStandardsIgnoreStart
 class ExceptionTestThrowError extends Exception
 {
-    public function getCustomExceptionName(): string
+    public function getCustomExceptionTitle(): string
     {
         throw new \Exception('just to cover __string');
     }


### PR DESCRIPTION
Plus use "Critical Error" for non-atk exceptions to be consistent with them.

Before:
![image](https://user-images.githubusercontent.com/2228672/78898455-209a4e80-7a74-11ea-87eb-ee837a6223bf.png)

After:
![image](https://user-images.githubusercontent.com/2228672/78898489-2bed7a00-7a74-11ea-8376-35904e7745d9.png)
