### PR TITLE
ConfigTrait - Fix format unknown not throwing exception

### DIFF
--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -83,6 +83,12 @@ trait ConfigTrait
                     $tempConfig = \Symfony\Component\Yaml\Yaml::parseFile($file);
                     // @codeCoverageIgnoreEnd
                     break;
+                default:
+                    throw new Exception([
+                        'Unknown Format. Allowed format : php, php-inline, json, yml.',
+                        'file' => $file,
+                        'format' => $format
+                    ]);
             }
 
             if (!is_array($tempConfig)) {

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -87,7 +87,7 @@ trait ConfigTrait
                     throw new Exception([
                         'Unknown Format. Allowed format : php, php-inline, json, yml.',
                         'file' => $file,
-                        'format' => $format
+                        'format' => $format,
                     ]);
             }
 

--- a/tests/ConfigTraitTest.php
+++ b/tests/ConfigTraitTest.php
@@ -99,6 +99,13 @@ class ConfigTraitTest extends AtkPhpunit\TestCase
         $m->readConfig($this->dir . 'config_bad_format.php');
     }
 
+    public function testWrongFileFormatException()
+    {
+        $this->expectException(\atk4\core\Exception::class);
+        $m = new ConfigMock();
+        $m->readConfig($this->dir . 'config.yml', 'wrong-format');
+    }
+
     public function testSetGetConfig()
     {
         $a = [


### PR DESCRIPTION
If config format is unknown, the config array will be empty, without throwing an error.