### PR TITLE
Fix - do not read/set name property if there is no NameTrait

### DIFF
--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -147,7 +147,9 @@ trait ContainerTrait
 
         $element->owner = $this;
         $element->short_name = $args[0];
-        $element->name = $this->_shorten($this->name . '_' . $element->short_name);
+        if (isset($this->_nameTrait)) {
+            $element->name = $this->_shorten($this->name . '_' . $element->short_name);
+        }
         $this->elements[$element->short_name] = $element;
 
         unset($args[0]);


### PR DESCRIPTION
Avoid accessing "name" property if NameTrait is not used.