### PR TITLE
Always build html safe name

### DIFF
--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -52,7 +52,7 @@ trait TrackableTrait
             $name .= '@anonymous';
         }
 
-        return trim(preg_replace('~^atk4\\\\[^\\\\]+\\\\|[^0-9a-z_]+~is', '_', mb_strtolower($name)), '_');
+        return trim(preg_replace('~^atk4\\\\[^\\\\]+\\\\|[^0-9a-z\x7f-\xfe]+~s', '_', mb_strtolower($name)), '_');
     }
 
     /**

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -47,6 +47,7 @@ trait TrackableTrait
             foreach (class_parents(static::class) as $v) {
                 if (strpos($v, 'class@anonymous') !== 0) {
                     $name = $v;
+
                     break;
                 }
             }

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -40,7 +40,19 @@ trait TrackableTrait
      */
     public function getDesiredName(): string
     {
-        return preg_replace('/.*\\\\/', '', mb_strtolower(static::class));
+        // can be anything, but better to build meaningful name
+        $name = static::class;
+        if (strpos($name, 'class@anonymous') === 0) {
+            $name = '';
+            foreach (class_parents(static::class) as $name) {
+                if (strpos($name, 'class@anonymous') !== 0) {
+                    break;
+                }
+            }
+            $name .= '@anonymous';
+        }
+
+        return trim(preg_replace('~^atk4\\\\[^\\\\]+\\\\|[^0-9a-z_]+~is', '_', mb_strtolower($name)), '_');
     }
 
     /**

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -44,8 +44,9 @@ trait TrackableTrait
         $name = static::class;
         if (strpos($name, 'class@anonymous') === 0) {
             $name = '';
-            foreach (class_parents(static::class) as $name) {
-                if (strpos($name, 'class@anonymous') !== 0) {
+            foreach (class_parents(static::class) as $v) {
+                if (strpos($v, 'class@anonymous') !== 0) {
+                    $name = $v;
                     break;
                 }
             }


### PR DESCRIPTION
Needed at least for anonymous classes at their names contain unsafe characters (`\0` etc.)

Related with (now reverted) PR: https://github.com/atk4/ui/pull/1230

Marking as BC breaking as the generated named might be used by someone in static CSS rules