### PR TITLE
Add polyfill for PHP < 7.3 for array_key_first/last

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   "require": {
     "php": ">=7.2.0",
     "psr/log": "~1.0",
+    "symfony/polyfill-php73": "^1.15",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
To be used in ui & data, can be dropped once PHP 7.2 is no longer supported.