### PR TITLE
Generate better names for dyn. methods hooks

### DIFF
--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -38,7 +38,7 @@ trait DynamicMethodTrait
         ]);
     }
 
-    private function buildMethodHookName(string $name, bool $isGlobal)
+    private function buildMethodHookName(string $name, bool $isGlobal): string
     {
         return '__atk__method__' . ($isGlobal ? 'g' : 'l') . '__' . $name;
     }


### PR DESCRIPTION
no BC break if the actual names were not used somewhere (i.e. used via the trait iface only)