### PR TITLE
Require closures for callbacks

### DIFF
--- a/docs/dynamicmethod.rst
+++ b/docs/dynamicmethod.rst
@@ -55,7 +55,7 @@ Methods
     Tries to call dynamic method, but doesn't throw exception if it is not
     possible.
 
-.. php:method:: addMethod($name, $callable)
+.. php:method:: addMethod($name, $closure)
 
     Add new method for this object.
     See examples above.
@@ -69,7 +69,7 @@ Methods
 
     Remove dynamically registered method.
 
-.. php:method:: addGlobalMethod($name, $callable)
+.. php:method:: addGlobalMethod($name, $closure)
 
     Registers a globally-recognized method for all objects.
 

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -67,7 +67,7 @@ trait DynamicMethodTrait
      *
      * @return $this
      */
-    public function addMethod(string $name, callable $fx)
+    public function addMethod(string $name, \Closure $fx)
     {
         // HookTrait is mandatory
         if (!isset($this->_hookTrait)) {
@@ -129,7 +129,7 @@ trait DynamicMethodTrait
      *
      * @param string $name Name of the method
      */
-    public function addGlobalMethod(string $name, callable $fx): void
+    public function addGlobalMethod(string $name, \Closure $fx): void
     {
         // AppScopeTrait and HookTrait for app are mandatory
         if (!isset($this->_appScopeTrait) || !isset($this->app->_hookTrait)) {

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -28,64 +28,19 @@ trait HookTrait
     private $_hookIndexCounter = 0;
 
     /**
-     * @deprecated use onHook instead
-     */
-    public function addHook($spot, $fx, array $args = null, int $priority = null)
-    {
-        return $this->onHook($spot, $fx, $args ?? [], $priority ?? 0);
-    }
-
-    /**
      * Add another callback to be executed during hook($hook_spot);.
      *
      * If priority is negative, then hooks will be executed in reverse order.
      *
-     * @param string|string[]      $spot     Hook identifier to bind on
-     * @param object|\Closure|null $fx       Will be called on hook()
-     * @param array                $args     Arguments are passed to $fx
-     * @param int                  $priority Lower priority is called sooner
+     * @param string   $spot     Hook identifier to bind on
+     * @param \Closure $fx       Will be called on hook()
+     * @param array    $args     Arguments are passed to $fx
+     * @param int      $priority Lower priority is called sooner
      *
-     * @return int|int[] Index under which the hook was added
+     * @return int Index under which the hook was added
      */
-    public function onHook($spot, $fx = null, array $args = [], int $priority = 5)
+    public function onHook(string $spot, \Closure $fx = null, array $args = [], int $priority = 5)
     {
-        $fx = $fx ?: $this;
-
-        // multiple hooks can be linked
-        if (is_string($spot) && strpos($spot, ',') !== false) {
-            $spot = explode(',', $spot);
-        }
-        if (is_array($spot)) {
-            $indexes = [];
-            foreach ($spot as $k => $h) {
-                $indexes[$k] = $this->onHook($h, $fx, $args, $priority);
-            }
-
-            return $indexes;
-        }
-        $spot = (string) $spot;
-
-        // short for onHook('test', $this); to call $this->test();
-        if (!is_callable($fx)) {
-            $valid = false;
-            if (is_object($fx)) {
-                $valid = (isset($fx->_dynamicMethodTrait) && $fx->hasMethod($spot)) || method_exists($fx, $spot);
-            }
-
-            if (!$valid) {
-                throw new Exception([
-                    '$fx should be a valid callback',
-                    'fx' => $fx,
-                ]);
-            }
-
-            $fx = \Closure::fromCallable([$fx, $spot]);
-        }
-
-        if (!$fx instanceof \Closure) {
-            throw new Exception('Callable must be an instance of Closure');
-        }
-
         if (!isset($this->hooks[$spot][$priority])) {
             $this->hooks[$spot][$priority] = [];
         }

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -41,7 +41,7 @@ trait HookTrait
      * If priority is negative, then hooks will be executed in reverse order.
      *
      * @param string|string[]      $spot     Hook identifier to bind on
-     * @param object|callable|null $fx       Will be called on hook()
+     * @param object|\Closure|null $fx       Will be called on hook()
      * @param array                $args     Arguments are passed to $fx
      * @param int                  $priority Lower priority is called sooner
      *
@@ -79,7 +79,11 @@ trait HookTrait
                 ]);
             }
 
-            $fx = [$fx, $spot];
+            $fx = \Closure::fromCallable([$fx, $spot]);
+        }
+
+        if (!$fx instanceof \Closure) {
+            throw new Exception('Callable must be an instance of Closure');
         }
 
         if (!isset($this->hooks[$spot][$priority])) {

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -86,6 +86,10 @@ trait SessionTrait
             || $_SESSION[$this->session_key][$this->name][$key] === null
         ) {
             if (is_callable($default)) {
+                if (!$default instanceof \Closure) {
+                    throw new Exception('Callable must be an instance of Closure');
+                }
+
                 $default = $default($key);
             }
 
@@ -109,6 +113,9 @@ trait SessionTrait
             || $_SESSION[$this->session_key][$this->name][$key] === null
         ) {
             if (is_callable($default)) {
+                if (!$default instanceof \Closure) {
+                    throw new Exception('Callable must be an instance of Closure');
+                }
                 $default = $default($key);
             }
 

--- a/tests/DynamicMethodTraitTest.php
+++ b/tests/DynamicMethodTraitTest.php
@@ -81,7 +81,7 @@ class DynamicMethodTraitTest extends AtkPhpunit\TestCase
 
         // callable as object/array
         $m = new DynamicMethodMock();
-        $m->addMethod('getElementCount', [new ContainerMock(), 'getElementCount']);
+        $m->addMethod('getElementCount', \Closure::fromCallable([new ContainerMock(), 'getElementCount']));
         $this->assertSame(0, $m->getElementCount());
     }
 


### PR DESCRIPTION
merge after https://github.com/atk4/data/pull/597

Callables should have context which is not the case if passes as an array. Now accept only Closure instances.

HOW TO UPGRADE:
calls with instance/array callables need to be converted to `\Closure` before adding, so calls like these:
```
$this->onHook('beforeSave', $this);
$this->onHook('beforeSave',[$this, 'beforeSave']);
```
need to be updated to:
```
$this->onHook('beforeSave', \Closure::fromCallable([$this, 'beforeSave']));
```

anonymous functions are `\Closures`, so adding them is fully supported and nothing neeeds to be changed