### PR TITLE
Do not normalize "/" in class names

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -78,7 +78,7 @@ Example::
         {
             $seed = $this->mergeSeeds($seed, ['FieldMock']);
 
-            $field = $this->factory($seed, ['name'=>$name], '\atk4\core\tests');
+            $field = $this->factory($seed, ['name'=>$name], 'atk4\core\tests');
 
             return $this->_addIntoCollection($name, $field, 'fields');
         }
@@ -107,7 +107,7 @@ Methods
     Adds a new element into collection::
 
         function addField($name, $definition) {
-            $field = $this->factory($definition, [], '\atk4\data\Field');
+            $field = $this->factory($definition, [], 'atk4\data\Field');
             return $this->_addIntoCollection($name, $field, 'fields');
         }
 

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -596,7 +596,7 @@ A same logic can be applied to addField::
 
 and the implementation uses factory's default::
 
-    $field = $this->factory($this->_field_class, $arg, '\atk4\data');
+    $field = $this->factory($this->_field_class, $arg, 'atk4\data');
 
 Normally the field class property is a string, which will be used, but it can
 also be array.
@@ -606,31 +606,10 @@ also be array.
 OBSOLETE - Namespace
 ====================
 
-.. important:: MUST REVIEW THIS!!!!!!!!
-
 You might have noticed, that seeds do not specify namespace. This is because
 factory relies on $app to normalize your class name.
 
 .. php:method:: normalizeClassName($name, $prefix = null)
-
-Seed can use '/my/namespace/Class' where '/' are used instead of '\' to separate
-namespaces. The '/' will be translated into '\' and they have exactly the same
-meaning::
-
-    $button = $this->factory(['\My\Namespace\RedButton'], null, 'other/prefix');
-
-    // same as
-
-    $button = $this->factory(['/My/Namespace/RedButton'], null, 'other/prefix');
-
-A regular slashes, may be used in various combinations. Here are few things
-to consider.
-
-    - 3rd argument of factory() is called "Contextual Prefix" and is explained
-      below.
-    - Application may change namespace with "Global Prefixing"
-    - User may want to specify extra namespace inside seed
-    - User may want to override namespace entirely
 
 Motivation
 ----------
@@ -659,7 +638,7 @@ framework:
 
  - Allow to work with App and without App.
  - Contextual prefixing is great for creating separate class namespaces:
-   'Checkbox' -> 'FormField/Checkbox'
+   'Checkbox' -> 'FormField\Checkbox'
  - Namespace prefix "FormLayout" can be used for discovery of possible classes.
  - Global prefixing logic can be quite sophisticated and implemented inside App.
  - Use of forward slashes helps avoid errors
@@ -679,7 +658,7 @@ by you "Button" is converted into ``\atk4\ui\Button``::
     $app->add(['Button\WithDropdown', 'My Label']);
 
     // \MyNamespace\Button
-    $app->add(['\MyNamespace\Button', 'My Label']);
+    $app->add([\MyNamespace\Button::class, 'My Label']);
 
 
 Contextual Prefix
@@ -710,7 +689,7 @@ Here are some examples of contextual prefixing::
 
     // \MyNamespace\Checkbox
     $form = $app->add('Form');
-    $form->addField('agree_to_terms', '\MyNamespace\Checkbox', 'I Agree to Terms of Service');
+    $form->addField('agree_to_terms', \MyNamespace\Checkbox::class, 'I Agree to Terms of Service');
 
 Specifying contextual prefix will still leave it up for global prefixing, but
 if you want to fully specify a namespace, then you can use ``\Prefix``. If you
@@ -725,7 +704,7 @@ this technique::
         use ContainerTrait;  // implements $this->add
 
         function enableFeature($feature) {
-            return $this->add($this->factory($feature, ['myattr' => $this], '\my\auth\feature');
+            return $this->add($this->factory($feature, ['myattr' => $this], 'my\auth\feature');
         }
     }
 
@@ -761,7 +740,7 @@ implemented inside your own namespace::
     class MyApp extends \atk4\ui\App {
         function normalizeClassNameApp(string $name, string $prefix = null): ?string {
             if ($name == 'Grid') {
-                return '\myextensions\Grid';
+                return 'myextensions\Grid';
             }
 
             return parent::normalizeClassNameApp($name);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ to create necessary methods with minimum code footprint::
        {
            $seed = $this->mergeSeeds($seed, ['FieldMock']);
 
-           $field = $this->factory($seed, ['name'=>$name], '\atk4\ui\FormField');
+           $field = $this->factory($seed, ['name'=>$name], 'atk4\ui\FormField');
 
            return $this->_addIntoCollection($name, $field, 'fields');
        }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -19,7 +19,7 @@ trait CollectionTrait
      * Use this method trait like this:.
      *
      * function addField($name, $definition) {
-     *     $field = $this->factory($definition, [], '\atk4\data\Field');
+     *     $field = $this->factory($definition, [], 'atk4\data\Field');
      *
      *     return $this->_addIntoCollection($name, $field, 'fields');
      * }

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -217,7 +217,6 @@ trait FactoryTrait
             && method_exists($this->app, 'normalizeClassNameApp')
         ) {
             $result = $this->app->normalizeClassNameApp($name, $prefix);
-
             if ($result !== null) {
                 return $result;
             }

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -191,14 +191,14 @@ trait FactoryTrait
      * add prefix.
      *
      * Rules observed, in order:
-     *  - If class starts with "./" then prefixing is always done.
+     *  - If class starts with ".\" then prefixing is always done.
      *  - If class contains "\" or it is an anonymous class prefixing is never done.
      *  - If class (with prefix) exists, do prefix.
      *  - don't prefix otherwise.
      *
      * Example: normalizeClassName('User', 'Model') == 'Model\User';
      * Example: normalizeClassName(Test\User::class, 'Model') == 'Test\User'; # or as per "use"
-     * Example: normalizeClassName('./User', 'Model') == 'Model\User';
+     * Example: normalizeClassName('.\User', 'Model') == 'Model\User';
      * Example: normalizeClassName('User', 'Model') == 'Model\User'; # if exists, 'User' otherwise
      *
      * # If used without namespace:
@@ -222,12 +222,12 @@ trait FactoryTrait
             }
         }
 
-        // Rule 1: if starts with "./" always prefix
-        if (strpos($name, './') === 0 && $prefix) {
-            return $prefix . '\\' . substr($name, 2);
+        // Rule 1: if starts with ".\" always prefix
+        if (strpos($name, '.\\') === 0 && $prefix) {
+            return $prefix . substr($name, 1);
         }
 
-        // Rule 2: if "\" is present, don't prefix
+        // Rule 2: if contains "\" never prefix
         if (strpos($name, '\\') !== false || strpos($name, 'class@anonymous') === 0) {
             return $name;
         }

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -191,14 +191,13 @@ trait FactoryTrait
      * add prefix.
      *
      * Rules observed, in order:
-     *  - If class starts with "." then prefixing is always done.
-     *  - If class contains "\" prefixing is never done.
+     *  - If class starts with "./" then prefixing is always done.
+     *  - If class contains "\" or it is an anonymous class prefixing is never done.
      *  - If class (with prefix) exists, do prefix.
      *  - don't prefix otherwise.
      *
      * Example: normalizeClassName('User', 'Model') == 'Model\User';
      * Example: normalizeClassName(Test\User::class, 'Model') == 'Test\User'; # or as per "use"
-     * Example: normalizeClassName('Test/User', 'Model') == 'Model\Test\User';
      * Example: normalizeClassName('./User', 'Model') == 'Model\User';
      * Example: normalizeClassName('User', 'Model') == 'Model\User'; # if exists, 'User' otherwise
      *
@@ -224,26 +223,19 @@ trait FactoryTrait
             }
         }
 
-        // Rule 1: if starts with "." always prefix
-        if ($name && $name[0] === '.' && $prefix) {
-            $name = $prefix . '\\' . substr($name, 1);
-            $name = str_replace('/', '\\', $name);
-
-            return $name;
+        // Rule 1: if starts with "./" always prefix
+        if (strpos($name, './') === 0 && $prefix) {
+            return $prefix . '\\' . substr($name, 2);
         }
 
         // Rule 2: if "\" is present, don't prefix
-        if (strpos($name, '\\') !== false) {
-            $name = str_replace('/', '\\', $name);
-
+        if (strpos($name, '\\') !== false || strpos($name, 'class@anonymous') === 0) {
             return $name;
         }
 
-        if ($name && $name[0] !== '/' && $prefix) {
+        if ($name && $prefix) {
             $name = $prefix . '\\' . $name;
         }
-
-        $name = str_replace('/', '\\', $name);
 
         return $name;
     }

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -196,11 +196,11 @@ trait FactoryTrait
      *  - If class (with prefix) exists, do prefix.
      *  - don't prefix otherwise.
      *
-     * Example: normalizeClassName('User') == 'User'; # default -> no prefix
-     * Example: normalizeClassName('User', 'Model') == 'Model\User'; # default -> with prefix
-     * Example: normalizeClassName('.\User', 'Model') == 'Model\User'; # relative to Model
-     * Example: normalizeClassName(User::class, 'Model') == 'Model\User'; # no namespace -> prefix
-     * Example: normalizeClassName(Test\User::class, 'Model') == 'Test\User'; # has namespace -> no prefix
+     * Example: normalizeClassName('User')                    -> 'User'
+     * Example: normalizeClassName('User', 'Model')           -> 'Model\User'
+     * Example: normalizeClassName('.\User', 'Model')         -> 'Model\User'
+     * Example: normalizeClassName(User::class, 'Model')      -> 'Model\User'
+     * Example: normalizeClassName(Test\User::class, 'Model') -> 'Test\User'
      *
      * @param string $name   Name of class
      * @param string $prefix Optional prefix for class name
@@ -230,7 +230,7 @@ trait FactoryTrait
             return $name;
         }
 
-        if ($name && $prefix) {
+        if ($name && $prefix && class_exists($prefix . '\\' . $name)) {
             $name = $prefix . '\\' . $name;
         }
 

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -196,13 +196,11 @@ trait FactoryTrait
      *  - If class (with prefix) exists, do prefix.
      *  - don't prefix otherwise.
      *
-     * Example: normalizeClassName('User', 'Model') == 'Model\User';
-     * Example: normalizeClassName(Test\User::class, 'Model') == 'Test\User'; # or as per "use"
-     * Example: normalizeClassName('.\User', 'Model') == 'Model\User';
-     * Example: normalizeClassName('User', 'Model') == 'Model\User'; # if exists, 'User' otherwise
-     *
-     * # If used without namespace:
-     * Example: normalizeClassName(User::class, 'Model') == 'Model\User'; # if exists, 'User' otherwise
+     * Example: normalizeClassName('User') == 'User'; # default -> no prefix
+     * Example: normalizeClassName('User', 'Model') == 'Model\User'; # default -> with prefix
+     * Example: normalizeClassName('.\User', 'Model') == 'Model\User'; # relative to Model
+     * Example: normalizeClassName(User::class, 'Model') == 'Model\User'; # no namespace -> prefix
+     * Example: normalizeClassName(Test\User::class, 'Model') == 'Test\User'; # has namespace -> no prefix
      *
      * @param string $name   Name of class
      * @param string $prefix Optional prefix for class name
@@ -211,7 +209,7 @@ trait FactoryTrait
      */
     public function normalizeClassName(string $name, string $prefix = null): string
     {
-        // If App has "normalizeClassName" (obsolete now), use it instead
+        // Compatibility: if App has "normalizeClassNameApp" (obsolete now), use it instead
         if (
             isset($this->_appScopeTrait, $this->app)
             && method_exists($this->app, 'normalizeClassNameApp')
@@ -222,12 +220,12 @@ trait FactoryTrait
             }
         }
 
-        // Rule 1: if starts with ".\" always prefix
+        // Rule 1: if starts with ".\" then always prefix
         if (strpos($name, '.\\') === 0 && $prefix) {
             return $prefix . substr($name, 1);
         }
 
-        // Rule 2: if contains "\" never prefix
+        // Rule 2: if contains "\" or is anonymous class then never prefix
         if (strpos($name, '\\') !== false || strpos($name, 'class@anonymous') === 0) {
             return $name;
         }

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -96,7 +96,7 @@ class Generic implements ITranslatorAdapter
 
         $this->definitions[$locale]['atk'] = [];
 
-        if (class_exists('\atk4\data\Locale')) {
+        if (class_exists(\atk4\data\Locale::class)) {
             $path = Locale::getPath();
             $this->addDefinitionFromFile($path . '/' . $locale . '/atk.php', $locale, 'atk', 'php');
         }

--- a/tests/CollectionMock.php
+++ b/tests/CollectionMock.php
@@ -22,7 +22,7 @@ class CollectionMock
     {
         $seed = $this->mergeSeeds($seed, ['FieldMock']);
 
-        $field = $this->factory($seed, ['name' => $name], '\atk4\core\tests');
+        $field = $this->factory($seed, ['name' => $name], 'atk4\core\tests');
 
         return $this->_addIntoCollection($name, $field, 'fields');
     }

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -115,11 +115,11 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
     public function testFactoryMock()
     {
         $m = new ContainerFactoryMock();
-        $m2 = $m->add('atk4/core/tests/ContainerMock');
-        $this->assertSame('atk4\core\tests\ContainerMock', get_class($m2));
+        $m2 = $m->add(ContainerMock::class);
+        $this->assertSame(ContainerMock::class, get_class($m2));
 
-        $m3 = $m->add('atk4/core/tests/TrackableContainerMock', 'name');
-        $this->assertSame('atk4\core\tests\TrackableContainerMock', get_class($m3));
+        $m3 = $m->add(TrackableContainerMock::class, 'name');
+        $this->assertSame(TrackableContainerMock::class, get_class($m3));
         $this->assertSame('name', $m3->short_name);
     }
 

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -30,7 +30,7 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
 
         // pass classname
         $m1 = $m->factory('atk4\core\tests\FactoryMock');
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m1));
+        $this->assertSame(FactoryMock::class, get_class($m1));
     }
 
     /**
@@ -48,18 +48,6 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $class = $m->normalizeClassName('a\b\MyClass');
         $this->assertSame('a\b\MyClass', $class);
 
-        $class = $m->normalizeClassName('a/b\MyClass');
-        $this->assertSame('a\b\MyClass', $class);
-
-        $class = $m->normalizeClassName('a/b/MyClass', 'Prefix');
-        $this->assertSame('Prefix\a\b\MyClass', $class);
-
-        $class = $m->normalizeClassName('/a/b/MyClass', 'Prefix');
-        $this->assertSame('\a\b\MyClass', $class);
-
-        $class = $m->normalizeClassName('\a\b\MyClass', 'Prefix');
-        $this->assertSame('\a\b\MyClass', $class);
-
         $class = $m->normalizeClassName('a\b\MyClass', 'Prefix');
         $this->assertSame('a\b\MyClass', $class);
 
@@ -70,12 +58,12 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $this->assertSame('atk4\core\HookBreaker', $class);
 
         $class = $m->normalizeClassName(\Datetime::class, 'Prefix');
+        $this->assertSame('Datetime', $class);
+
+        $class = $m->normalizeClassName('.\Datetime', 'Prefix');
         $this->assertSame('Prefix\Datetime', $class);
 
-        $class = $m->normalizeClassName('.Datetime', 'Prefix');
-        $this->assertSame('Prefix\Datetime', $class);
-
-        $class = $m->normalizeClassName('.Date\Time', 'Prefix');
+        $class = $m->normalizeClassName('.\Date\Time', 'Prefix');
         $this->assertSame('Prefix\Date\Time', $class);
 
         // With Application Prefixing
@@ -105,26 +93,26 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
 
         // as class name
         $m1 = $m->factory('atk4\core\tests\FactoryMock');
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m1));
+        $this->assertSame(FactoryMock::class, get_class($m1));
 
         $m1 = $m->factory(\atk4\core\tests\FactoryMock::class);
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m1));
+        $this->assertSame(FactoryMock::class, get_class($m1));
 
         $m1 = $m->factory(FactoryMock::class);
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m1));
+        $this->assertSame(FactoryMock::class, get_class($m1));
 
         $m1 = $m->factory(HB::class, ['ok']);
-        $this->assertSame('atk4\core\HookBreaker', get_class($m1));
+        $this->assertSame(\atk4\core\HookBreaker::class, get_class($m1));
 
         $m1 = $m->factory(['atk4\core\tests\FactoryMock']);
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m1));
+        $this->assertSame(FactoryMock::class, get_class($m1));
 
         // as object
         $m2 = $m->factory($m1);
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m2));
+        $this->assertSame(FactoryMock::class, get_class($m2));
 
         $m2 = $m->factory([$m1]);
-        $this->assertSame('atk4\core\tests\FactoryMock', get_class($m2));
+        $this->assertSame(FactoryMock::class, get_class($m2));
 
         // as class name with parameters
         $m1 = $m->factory('atk4\core\tests\FactoryDIMock', ['a' => 'XXX', 'b' => 'YYY']);

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -224,7 +224,7 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testBasic()
     {
-        $s1 = $this->factory('atk4/core/tests/SeedTestMock');
+        $s1 = $this->factory(SeedTestMock::class);
         $this->assertEmpty($s1->args);
 
         $s1 = $this->factory(new SeedTestMock());
@@ -236,7 +236,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $s1 = $this->factory(new SeedTestMock(null, 'world'));
         $this->assertSame([null, 'world'], $s1->args);
 
-        $s1 = $this->factory(['atk4/core/tests/SeedTestMock']);
+        $s1 = $this->factory([SeedTestMock::class]);
         $this->assertEmpty($s1->args);
     }
 
@@ -252,39 +252,24 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testArguments()
     {
         /*
-        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello']);
+        $s1 = $this->factory([SeedTestMock::class, 'hello']);
         $this->assertEquals(['hello'], $s1->args);
 
-        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello', 'world']);
+        $s1 = $this->factory([SeedTestMock::class, 'hello', 'world']);
         $this->assertEquals(['hello', 'world'], $s1->args);
          */
 
-        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', null, 'world']);
+        $s1 = $this->factory([SeedTestMock::class, null, 'world']);
         $this->assertSame([null, 'world'], $s1->args);
 
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo' => 'bar', 'world']);
+        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'foo' => 'bar', 'world']);
         $this->assertSame(['hello', 'world'], $s1->args);
         $this->assertSame('bar', $s1->foo);
     }
 
-    public function testPrefix()
-    {
-        // prefix could be fully specified (global)
-        $s1 = $this->factory('SeedTestMock', ['hello'], '/atk4/core/tests');
-        $this->assertSame(['hello'], $s1->args);
-
-        // specifying prefix yourself will override, but only if you start with slash
-        $s1 = $this->factory('/atk4/core/tests/SeedTestMock', ['hello'], '/atk4/core/tests');
-        $this->assertSame(['hello'], $s1->args);
-
-        // without slash, prefixes add up
-        $s1 = $this->factory('tests/SeedTestMock', ['hello'], '/atk4/core');
-        $this->assertSame(['hello'], $s1->args);
-    }
-
     public function testDefaults()
     {
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'foo' => 'bar', 'world'], ['more', 'baz' => '', 'more', 'args']);
+        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'foo' => 'bar', 'world'], ['more', 'baz' => '', 'more', 'args']);
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['hello', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
@@ -295,27 +280,27 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testNull()
     {
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'foo' => null, null, 'world'], ['more', 'foo' => 'bar', 'more', 'args']);
+        $s1 = $this->factory([SeedDITestMock::class, 'foo' => null, null, 'world'], ['more', 'foo' => 'bar', 'more', 'args']);
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds(['atk4/core/tests/SeedDITestMock', 'foo' => null, null, 'world'], ['atk4/core/tests/SeedTestMock', 'more', 'foo' => 'bar', 'more', 'args']));
+        $s1 = $this->factory($this->mergeSeeds([SeedDITestMock::class, 'foo' => null, null, 'world'], [SeedTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds([null, 'foo' => null, null, 'world'], ['atk4/core/tests/SeedDITestMock', 'more', 'foo' => 'bar', 'more', 'args']));
+        $s1 = $this->factory($this->mergeSeeds([null, 'foo' => null, null, 'world'], [SeedDITestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds(null, ['atk4/core/tests/SeedDITestMock', 'more', 'foo' => 'bar', 'more', 'args']));
+        $s1 = $this->factory($this->mergeSeeds(null, [SeedDITestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['more', 'more', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds([], ['atk4/core/tests/SeedDITestMock', 'test']));
+        $s1 = $this->factory($this->mergeSeeds([], [SeedDITestMock::class, 'test']));
         $this->assertSame(['test'], $s1->args);
     }
 
@@ -336,10 +321,10 @@ class SeedTest extends AtkPhpunit\TestCase
         $s1 = $this->factory([$o, 'foo' => ['red']], ['foo' => ['big'], 'foo' => 'default']);
         $this->assertSame(['xx', 'red'], $s1->foo);
 
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'world'], ['more', 'more', 'args']);
+        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'world'], ['more', 'more', 'args']);
         $this->assertSame(['hello', 'world', 'args'], $s1->args);
 
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', null, 'world'], ['more', 'more', 'args']);
+        $s1 = $this->factory([SeedDITestMock::class, null, 'world'], ['more', 'more', 'args']);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
 
         $s1 = $this->factory([new SeedDITestMock('x', 'y'), null, 'bar'], ['foo', 'baz']);
@@ -367,20 +352,20 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testClassMayNotBeEmpty()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory([''], ['atk4/core/tests/SeedDITestMock', 'test']);
+        $s1 = $this->factory([''], [SeedDITestMock::class, 'test']);
         $this->assertSame(['test'], $s1->args);
     }
 
     public function testMystBeDI()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory(['atk4/core/tests/SeedTestMock', 'hello', 'foo' => 'bar', 'world']);
+        $s1 = $this->factory([SeedTestMock::class, 'hello', 'foo' => 'bar', 'world']);
     }
 
     public function testMustHaveProperty()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory(['atk4/core/tests/SeedDITestMock', 'hello', 'xxx' => 'bar', 'world']);
+        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'xxx' => 'bar', 'world']);
     }
 
     public function testGiveClassFirst()
@@ -392,12 +377,12 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testStringDefault()
     {
-        $s1 = $this->factory('atk4/core/tests/SeedDITestMock', 'hello');
+        $s1 = $this->factory(SeedDITestMock::class, 'hello');
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['hello'], $s1->args);
 
         // also OK if it's not a DIContainer object
-        $s1 = $this->factory('atk4/core/tests/SeedTestMock', 'hello');
+        $s1 = $this->factory(SeedTestMock::class, 'hello');
         $this->assertTrue($s1 instanceof SeedTestMock);
         $this->assertSame(['hello'], $s1->args);
     }
@@ -408,7 +393,7 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testNonDIInject()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory('atk4/core/tests/SeedTestMock', ['foo' => 'hello']);
+        $s1 = $this->factory(SeedTestMock::class, ['foo' => 'hello']);
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['hello'], $s1->args);
     }
@@ -419,7 +404,7 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testPropertyMerging()
     {
         $s1 = $this->factory(
-            ['atk4/core/tests/SeedDITestMock', 'foo' => ['Button', 'icon' => 'red']],
+            [SeedDITestMock::class, 'foo' => ['Button', 'icon' => 'red']],
             ['foo' => ['Label', 'red']]
         );
 


### PR DESCRIPTION
Proper usage should be fully BC. Usage of `/` as NS separator will throw an error.

Normalizing "/" to "\\" in class names does not add any advantage.

The current implementation breaks anonymous class names.

Example:
```
$seed = [get_class(new class () extends \atk4\ui\FormField\Upload {
    ...
})]
```
is valid seed and this PR fixes it.