### PR TITLE
WIP: Do not pass this by default

### DIFF
--- a/src/HookArgThis.php
+++ b/src/HookArgThis.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace atk4\core;
+
+class HookArgThis
+{
+}

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -133,12 +133,18 @@ trait HookTrait
             $hookBackup = $this->hooks[$spot];
 
             try {
-                while ($_data = array_pop($this->hooks[$spot])) {
-                    foreach ($_data as $index => $data) {
-                        $return[$index] = $data[0](...array_merge(
-                            [$this],
+                while ($data = array_pop($this->hooks[$spot])) {
+                    foreach ($data as $index => [$hFx, $hArgs]) {
+                        $withThis = false;
+                        if (isset($hArgs[0]) && $hArgs[0] instanceof HookArgThis) {
+                            $withThis = true;
+                            unset($hArgs[0]);
+                        }
+
+                        $return[$index] = $hFx(...array_merge(
+                            $withThis ? [$this] : [],
                             $args,
-                            $data[1]
+                            $hArgs
                         ));
                     }
                 }


### PR DESCRIPTION
Fix #201

Once #196 is merged the arguments from `onHook` should be not longer needed at all.