### PR TITLE
Move types to code if possible

### DIFF
--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -405,7 +405,7 @@ values. See my description below the example::
     class RedButton extends Button {
         protected $icon = 'book';
 
-        function init() {
+        function init(): void {
             parent::init();
 
             $this->icon = 'right arrow';

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -141,7 +141,7 @@ ATK provides a way:
 Example::
 
    // class App
-   function normalizeClassName($name, $prefix) {
+   function normalizeClassName(string $name, string $prefix = null): string {
       if ($name == 'Form' && $prefix == 'atk4\ui') {
          return MyExtensions\SecureForm::class;
       }
@@ -759,12 +759,12 @@ The next example will replace all the ``Grid`` classes with the one you have
 implemented inside your own namespace::
 
     class MyApp extends \atk4\ui\App {
-        function normalizeClassNameApp($class) {
-            if ($class == 'Grid') {
+        function normalizeClassNameApp(string $name, string $prefix = null): ?string {
+            if ($name == 'Grid') {
                 return '\myextensions\Grid';
             }
 
-            return parent::normalizeClassNameApp($class);
+            return parent::normalizeClassNameApp($name);
         }
     }
 

--- a/docs/hook.rst
+++ b/docs/hook.rst
@@ -48,7 +48,7 @@ In case $fx is omitted then $this object is used as $fx.
 
 In this case a method with same name as $spot will be used as callback::
 
-    function init() {
+    function init(): void {
         parent::init();
 
         $this->onHook('beforeUpdate');

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,7 +191,7 @@ class to define a business object, such as - ShoppingBag::
     class ShoppingBag extends \atk4\data\Model {
         public $table = 'shopping_bag';
 
-        function init() {
+        function init(): void {
             parent::init();
 
             $this->hasOne('user_id', new User());

--- a/docs/initializer.rst
+++ b/docs/initializer.rst
@@ -24,7 +24,7 @@ Declare a object class in your framework::
 
         public $value = null;
 
-        function init() {
+        function init(): void {
             parent::init();
 
             if($_POST[$this->name) {
@@ -65,7 +65,7 @@ class::
 
         public $value = null;
 
-        function init() {
+        function init(): void {
             $this->_init();   // call init of InitializerTrait
 
             if($_POST[$this->name) {

--- a/src/AppUserNotificationInterface.php
+++ b/src/AppUserNotificationInterface.php
@@ -14,8 +14,6 @@ interface AppUserNotificationInterface
     /**
      * This function will be called with a message that needs to be
      * displayed to user.
-     *
-     * @param string $message
      */
-    public function userNotification($message, array $context = []);
+    public function userNotification(string $message, array $context = []): void;
 }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -28,7 +28,7 @@ trait CollectionTrait
      *
      * @throws Exception
      *
-     * @return object|mixed $obect
+     * @return object
      */
     public function _addIntoCollection(string $name, object $object, string $collection)
     {
@@ -90,12 +90,9 @@ trait CollectionTrait
     /**
      * Removes element from specified collection.
      *
-     * @param string $name
-     * @param string $collection
-     *
      * @throws Exception
      */
-    public function _removeFromCollection(string $name, string $collection)
+    public function _removeFromCollection(string $name, string $collection): void
     {
         if ($this->_hasInCollection($name, $collection) === false) {
             throw new Exception([
@@ -112,9 +109,9 @@ trait CollectionTrait
      * Call this on collections after cloning object. This will clone all collection
      * elements (which are objects).
      *
-     * @param string $collection to be cloned
+     * @param string Collection to be cloned
      */
-    public function _cloneCollection(string $collection)
+    public function _cloneCollection(string $collection): void
     {
         foreach ($this->{$collection} as &$object) {
             $object = clone $object;
@@ -127,9 +124,6 @@ trait CollectionTrait
     /**
      * Returns object from collection or false if object is not found.
      *
-     * @param string $name
-     * @param string $collection
-     *
      * @return object|false
      */
     public function _hasInCollection(string $name, string $collection)
@@ -138,14 +132,9 @@ trait CollectionTrait
     }
 
     /**
-     * @param string $name
-     * @param string $collection
-     *
      * @throws Exception
-     *
-     * @return object
      */
-    public function _getFromCollection(string $name, string $collection)
+    public function _getFromCollection(string $name, string $collection): object
     {
         $object = $this->_hasInCollection($name, $collection);
         if (false === $object) {
@@ -162,13 +151,13 @@ trait CollectionTrait
 
     /**
      * Method used internally for shortening object names
-     * Identical implementation to ContainerTrait::_shortern.
+     * Identical implementation to ContainerTrait::_shorten.
      *
      * @param string $desired Desired name of new object.
      *
      * @return string Shortened name of new object.
      */
-    protected function _shorten_ml($desired)
+    protected function _shorten_ml(string $desired): string
     {
         if (
             isset($this->_appScopeTrait) &&

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -44,7 +44,7 @@ trait ConfigTrait
      *
      * @return $this
      */
-    public function readConfig($files = ['config.php'], $format = 'php')
+    public function readConfig($files = ['config.php'], string $format = 'php')
     {
         if (!is_array($files)) {
             $files = [$files];
@@ -136,7 +136,7 @@ trait ConfigTrait
      *
      * @return mixed
      */
-    public function getConfig($path, $default_value = null)
+    public function getConfig(string $path, $default_value = null)
     {
         $pos = &$this->_lookupConfigElement($path, false);
 
@@ -157,7 +157,7 @@ trait ConfigTrait
      * @return &pos|false Pointer to element in $this->config or false is element don't exist and $create_elements===false
      *                    Returns false if element don't exist and $create_elements===false
      */
-    protected function &_lookupConfigElement($path, $create_elements = false)
+    protected function &_lookupConfigElement(string $path, bool $create_elements = false)
     {
         // trick to return false because we need reference here
         $false = false;

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -23,16 +23,15 @@ trait ContainerTrait
      */
     public $elements = [];
 
+    /**
+     * @var int[]
+     */
     private $_element_name_counts = [];
 
     /**
      * Returns unique element name based on desired name.
-     *
-     * @param string $desired
-     *
-     * @return string
      */
-    public function _unique_element($desired)
+    public function _unique_element(string $desired): string
     {
         if (!isset($this->_element_name_counts[$desired])) {
             $this->_element_name_counts[$desired] = 1;
@@ -54,10 +53,8 @@ trait ContainerTrait
      * @param array|string $args
      *
      * @throws Exception
-     *
-     * @return object
      */
-    public function add($obj, $args = [])
+    public function add($obj, $args = []): object
     {
         if (isset($this->_factoryTrait)) {
             // Factory allows us to pass string-type objects
@@ -95,10 +92,8 @@ trait ContainerTrait
      * @param array|string $args
      *
      * @throws Exception
-     *
-     * @return object
      */
-    protected function _add_Container($element, $args = [])
+    protected function _add_Container($element, $args = []): object
     {
         if (!is_object($element)) {
             throw new Exception(['Only objects may be added into containers', 'arg' => $element]);
@@ -175,10 +170,8 @@ trait ContainerTrait
      * @param string $short_name short name of the element
      *
      * @throws Exception
-     *
-     * @return $this
      */
-    public function removeElement($short_name)
+    public function removeElement(string $short_name)
     {
         if (is_object($short_name)) {
             $short_name = $short_name->short_name;
@@ -204,7 +197,7 @@ trait ContainerTrait
      *
      * @return string Shortened name of new object.
      */
-    protected function _shorten($desired)
+    protected function _shorten(string $desired): string
     {
         if (
             isset($this->_appScopeTrait) &&
@@ -240,10 +233,8 @@ trait ContainerTrait
      * @param string $short_name Short name of the child element
      *
      * @throws Exception
-     *
-     * @return object
      */
-    public function getElement($short_name)
+    public function getElement(string $short_name): object
     {
         if (!isset($this->elements[$short_name])) {
             throw new Exception([

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -167,11 +167,11 @@ trait ContainerTrait
     /**
      * Remove child element if it exists.
      *
-     * @param string $short_name short name of the element
+     * @param string|TrackableTrait $short_name short name of the element
      *
      * @throws Exception
      */
-    public function removeElement(string $short_name)
+    public function removeElement($short_name)
     {
         if (is_object($short_name)) {
             $short_name = $short_name->short_name;

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -45,12 +45,8 @@ trait DIContainerTrait
      *
      * @return $this
      */
-    public function setDefaults(array $properties = [], bool $passively = false)
+    public function setDefaults(array $properties, bool $passively = false)
     {
-        if ($properties === null) {
-            $properties = [];
-        }
-
         foreach ($properties as $key => $val) {
             if (!is_numeric($key) && property_exists($this, $key)) {
                 if ($passively && $this->$key !== null) {

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -41,10 +41,11 @@ trait DIContainerTrait
      * Call from __construct() to initialize the properties allowing
      * developer to pass Dependency Injector Container.
      *
-     * @param array $properties
-     * @param bool  $passively  if true, existing non-null argument values will be kept
+     * @param bool $passively If true, existing non-null argument values will be kept
+     *
+     * @return $this
      */
-    public function setDefaults($properties = [], $passively = false)
+    public function setDefaults(array $properties = [], bool $passively = false)
     {
         if ($properties === null) {
             $properties = [];
@@ -63,6 +64,8 @@ trait DIContainerTrait
                 $this->setMissingProperty($key, $val);
             }
         }
+
+        return $this;
     }
 
     /**
@@ -72,12 +75,14 @@ trait DIContainerTrait
      * @param mixed $key
      * @param mixed $value
      * @param bool  $strict
+     *
+     * @return $this
      */
     protected function setMissingProperty($key, $value)
     {
         // ignore numeric properties by default
         if (is_numeric($key)) {
-            return;
+            return $this;
         }
 
         throw new Exception([

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -26,7 +26,7 @@ trait DebugTrait
      *
      * @param string $message
      */
-    protected function _echo_stderr($message)
+    protected function _echo_stderr(string $message): void
     {
         file_put_contents('php://stderr', $message);
     }
@@ -62,18 +62,14 @@ trait DebugTrait
     /**
      * Output log message.
      *
-     * @param string $level
-     * @param string $message
-     * @param array  $context
-     *
      * @return $this
      */
-    public function log($level, $message, array $context = [])
+    public function log(string $level, string $message, array $context = [])
     {
         if (isset($this->app) && isset($this->app->logger) && $this->app->logger instanceof \Psr\Log\LoggerInterface) {
             $this->app->logger->log($level, $message, $context);
         } else {
-            $this->_echo_stderr("$message\n");
+            $this->_echo_stderr($message."\n");
         }
 
         return $this;
@@ -83,12 +79,9 @@ trait DebugTrait
      * Output message that needs to be acknowledged by application user. Make sure
      * that $context does not contain any sensitive information.
      *
-     * @param string $message
-     * @param array  $context
-     *
      * @return $this
      */
-    public function userMessage($message, $context = [])
+    public function userMessage(string $message, array $context = [])
     {
         if (isset($this->app) && $this->app instanceof \atk4\core\AppUserNotificationInterface) {
             $this->app->userNotification($message, $context);
@@ -111,10 +104,8 @@ trait DebugTrait
      * is invoked through different call paths, this debug info will be logged.
      *
      * Do not leave this method in production code !!!
-     *
-     * @param string $trace
      */
-    public function debugTraceChange($trace = 'default')
+    public function debugTraceChange(string $trace = 'default'): void
     {
         $bt = [];
         foreach (debug_backtrace() as $line) {
@@ -135,13 +126,8 @@ trait DebugTrait
 
     /**
      * System is unusable.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function emergency($message, array $context = [])
+    public function emergency(string $message, array $context = []): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
@@ -151,13 +137,8 @@ trait DebugTrait
      *
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function alert($message, array $context = [])
+    public function alert(string $message, array $context = []): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
@@ -166,13 +147,8 @@ trait DebugTrait
      * Critical conditions.
      *
      * Example: Application component unavailable, unexpected exception.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function critical($message, array $context = [])
+    public function critical(string $message, array $context = []): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
@@ -180,13 +156,8 @@ trait DebugTrait
     /**
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function error($message, array $context = [])
+    public function error(string $message, array $context = []): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
@@ -196,26 +167,16 @@ trait DebugTrait
      *
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function warning($message, array $context = [])
+    public function warning(string $message, array $context = []): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
 
     /**
      * Normal but significant events.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function notice($message, array $context = [])
+    public function notice(string $message, array $context = []): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
@@ -224,13 +185,8 @@ trait DebugTrait
      * Interesting events.
      *
      * Example: User logs in, SQL logs.
-     *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
      */
-    public function info($message, array $context = [])
+    public function info(string $message, array $context = []): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -62,9 +62,12 @@ trait DebugTrait
     /**
      * Output log message.
      *
+     * @param string $level
+     * @param string $message
+     *
      * @return $this
      */
-    public function log(string $level, string $message, array $context = [])
+    public function log($level, $message, array $context = [])
     {
         if (isset($this->app) && isset($this->app->logger) && $this->app->logger instanceof \Psr\Log\LoggerInterface) {
             $this->app->logger->log($level, $message, $context);
@@ -126,8 +129,12 @@ trait DebugTrait
 
     /**
      * System is unusable.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function emergency(string $message, array $context = []): void
+    public function emergency($message, array $context = [])
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
@@ -137,8 +144,12 @@ trait DebugTrait
      *
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function alert(string $message, array $context = []): void
+    public function alert($message, array $context = [])
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
@@ -147,8 +158,12 @@ trait DebugTrait
      * Critical conditions.
      *
      * Example: Application component unavailable, unexpected exception.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function critical(string $message, array $context = []): void
+    public function critical($message, array $context = [])
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
@@ -156,8 +171,12 @@ trait DebugTrait
     /**
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function error(string $message, array $context = []): void
+    public function error($message, array $context = [])
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
@@ -167,16 +186,24 @@ trait DebugTrait
      *
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function warning(string $message, array $context = []): void
+    public function warning($message, array $context = [])
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
 
     /**
      * Normal but significant events.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function notice(string $message, array $context = []): void
+    public function notice($message, array $context = [])
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
@@ -185,8 +212,12 @@ trait DebugTrait
      * Interesting events.
      *
      * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     *
+     * @return void
      */
-    public function info(string $message, array $context = []): void
+    public function info($message, array $context = [])
     {
         $this->log(LogLevel::INFO, $message, $context);
     }

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -61,27 +61,15 @@ trait DynamicMethodTrait
     /**
      * Add new method for this object.
      *
-     * @param string|array $name Name of new method of $this object
+     * @param string $name Name of new method of $this object
      *
      * @return $this
      */
-    public function addMethod($name, callable $fx)
+    public function addMethod(string $name, callable $fx)
     {
         // HookTrait is mandatory
         if (!isset($this->_hookTrait)) {
             throw new Exception(['Object must use hookTrait for Dynamic Methods to work']);
-        }
-
-        if (is_string($name) && strpos($name, ',') !== false) {
-            $name = array_map('trim', explode(',', $name));
-        }
-
-        if (is_array($name)) {
-            foreach ($name as $h) {
-                $this->addMethod($h, $fx);
-            }
-
-            return $this;
         }
 
         if ($this->hasMethod($name)) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -46,12 +46,10 @@ class Exception extends \Exception
      * Constructor.
      *
      * @param string|array $message
-     * @param int          $code
-     * @param \Throwable   $previous
      */
     public function __construct(
         $message = '',
-        ?int $code = null,
+        int $code = 0,
         \Throwable $previous = null
     ) {
         if (is_array($message)) {
@@ -66,7 +64,7 @@ class Exception extends \Exception
             }
         }
 
-        parent::__construct($message, $code ?? 0, $previous);
+        parent::__construct($message, $code, $previous);
         $this->trace2 = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
     }
 
@@ -74,11 +72,9 @@ class Exception extends \Exception
      * Change message (subject) of a current exception. Primary use is
      * for localization purposes.
      *
-     * @param string $message
-     *
      * @return $this
      */
-    public function setMessage($message): self
+    public function setMessage(string $message): self
     {
         $this->message = $message;
 
@@ -87,10 +83,8 @@ class Exception extends \Exception
 
     /**
      * Return trace array.
-     *
-     * @return array
      */
-    public function getMyTrace()
+    public function getMyTrace(): array
     {
         return $this->trace2;
     }
@@ -105,8 +99,6 @@ class Exception extends \Exception
      *
      * --
      * <triggered by>
-     *
-     * @return string
      */
     public function getColorfulText(): string
     {
@@ -115,8 +107,6 @@ class Exception extends \Exception
 
     /**
      * Similar to getColorfulText() but will use raw HTML for outputting colors.
-     *
-     * @return string
      */
     public function getHTMLText(): string
     {
@@ -132,8 +122,6 @@ class Exception extends \Exception
      *   $l->layout->template->setHTML('Content', $e->getHTML());
      *   $l->run();
      *   exit;
-     *
-     * @return string
      */
     public function getHTML(): string
     {
@@ -142,8 +130,6 @@ class Exception extends \Exception
 
     /**
      * Return exception in JSON Format.
-     *
-     * @return string
      */
     public function getJSON(): string
     {
@@ -154,8 +140,6 @@ class Exception extends \Exception
      * Safely converts some value to string.
      *
      * @param mixed $val
-     *
-     * @return string
      */
     public function toString($val): string
     {
@@ -164,10 +148,8 @@ class Exception extends \Exception
 
     /**
      * Follow the getter-style of PHP Exception.
-     *
-     * @return array
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->params;
     }
@@ -175,12 +157,11 @@ class Exception extends \Exception
     /**
      * Augment existing exception with more info.
      *
-     * @param string $param
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
-    public function addMoreInfo($param, $value): self
+    public function addMoreInfo(string $param, $value): self
     {
         $this->params[$param] = $value;
 
@@ -192,11 +173,9 @@ class Exception extends \Exception
      *
      * @TODO can be added more features? usually we are out of App
      *
-     * @param string $solution
-     *
-     * @return Exception
+     * @return $this
      */
-    public function addSolution(string $solution)
+    public function addSolution(string $solution): self
     {
         $this->solutions[] = $solution;
 
@@ -213,8 +192,6 @@ class Exception extends \Exception
 
     /**
      * Get the custom Exception title, if defined in $custom_exception_title.
-     *
-     * @return string
      */
     public function getCustomExceptionTitle(): string
     {
@@ -226,7 +203,7 @@ class Exception extends \Exception
      *
      * @param ITranslatorAdapter|null $adapter
      *
-     * @return Exception
+     * @return $this
      */
     public function setTranslatorAdapter(?ITranslatorAdapter $adapter = null): self
     {

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -8,6 +8,7 @@ use atk4\core\Exception;
 
 class JSON extends RendererAbstract
 {
+    /** @var array */
     protected $json = [
         'success'  => false,
         'code'     => 0,

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -106,10 +106,8 @@ trait FactoryTrait
      * @param mixed  $seed
      * @param array  $defaults
      * @param string $prefix   Optional prefix for class name
-     *
-     * @return object
      */
-    public function factory($seed, $defaults = [], $prefix = null)
+    public function factory($seed, $defaults = [], string $prefix = null): object
     {
         if ($defaults === null) {
             $defaults = [];
@@ -195,7 +193,7 @@ trait FactoryTrait
      *
      * @return string Full, normalized class name
      */
-    public function normalizeClassName($name, $prefix = null)
+    public function normalizeClassName(string $name, string $prefix = null): string
     {
         // If App has "normalizeClassName" (obsolete now), use it instead
         if (

--- a/src/HookBreaker.php
+++ b/src/HookBreaker.php
@@ -10,12 +10,18 @@ namespace atk4\core;
  * @license MIT
  * @copyright Agile Toolkit (c) http://agiletoolkit.org/
  */
-class HookBreaker extends \Exception
+class HookBreaker extends Exception
 {
+    /**
+     * @var mixed
+     */
     public $return_value = null;
 
-    public function __construct($rv)
+    /**
+     * @param mixed $return_value
+     */
+    public function __construct($return_value)
     {
-        $this->return_value = $rv;
+        $this->return_value = $return_value;
     }
 }

--- a/src/HookBreaker.php
+++ b/src/HookBreaker.php
@@ -22,6 +22,7 @@ class HookBreaker extends Exception
      */
     public function __construct($return_value)
     {
+        parent::__construct();
         $this->return_value = $return_value;
     }
 }

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -100,7 +100,7 @@ trait HookTrait
      *
      * @param string   $spot            Hook identifier
      * @param int|null $priority        Filter specific priority, null for all
-     * @param int|null $priorityIsIndex Filter by index instead of priority
+     * @param int      $priorityIsIndex Filter by index instead of priority
      *
      * @return static
      */
@@ -127,7 +127,7 @@ trait HookTrait
      *
      * @param string   $spot            Hook identifier
      * @param int|null $priority        Filter specific priority, null for all
-     * @param int|null $priorityIsIndex Filter by index instead of priority
+     * @param int      $priorityIsIndex Filter by index instead of priority
      */
     public function hookHasCallbacks(string $spot, int $priority = null, bool $priorityIsIndex = false): bool
     {
@@ -204,7 +204,7 @@ trait HookTrait
      *
      * @throws HookBreaker
      */
-    public function breakHook($return)
+    public function breakHook($return): void
     {
         throw new HookBreaker($return);
     }

--- a/src/InitializerTrait.php
+++ b/src/InitializerTrait.php
@@ -25,7 +25,7 @@ trait InitializerTrait
     /**
      * Initialize object. Always call parent::init(). Do not call directly.
      */
-    public function init()
+    public function init(): void
     {
         if ($this->_initialized) {
             throw new Exception(['Attempting to initialize twice', 'this'=>$this]);

--- a/src/MultiContainerTrait.php
+++ b/src/MultiContainerTrait.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace atk4\core;
-
-trait MultiContainerTrait
-{
-    use CollectionTrait;
-}

--- a/src/PHPUnit7_AgileExceptionWrapper.php
+++ b/src/PHPUnit7_AgileExceptionWrapper.php
@@ -7,17 +7,10 @@ namespace atk4\core;
  */
 class PHPUnit7_AgileExceptionWrapper extends \PHPUnit\Framework\Exception
 {
-    /** @var \Exception Previous exception */
+    /** @var \Throwable Previous exception */
     public $previous;
 
-    /**
-     * Constructor.
-     *
-     * @param string     $message
-     * @param int        $code
-     * @param \Exception $previous
-     */
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
     {
         $this->previous = $previous;
         parent::__construct($message, $code, $previous);

--- a/src/PHPUnit7_AgileTestCase.php
+++ b/src/PHPUnit7_AgileTestCase.php
@@ -15,12 +15,8 @@ class PHPUnit7_AgileTestCase extends TestCase
     {
         try {
             parent::runBare();
-        } catch (\Exception $e) {
-            if ($e instanceof \atk4\core\Exception) {
-                throw new PHPUnit7_AgileExceptionWrapper($e->getMessage(), 0, $e);
-            } else {
-                throw $e;
-            }
+        } catch (Exception $e) {
+            throw new PHPUnit7_AgileExceptionWrapper($e->getMessage(), 0, $e);
         }
     }
 
@@ -30,15 +26,11 @@ class PHPUnit7_AgileTestCase extends TestCase
      * NOTE: this method must only be used for low-level functionality, not
      * for general test-scripts.
      *
-     * @param object $obj
-     * @param string $name
-     * @param array  $args
-     *
      * @throws \ReflectionException
      *
      * @return mixed
      */
-    public function callProtected($obj, $name, array $args = [])
+    public function callProtected(object $obj, string $name, array $args = [])
     {
         $class = new \ReflectionClass($obj);
         $method = $class->getMethod($name);
@@ -53,14 +45,11 @@ class PHPUnit7_AgileTestCase extends TestCase
      * NOTE: this method must only be used for low-level functionality, not
      * for general test-scripts.
      *
-     * @param object $obj
-     * @param string $name
-     *
      * @throws \ReflectionException
      *
      * @return mixed
      */
-    public function getProtected($obj, $name)
+    public function getProtected(object $obj, string $name)
     {
         $class = new \ReflectionClass($obj);
         $method = $class->getProperty($name);
@@ -72,7 +61,7 @@ class PHPUnit7_AgileTestCase extends TestCase
     /**
      * Fake test. Otherwise Travis gives warning that there are no tests in here.
      */
-    public function testFake()
+    public function testFake(): void
     {
         $this->assertTrue(true);
     }

--- a/src/PHPUnit_AgileExceptionWrapper.php
+++ b/src/PHPUnit_AgileExceptionWrapper.php
@@ -7,17 +7,10 @@ namespace atk4\core;
  */
 class PHPUnit_AgileExceptionWrapper extends \PHPUnit_Framework_Exception
 {
-    /** @var \Exception Previous exception */
+    /** @var \Throwable Previous exception */
     public $previous;
 
-    /**
-     * Constructor.
-     *
-     * @param string     $message
-     * @param int        $code
-     * @param \Exception $previous
-     */
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
     {
         $this->previous = $previous;
         parent::__construct($message, $code, $previous);

--- a/src/PHPUnit_AgileResultPrinter.php
+++ b/src/PHPUnit_AgileResultPrinter.php
@@ -12,11 +12,13 @@ class PHPUnit_AgileResultPrinter extends \PHPUnit_TextUI_ResultPrinter
      *
      * @param \PHPUnit_Framework_TestFailure $defect
      */
-    protected function printDefectTrace(\PHPUnit_Framework_TestFailure $defect)
+    protected function printDefectTrace(\PHPUnit_Framework_TestFailure $defect): void
     {
         $e = $defect->thrownException();
         if (!$e instanceof \atk4\core\PHPUnit_AgileExceptionWrapper) {
-            return parent::printDefectTrace($defect);
+            parent::printDefectTrace($defect);
+
+            return;
         }
         $this->write((string) $e);
 

--- a/src/PHPUnit_AgileTestCase.php
+++ b/src/PHPUnit_AgileTestCase.php
@@ -7,15 +7,10 @@ namespace atk4\core;
  */
 class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * Runs the bare test sequence.
-     *
-     * @return null
-     */
-    public function runBare()
+    public function runBare(): void
     {
         try {
-            return parent::runBare();
+            parent::runBare();
         } catch (Exception $e) {
             throw new PHPUnit_AgileExceptionWrapper($e->getMessage(), 0, $e);
         }
@@ -27,13 +22,11 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
      * NOTE: this method must only be used for low-level functionality, not
      * for general test-scripts.
      *
-     * @param object $obj
-     * @param string $name
-     * @param array  $args
+     * @throws \ReflectionException
      *
      * @return mixed
      */
-    public function callProtected($obj, $name, array $args = [])
+    public function callProtected(object $obj, string $name, array $args = [])
     {
         $class = new \ReflectionClass($obj);
         $method = $class->getMethod($name);
@@ -48,12 +41,11 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
      * NOTE: this method must only be used for low-level functionality, not
      * for general test-scripts.
      *
-     * @param object $obj
-     * @param string $name
+     * @throws \ReflectionException
      *
      * @return mixed
      */
-    public function getProtected($obj, $name)
+    public function getProtected(object $obj, string $name)
     {
         $class = new \ReflectionClass($obj);
         $method = $class->getProperty($name);
@@ -65,7 +57,7 @@ class PHPUnit_AgileTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Fake test. Otherwise Travis gives warning that there are no tests in here.
      */
-    public function testFake()
+    public function testFake(): void
     {
         $this->assertTrue(true);
     }

--- a/src/PsyshE.php
+++ b/src/PsyshE.php
@@ -28,14 +28,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PsyshE extends TraceCommand implements ContextAware
 {
+    /**
+     * @var Context
+     */
     protected $context;
 
-    public function setContext(Context $context)
+    public function setContext(Context $context): void
     {
         $this->context = $context;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('e')
@@ -47,7 +50,7 @@ HELP
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $exception = $this->context->getLastException();
         if (!$exception instanceof \atk4\core\Exception) {

--- a/src/QuickExceptionTrait.php
+++ b/src/QuickExceptionTrait.php
@@ -20,6 +20,8 @@ trait QuickExceptionTrait
 
     /**
      * Calls exception.
+     *
+     * @TODO NOT IMPLEMENTED
      */
     public function exception()
     {

--- a/src/ReadableCaptionTrait.php
+++ b/src/ReadableCaptionTrait.php
@@ -9,12 +9,8 @@ trait ReadableCaptionTrait
      *
      * This will translate 'this\\ _isNASA_MyBigBull shit_123\Foo'
      * into 'This Is NASA My Big Bull Shit 123 Foo'
-     *
-     * @param string $s
-     *
-     * @return string
      */
-    public function readableCaption($s)
+    public function readableCaption(string $s): string
     {
         //$s = 'this\\ _isNASA_MyBigBull shit_123\Foo';
 

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -16,14 +16,14 @@ trait SessionTrait
      *
      * @var string
      */
-    protected $session_key = 'o';
+    protected $session_key = '__atk_session';
 
     /**
      * Create new session.
      *
      * @param array $options Options for session_start()
      */
-    public function startSession($options = [])
+    public function startSession(array $options = [])
     {
         // all methods use this method to start session, so we better check
         // NameTrait existence here in one place.
@@ -57,12 +57,11 @@ trait SessionTrait
     /**
      * Remember data in object-relevant session data.
      *
-     * @param string $key   Key for the data
-     * @param mixed  $value Value
+     * @param mixed $value Value
      *
      * @return mixed $value
      */
-    public function memorize($key, $value)
+    public function memorize(string $key, $value)
     {
         $this->startSession();
 
@@ -78,12 +77,9 @@ trait SessionTrait
     /**
      * Similar to memorize, but if value for key exist, will return it.
      *
-     * @param string $key     Data Key
-     * @param mixed  $default Default value
-     *
      * @return mixed Previously memorized data or $default
      */
-    public function learn($key, $default = null)
+    public function learn(string $key, $default = null)
     {
         $this->startSession();
 
@@ -100,12 +96,9 @@ trait SessionTrait
      * Returns session data for this object. If not previously set, then
      * $default is returned.
      *
-     * @param string $key     Data Key
-     * @param mixed  $default Default value
-     *
      * @return mixed Previously memorized data or $default
      */
-    public function recall($key, $default = null)
+    public function recall(string $key, $default = null)
     {
         $this->startSession();
 
@@ -130,7 +123,7 @@ trait SessionTrait
      *
      * @return $this
      */
-    public function forget($key = null)
+    public function forget(string $key = null)
     {
         $this->startSession();
 

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -27,7 +27,7 @@ trait StaticAddToTrait
      *
      * @return static
      */
-    public static function addTo(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)
+    public static function addTo(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)/* :static supported by PHP8+ */
     {
         if (is_object($seed)) {
             $object = $seed;
@@ -78,7 +78,7 @@ trait StaticAddToTrait
      *
      * @return static
      */
-    public static function addToWithClassName(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)
+    public static function addToWithClassName(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)/* :static supported by PHP8+ */
     {
         return static::_addToWithClassName($parent, $seed, false, $add_args, $skip_add);
     }
@@ -90,7 +90,7 @@ trait StaticAddToTrait
      *
      * @return static
      */
-    public static function addToWithClassNameUnsafe(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)
+    public static function addToWithClassNameUnsafe(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)/* :self is too strict with unsafe behaviour */
     {
         return static::_addToWithClassName($parent, $seed, true, $add_args, $skip_add);
     }

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -30,15 +30,13 @@ trait TrackableTrait
      *
      * @var string
      */
-    public $short_name = null;
+    public $short_name;
 
     /**
      * If name of the object is omitted then it's naturally to name them
      * after the class. You can specify a different naming pattern though.
-     *
-     * @return string
      */
-    public function getDesiredName()
+    public function getDesiredName(): string
     {
         return preg_replace('/.*\\\\/', '', strtolower(get_class($this)));
     }
@@ -47,7 +45,7 @@ trait TrackableTrait
      * Removes object from parent, so that PHP's Garbage Collector can
      * dispose of it.
      */
-    public function destroy()
+    public function destroy(): void
     {
         if (
             isset($this->owner) &&

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -16,6 +16,7 @@ class Generic implements ITranslatorAdapter
         setConfig as protected;
     }
 
+    /** @var array */
     protected $definitions = [];
 
     /**
@@ -37,13 +38,8 @@ class Generic implements ITranslatorAdapter
     /**
      * Return translated string.
      * if parameters is not empty will replace tokens.
-     *
-     * @param array|string $definition
-     * @param array|null   $parameters
-     *
-     * @return string
      */
-    protected function processMessage($definition, array $parameters = []): string
+    protected function processMessage(string $definition, array $parameters = []): string
     {
         foreach ($parameters as $key => $val) {
             $definition = str_replace('{{'.$key.'}}', $val, $definition);
@@ -56,8 +52,6 @@ class Generic implements ITranslatorAdapter
      * @param array|string $definition A string of definitions separated by |
      * @param array        $parameters An array of parameters
      * @param int          $count      Requested plural form
-     *
-     * @return string
      */
     protected function processMessagePlural($definition, array $parameters = [], int $count = 1): string
     {
@@ -81,6 +75,9 @@ class Generic implements ITranslatorAdapter
         return $this->processMessage($definition, $parameters);
     }
 
+    /**
+     * @return array|string
+     */
     protected function getDefinition(string $message, $domain, ?string $locale)
     {
         $this->loadDefinitionATK($locale); // need to be called before manual add
@@ -105,11 +102,6 @@ class Generic implements ITranslatorAdapter
     /**
      * Load definitions from file.
      *
-     * @param string $file
-     * @param string $locale
-     * @param string $domain
-     * @param string $format
-     *
      * @throws \atk4\core\Exception
      */
     public function addDefinitionFromFile(string $file, string $locale, string $domain, string $format): void
@@ -133,10 +125,7 @@ class Generic implements ITranslatorAdapter
     /**
      * Set or Replace a single definition within a domain.
      *
-     * @param string       $key
      * @param string|array $definition
-     * @param string       $locale
-     * @param string       $domain
      *
      * @return $this
      */

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -42,7 +42,7 @@ class Translator
      *
      * @throws Exception
      */
-    public function setDefaults(array $properties = [], bool $passively = false): void
+    public function setDefaults(array $properties, bool $passively = false): void
     {
         if (null !== ($properties['instance'] ?? null)) {
             throw new Exception(['$instance cannot be replaced']);

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -40,12 +40,9 @@ class Translator
     /**
      * Set property like Depedency injection.
      *
-     * @param array $properties
-     * @param bool  $passively
-     *
      * @throws Exception
      */
-    public function setDefaults($properties = [], $passively = false): void
+    public function setDefaults(array $properties = [], bool $passively = false): void
     {
         if (null !== ($properties['instance'] ?? null)) {
             throw new Exception(['$instance cannot be replaced']);
@@ -67,11 +64,6 @@ class Translator
         $this->_setDefaults($properties);
     }
 
-    /**
-     * @param string $locale
-     *
-     * @return Translator
-     */
     public function setDefaultLocale(string $locale): self
     {
         $this->default_locale = $locale;
@@ -79,11 +71,6 @@ class Translator
         return $this;
     }
 
-    /**
-     * @param string $default_domain
-     *
-     * @return Translator
-     */
     public function setDefaultDomain(string $default_domain): self
     {
         $this->default_domain = $default_domain;
@@ -98,6 +85,7 @@ class Translator
      */
     protected function __clone()
     {
+        throw new Exception('Translator cannot be cloned');
     }
 
     /**
@@ -113,7 +101,7 @@ class Translator
     }
 
     /**
-     * is a singleton and need a method to access the instance.
+     * Is a singleton and need a method to access the instance.
      */
     public static function instance(): self
     {
@@ -126,10 +114,6 @@ class Translator
 
     /**
      * Set the Translator Adapter.
-     *
-     * @param ITranslatorAdapter $translator
-     *
-     * @return Translator
      */
     public function setAdapter(ITranslatorAdapter $translator): self
     {
@@ -142,8 +126,6 @@ class Translator
      * Get the adapter.
      *
      * @TODO should remain private?
-     *
-     * @return ITranslatorAdapter
      */
     private function getAdapter(): ITranslatorAdapter
     {

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -49,7 +49,7 @@ class AppScopeMock
     use ContainerTrait;
     use NameTrait;
 
-    public function add($obj, $args = [])
+    public function add($obj, $args = []): object
     {
         return $this->_add_Container($obj, $args);
     }
@@ -59,7 +59,7 @@ class AppScopeMock2
 {
     use ContainerTrait;
 
-    public function add($obj, $args = [])
+    public function add($obj, $args = []): object
     {
         return $this->_add_Container($obj, $args);
     }

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -131,7 +131,7 @@ class CollectionTraitTest extends TestCase
             use core\InitializerTrait;
             public $name;
 
-            public function init()
+            public function init(): void
             {
             }
         });

--- a/tests/CustomFieldMock.php
+++ b/tests/CustomFieldMock.php
@@ -18,7 +18,7 @@ class CustomFieldMock extends FieldMock
     /** @var null verifying if init wal called */
     public $var = null;
 
-    public function init()
+    public function init(): void
     {
         $this->_init();
 

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -70,7 +70,7 @@ class DIContainerTraitTest extends TestCase
     public function testPassively()
     {
         $m = new FactoryDIMock2();
-        $m->setDefaults(null, true);
+        $m->setDefaults([], true);
         $this->assertTrue(true);
     }
 }

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -216,7 +216,7 @@ class DebugAppMock2 implements \atk4\core\AppUserNotificationInterface
 {
     public $message;
 
-    public function userNotification($message, array $context = [])
+    public function userNotification(string $message, array $context = []): void
     {
         $this->message = [$message, $context];
     }

--- a/tests/DynamicMethodTraitTest.php
+++ b/tests/DynamicMethodTraitTest.php
@@ -102,9 +102,9 @@ class DynamicMethodTraitTest extends TestCase
         $res = $m->less(5, 3);
         $this->assertEquals(3, $res);
 
-        // callable as object
+        // callable as object/array
         $m = new DynamicMethodMock();
-        $m->addMethod('getElementCount', new ContainerMock());
+        $m->addMethod('getElementCount', [new ContainerMock(), 'getElementCount']);
         $this->assertEquals(0, $m->getElementCount());
     }
 

--- a/tests/DynamicMethodTraitTest.php
+++ b/tests/DynamicMethodTraitTest.php
@@ -77,31 +77,6 @@ class DynamicMethodTraitTest extends TestCase
         $res = $m->sum(3, 5);
         $this->assertEquals(8, $res);
 
-        // method name as CSV
-        $m = new DynamicMethodMock();
-        $m->addMethod(['min,less'], function ($m, $a, $b) {
-            return min($a, $b);
-        });
-        $res = $m->min(3, 5);
-        $this->assertEquals(3, $res);
-
-        $m = new DynamicMethodMock();
-        $m->addMethod(['min, less'], function ($m, $a, $b) {
-            return min($a, $b);
-        });
-        $res = $m->less(5, 3);
-        $this->assertEquals(3, $res);
-
-        // method name as array
-        $m = new DynamicMethodMock();
-        $m->addMethod(['min', 'less'], function ($m, $a, $b) {
-            return min($a, $b);
-        });
-        $res = $m->min(3, 5);
-        $this->assertEquals(3, $res);
-        $res = $m->less(5, 3);
-        $this->assertEquals(3, $res);
-
         // callable as object/array
         $m = new DynamicMethodMock();
         $m->addMethod('getElementCount', [new ContainerMock(), 'getElementCount']);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -168,6 +168,20 @@ class ExceptionTest extends TestCase
             $m->getJSON()
         );
     }
+
+    /**
+     * Add assertMatchesRegularExpression() method for phpunit >= 8.0 < 9.0 for compatibility with PHP 7.2.
+     *
+     * @TODO Remove once PHP 7.2 support is not needed for testing anymore.
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            static::assertRegExp($pattern, $string, $message);
+        }
+    }
 }
 
 // @codingStandardsIgnoreStart

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -75,7 +75,7 @@ class ExceptionTest extends TestCase
     {
         $m = new \Exception('Classic Exception');
 
-        $m = new Exception('atk4 exception', null, $m);
+        $m = new Exception('atk4 exception', 0, $m);
         $m->setMessage('bumbum');
 
         $ret = $m->getColorfulText();

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -33,27 +33,27 @@ class ExceptionTest extends TestCase
 
         // get colorful text
         $ret = $m->getColorfulText();
-        $this->assertRegExp('/TestIt/', $ret);
-        $this->assertRegExp('/PrevError/', $ret);
-        $this->assertRegExp('/333/', $ret);
+        $this->assertMatchesRegularExpression('/TestIt/', $ret);
+        $this->assertMatchesRegularExpression('/PrevError/', $ret);
+        $this->assertMatchesRegularExpression('/333/', $ret);
 
         // get console HTLM
         $ret = $m->getHTMLText();
-        $this->assertRegExp('/TestIt/', $ret);
-        $this->assertRegExp('/PrevError/', $ret);
-        $this->assertRegExp('/333/', $ret);
+        $this->assertMatchesRegularExpression('/TestIt/', $ret);
+        $this->assertMatchesRegularExpression('/PrevError/', $ret);
+        $this->assertMatchesRegularExpression('/333/', $ret);
 
         // get colorful text
         $ret = $m->getHTML();
-        $this->assertRegExp('/TestIt/', $ret);
-        $this->assertRegExp('/PrevError/', $ret);
-        $this->assertRegExp('/333/', $ret);
+        $this->assertMatchesRegularExpression('/TestIt/', $ret);
+        $this->assertMatchesRegularExpression('/PrevError/', $ret);
+        $this->assertMatchesRegularExpression('/333/', $ret);
 
         // get JSON
         $ret = $m->getJSON();
-        $this->assertRegExp('/TestIt/', $ret);
-        $this->assertRegExp('/PrevError/', $ret);
-        $this->assertRegExp('/333/', $ret);
+        $this->assertMatchesRegularExpression('/TestIt/', $ret);
+        $this->assertMatchesRegularExpression('/PrevError/', $ret);
+        $this->assertMatchesRegularExpression('/333/', $ret);
 
         // to string
         $ret = $m->toString(1);
@@ -79,20 +79,20 @@ class ExceptionTest extends TestCase
         $m->setMessage('bumbum');
 
         $ret = $m->getColorfulText();
-        $this->assertRegExp('/Classic/', $ret);
-        $this->assertRegExp('/bumbum/', $ret);
+        $this->assertMatchesRegularExpression('/Classic/', $ret);
+        $this->assertMatchesRegularExpression('/bumbum/', $ret);
 
         $ret = $m->getHTML();
-        $this->assertRegExp('/Classic/', $ret);
-        $this->assertRegExp('/bumbum/', $ret);
+        $this->assertMatchesRegularExpression('/Classic/', $ret);
+        $this->assertMatchesRegularExpression('/bumbum/', $ret);
 
         $ret = $m->getHTMLText();
-        $this->assertRegExp('/Classic/', $ret);
-        $this->assertRegExp('/bumbum/', $ret);
+        $this->assertMatchesRegularExpression('/Classic/', $ret);
+        $this->assertMatchesRegularExpression('/bumbum/', $ret);
 
         $ret = $m->getJSON();
-        $this->assertRegExp('/Classic/', $ret);
-        $this->assertRegExp('/bumbum/', $ret);
+        $this->assertMatchesRegularExpression('/Classic/', $ret);
+        $this->assertMatchesRegularExpression('/bumbum/', $ret);
     }
 
     public function testSolution(): void
@@ -101,19 +101,19 @@ class ExceptionTest extends TestCase
         $m->addSolution('One Solution');
 
         $ret = $m->getColorfulText();
-        $this->assertRegExp('/One Solution/', $ret);
+        $this->assertMatchesRegularExpression('/One Solution/', $ret);
 
         // get colorful text
         $ret = $m->getHTML();
-        $this->assertRegExp('/One Solution/', $ret);
+        $this->assertMatchesRegularExpression('/One Solution/', $ret);
 
         // get colorful text
         $ret = $m->getHTMLText();
-        $this->assertRegExp('/One Solution/', $ret);
+        $this->assertMatchesRegularExpression('/One Solution/', $ret);
 
         // get colorful text
         $ret = $m->getJSON();
-        $this->assertRegExp('/One Solution/', $ret);
+        $this->assertMatchesRegularExpression('/One Solution/', $ret);
     }
 
     public function testSolution2(): void
@@ -124,7 +124,7 @@ class ExceptionTest extends TestCase
         ]);
 
         $ret = $m->getColorfulText();
-        $this->assertRegExp('/1st Solution/', $ret);
+        $this->assertMatchesRegularExpression('/1st Solution/', $ret);
 
         $m = new Exception([
             'Exception with solution',
@@ -135,8 +135,8 @@ class ExceptionTest extends TestCase
         ]);
 
         $ret = $m->getColorfulText();
-        $this->assertRegExp('/1st Solution/', $ret);
-        $this->assertRegExp('/2nd Solution/', $ret);
+        $this->assertMatchesRegularExpression('/1st Solution/', $ret);
+        $this->assertMatchesRegularExpression('/2nd Solution/', $ret);
     }
 
     public function testExceptionFallback(): void

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -207,7 +207,7 @@ class FactoryAppScopeMock
 
 class FactoryTestAppMock
 {
-    public function normalizeClassNameApp($name, $prefix)
+    public function normalizeClassNameApp(string $name, string $prefix = null): ?string
     {
         if ($prefix == 'atk4\test') {
             return 'atk4\mytest\\'.$name;

--- a/tests/InitializerTraitTest.php
+++ b/tests/InitializerTraitTest.php
@@ -53,7 +53,7 @@ class InitializerMock extends _InitializerMock
 {
     public $result = false;
 
-    public function init()
+    public function init(): void
     {
         parent::init();
 
@@ -63,7 +63,7 @@ class InitializerMock extends _InitializerMock
 
 class BrokenInitializerMock extends _InitializerMock
 {
-    public function init()
+    public function init(): void
     {
         // do not call parent
     }

--- a/tests/LocalizationTest.php
+++ b/tests/LocalizationTest.php
@@ -70,4 +70,18 @@ class LocalizationTest extends TestCase
             $this->assertMatchesRegularExpression('/external translator/', $e->getJSON());
         }
     }
+
+    /**
+     * Add assertMatchesRegularExpression() method for phpunit >= 8.0 < 9.0 for compatibility with PHP 7.2.
+     *
+     * @TODO Remove once PHP 7.2 support is not needed for testing anymore.
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            static::assertRegExp($pattern, $string, $message);
+        }
+    }
 }

--- a/tests/LocalizationTest.php
+++ b/tests/LocalizationTest.php
@@ -20,10 +20,10 @@ class LocalizationTest extends TestCase
             Persistence::connect('error:error');
         } catch (\Throwable $e) {
             /* @var $e Exception */
-            $this->assertRegExp('/Невозможно определить постоянство драйвера из DSN/', $e->getHTML());
-            $this->assertRegExp('/Невозможно определить постоянство драйвера из DSN/', $e->getHTMLText());
-            $this->assertRegExp('/Невозможно определить постоянство драйвера из DSN/', $e->getColorfulText());
-            $this->assertRegExp('/Невозможно определить постоянство драйвера из DSN/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getHTMLText());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getColorfulText());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getJSON());
         }
     }
 
@@ -37,10 +37,10 @@ class LocalizationTest extends TestCase
         } catch (\Throwable $e) {
             /* @var $e Exception */
             $e->setTranslatorAdapter($adapter);
-            $this->assertRegExp('/message is translated/', $e->getHTML());
-            $this->assertRegExp('/message is translated/', $e->getHTMLText());
-            $this->assertRegExp('/message is translated/', $e->getColorfulText());
-            $this->assertRegExp('/message is translated/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getHTMLText());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getColorfulText());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getJSON());
         }
     }
 
@@ -64,10 +64,10 @@ class LocalizationTest extends TestCase
                     return 'external translator';
                 }
             });
-            $this->assertRegExp('/external translator/', $e->getHTML());
-            $this->assertRegExp('/external translator/', $e->getHTMLText());
-            $this->assertRegExp('/external translator/', $e->getColorfulText());
-            $this->assertRegExp('/external translator/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getHTMLText());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getColorfulText());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getJSON());
         }
     }
 }

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -288,7 +288,7 @@ class SeedTest extends TestCase
         $this->assertEquals('bar', $s1->foo);
         $this->assertEquals('', $s1->baz);
 
-        $s1->setDefaults(null);
+        $s1->setDefaults([]);
     }
 
     public function testNull()

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -453,7 +453,7 @@ class ViewTestMock extends SeedTestMock
     }
     public $def = null;
 
-    public function setDefaults($properties = [], $passively = false)
+    public function setDefaults(array $properties = [], bool $passively = false)
     {
         if ($properties['foo']) {
             if ($passively) {
@@ -475,15 +475,15 @@ class SeedDefTestMock extends SeedTestMock
     }
     public $def = null;
 
-    public function setDefaults($def, $passively = false)
+    public function setDefaults(array $properties, bool $passively = false)
     {
-        $this->def = $def;
+        $this->def = $properties;
     }
 }
 
 class SeedAppPrefixMock
 {
-    public function normalizeClassNameApp($name, $prefix)
+    public function normalizeClassNameApp(string $name, string $prefix = null): ?string
     {
         var_dump($name, $prefix);
     }

--- a/tests/SessionTraitTest.php
+++ b/tests/SessionTraitTest.php
@@ -44,22 +44,22 @@ class SessionTraitTest extends TestCase
 
         // value as string
         $m->memorize('foo', 'bar');
-        $this->assertEquals('bar', $_SESSION['o'][$m->name]['foo']);
+        $this->assertEquals('bar', $_SESSION['__atk_session'][$m->name]['foo']);
 
         // value as null
         $m->memorize('foo', null);
-        $this->assertEquals(null, $_SESSION['o'][$m->name]['foo']);
+        $this->assertEquals(null, $_SESSION['__atk_session'][$m->name]['foo']);
 
         // value as callable
         $m->memorize('foo', function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $_SESSION['o'][$m->name]['foo']);
+        $this->assertEquals('bar', $_SESSION['__atk_session'][$m->name]['foo']);
 
         // value as object
         $o = new \StdClass();
         $m->memorize('foo', $o);
-        $this->assertEquals($o, $_SESSION['o'][$m->name]['foo']);
+        $this->assertEquals($o, $_SESSION['__atk_session'][$m->name]['foo']);
 
         $m->destroySession();
     }


### PR DESCRIPTION
And also fixes #154

Forcing `:self` return type instead of phpdoc `@return $this` is not desired as some IDEs the ignore the phpdoc and uses `self` instead of `static` type. This will change in PHP 8.0, which will support native return type of `static`.