### PR TITLE
Add central/singleton Factory and deprecate FactoryTrait trait

### DIFF
--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -100,7 +100,8 @@ trait DIContainerTrait
     public static function assertInstanceOf(object $object)// :static supported by PHP8+
     {
         if (!($object instanceof static)) {
-            throw (new Exception('Object is not an instance of ' . static::class))
+            throw (new Exception('Object is not an instance of static class'))
+                ->addMoreInfo('static_class', static::class)
                 ->addMoreInfo('object_class', get_class($object));
         }
 
@@ -125,7 +126,8 @@ trait DIContainerTrait
 
             $cl = $seed[0];
             if (!$unsafe && !is_a($cl, static::class, true)) {
-                throw (new Exception('Seed class is not a subtype of ' . static::class))
+                throw (new Exception('Seed class is not a subtype of static class'))
+                    ->addMoreInfo('static_class', static::class)
                     ->addMoreInfo('seed_class', $cl);
             }
         }

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -121,7 +121,8 @@ trait DIContainerTrait
             }
 
             if (!isset($seed[0])) {
-                throw (new Exception('Class name is not defined in seed'));
+                throw (new Exception('Class name is not specified by the seed'))
+                    ->addMoreInfo('seed', $seed);
             }
 
             $cl = $seed[0];

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -88,4 +88,91 @@ trait DIContainerTrait
             ->addMoreInfo('property', $key)
             ->addMoreInfo('value', $value);
     }
+
+    /**
+     * Return the argument and assert it is instance of current class.
+     *
+     * The best, typehinting-friendly, way to annotate object type if it not defined
+     * at method header or strong typing in method header can not be used.
+     *
+     * @return static
+     */
+    public static function assertInstanceOf(object $object)// :static supported by PHP8+
+    {
+        if (!($object instanceof static)) {
+            throw (new Exception('Object is not an instance of ' . static::class))
+                ->addMoreInfo('object_class', get_class($object));
+        }
+
+        return $object;
+    }
+
+    private static function _fromSeedPrecheck($seed, bool $unsafe)// :self is too strict with unsafe behaviour
+    {
+        if (!is_object($seed)) {
+            if (!is_array($seed)) {
+                if (!is_string($seed)) { // allow string class name seed but prevent bad usage
+                    throw (new Exception('Seed must be an array, a string class name (deprecated) or an object'))
+                        ->addMoreInfo('seed_type', gettype($seed));
+                }
+
+                $seed = [$seed];
+            }
+
+            if (!isset($seed[0])) {
+                throw (new Exception('Class name is not defined in seed'));
+            }
+
+            $cl = $seed[0];
+            if (!$unsafe && !is_a($cl, static::class, true)) {
+                throw (new Exception('Seed class is not a subtype of ' . static::class))
+                    ->addMoreInfo('seed_class', $cl);
+            }
+        }
+
+        return $seed;
+    }
+
+    /**
+     * Create new object from seed and assert it is instance of current class.
+     *
+     * The best, typehinting-friendly, way to create an object if it should not be
+     * immediately added to a parent (otherwise use addTo() method).
+     *
+     * @param array|string|object $seed the first element specifies a class name, other elements are seed
+     *
+     * @return static
+     */
+    public static function fromSeed($seed = [], $defaults = [])// :static supported by PHP8+
+    {
+        if (func_num_args() > 2) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
+        $seed = static::_fromSeedPrecheck($seed, false);
+        $object = Factory::factory($seed, $defaults);
+
+        static::assertInstanceOf($object);
+
+        return $object;
+    }
+
+    /**
+     * Same as fromSeed(), but the new object is not asserted to be an instance of this class.
+     *
+     * @param array|string|object $seed the first element specifies a class name, other elements are seed
+     *
+     * @return static
+     */
+    public static function fromSeedUnsafe($seed = [], $defaults = [])// :self is too strict with unsafe behaviour
+    {
+        if (func_num_args() > 2) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
+        $seed = static::_fromSeedPrecheck($seed, true);
+        $object = Factory::factory($seed, $defaults);
+
+        return $object;
+    }
 }

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -136,7 +136,7 @@ HTML;
             $this->json = [
                 'success' => false,
                 'code' => $this->exception->getCode(),
-                'message' => 'Error during JSON renderer : ' . $this->exception->getMessage(),
+                'message' => 'Error during JSON renderer: ' . $this->exception->getMessage(),
                 // avoid translation
                 //'message'  => $this->_($this->exception->getMessage()),
                 'title' => get_class($this->exception),

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -172,6 +172,7 @@ abstract class RendererAbstract
     protected function getVendorDirectory(): string
     {
         $loaderFile = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
+
         return realpath(dirname($loaderFile, 2) . '/');
     }
 

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -61,7 +61,10 @@ abstract class RendererAbstract
             return $this->output;
         } catch (\Throwable $e) {
             // fallback if Exception occur in renderer
-            return get_class($this->exception) . ' [' . $this->exception->getCode() . '] Error: ' . $this->_($this->exception->getMessage());
+            return '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
+                . get_class($this->exception)
+                . ($this->exception->getCode() !== 0 ? '(' . $this->exception->getCode() . ')' : '')
+                . ': ' . $this->_($this->exception->getMessage()) . ' !!';
         }
     }
 

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -171,7 +171,8 @@ abstract class RendererAbstract
 
     protected function getVendorDirectory(): string
     {
-        return realpath(dirname(__DIR__, 4) . '/');
+        $loaderFile = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
+        return realpath(dirname($loaderFile, 2) . '/');
     }
 
     protected function makeRelativePath(string $path): string

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace atk4\core;
+
+class Factory
+{
+    /** @var Factory */
+    private static $_instance;
+
+    protected function __construct()
+    {
+        // singleton
+    }
+
+    final protected static function getInstance(): self
+    {
+        if (self::$_instance === null) {
+            self::$_instance = new self();
+        }
+
+        return self::$_instance;
+    }
+
+    protected function _mergeSeeds($seed, $seed2, ...$more_seeds)
+    {
+        // recursively merge extra seeds
+        if ($more_seeds) {
+            $seed2 = $this->_mergeSeeds($seed2, ...$more_seeds);
+        }
+
+        if (is_object($seed) || is_object($seed2)) {
+            if (is_object($seed)) {
+                $passively = true; // set defaults but don't override existing properties
+            } else {
+                $passively = false;
+                [$seed, $seed2] = [$seed2, $seed]; // swap seeds
+            }
+
+            if (is_array($seed2)) {
+                $arguments = array_filter($seed2, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
+                $injection = array_diff_key($seed2, $arguments); // with string keys
+                if ($injection) {
+                    if (isset($seed->_DIContainerTrait)) {
+                        $seed->setDefaults($injection, $passively);
+                    } else {
+                        throw (new Exception('Property injection is possible only to objects that use \atk4\core\DIContainerTrait trait'))
+                            ->addMoreInfo('object', $seed)
+                            ->addMoreInfo('injection', $injection)
+                            ->addMoreInfo('passively', $passively);
+                    }
+                }
+            }
+
+            return $seed;
+        }
+
+        if (!is_array($seed)) {
+            $seed = [$seed];
+        }
+
+        if (!is_array($seed2)) {
+            $seed2 = [$seed2];
+        }
+
+        // merge seeds but prefer seed over seed2
+        // move numerical keys to the beginning and sort them
+        $res = [];
+        $res2 = [];
+        foreach ($seed as $k => $v) {
+            if (is_numeric($k)) {
+                $res[$k] = $v;
+            } elseif ($v !== null) {
+                $res2[$k] = $v;
+            }
+        }
+        foreach ($seed2 as $k => $v) {
+            if (is_numeric($k)) {
+                if (!isset($res[$k])) {
+                    $res[$k] = $v;
+                }
+            } elseif ($v !== null) {
+                if (!isset($res2[$k])) {
+                    $res2[$k] = $v;
+                }
+            }
+        }
+        ksort($res, SORT_NUMERIC);
+        $res = $res + $res2;
+
+        return $res;
+    }
+
+    protected function createNewObject(string $className, array $ctorArgs): object
+    {
+        return new $className(...$ctorArgs);
+    }
+
+    protected function _factory($seed, $defaults = []): object
+    {
+        if ($defaults === null) {
+            $defaults = [];
+        }
+
+        if (!$seed) {
+            $seed = [];
+        }
+
+        if (!is_array($seed)) {
+            $seed = [$seed];
+        }
+
+        if (is_array($defaults)) {
+            array_unshift($defaults, null); // insert argument 0
+        } elseif (!is_object($defaults)) {
+            $defaults = [null, $defaults];
+        }
+        $seed = $this->_mergeSeeds($seed, $defaults);
+
+        if (is_object($seed)) {
+            // setDefaults() already called in _mergeSeeds()
+
+            return $seed;
+        }
+
+        $arguments = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
+        $injection = array_diff_key($seed, $arguments); // with string keys
+        $object = array_shift($arguments); // first numeric key argument is object
+
+        if (!is_object($object)) {
+            if (!is_string($object)) {
+                throw (new Exception('Class name was not specified by the seed'))
+                    ->addMoreInfo('seed', $seed);
+            }
+
+            $object = $this->createNewObject($object, $arguments);
+        }
+
+        if ($injection) {
+            if (isset($object->_DIContainerTrait)) {
+                $object->setDefaults($injection);
+            } else {
+                throw (new Exception('factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait'))
+                    ->addMoreInfo('object', $object)
+                    ->addMoreInfo('seed', $seed)
+                    ->addMoreInfo('injection', $injection);
+            }
+        }
+
+        return $object;
+    }
+
+    /**
+     * Given two seeds (or more) will merge them, prioritizing the first argument.
+     * If object is passed on either of arguments, then it will setDefaults() remaining
+     * arguments, respecting their positioning.
+     *
+     * To learn more about mechanics of factory trait, see documentation
+     *
+     * @return object|array if at least one seed is an object, will return object
+     */
+    final public static function mergeSeeds(...$seeds)
+    {
+        return self::getInstance()->_mergeSeeds(...$seeds);
+    }
+
+    /**
+     * Given a Seed (see doc) as a first argument, will create object of a corresponding
+     * class, call constructor with numerical arguments of a seed and inject key/value
+     * arguments.
+     *
+     * Argument $defaults has the same effect as the seed, but will not contain the class.
+     * Class is always determined by seed, except if you pass object into defaults.
+     *
+     * To learn more about mechanics of factory trait, see documentation
+     *
+     * @param array $defaults
+     */
+    final public static function factory($seed, $defaults = []): object
+    {
+        if (func_num_args() > 2) { // prevent bad usage
+            throw new \Error('Too many method arguments');
+        }
+
+        return self::getInstance()->_factory($seed, $defaults);
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -138,14 +138,7 @@ class Factory
         }
 
         if ($injection) {
-            if (isset($object->_DIContainerTrait)) {
-                $object->setDefaults($injection);
-            } else {
-                throw (new Exception('factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait'))
-                    ->addMoreInfo('object', $object)
-                    ->addMoreInfo('seed', $seed)
-                    ->addMoreInfo('injection', $injection);
-            }
+            $this->_mergeSeeds($injection, $object);
         }
 
         return $object;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -26,7 +26,7 @@ class Factory
     protected function _mergeSeeds($seed, $seed2, ...$more_seeds)
     {
         // recursively merge extra seeds
-        if ($more_seeds) {
+        if (count($more_seeds) > 0) {
             $seed2 = $this->_mergeSeeds($seed2, ...$more_seeds);
         }
 
@@ -99,15 +99,13 @@ class Factory
 
     protected function _factory($seed, $defaults = []): object
     {
-        if ($defaults === null) {
+        if ($defaults === null) { // should be deprecated soon
             $defaults = [];
         }
 
-        if (!$seed) {
+        if ($seed === null) { // should be deprecated soon
             $seed = [];
-        }
-
-        if (!is_array($seed)) {
+        } elseif (!is_array($seed)) {
             $seed = [$seed];
         }
 
@@ -130,7 +128,7 @@ class Factory
 
         if (!is_object($object)) {
             if (!is_string($object)) {
-                throw (new Exception('Class name was not specified by the seed'))
+                throw (new Exception('Class name is not specified by the seed'))
                     ->addMoreInfo('seed', $seed);
             }
 

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace atk4\core;
 
+/**
+ * @deprecated will be removed in 2021-jun
+ */
 trait FactoryTrait
 {
     /**
@@ -14,167 +17,26 @@ trait FactoryTrait
     public $_factoryTrait = true;
 
     /**
-     * Given two seeds (or more) will merge them, prioritizing the first argument.
-     * If object is passed on either of arguments, then it will setDefaults() remaining
-     * arguments, respecting their positioning.
+     * See \atk4\core\Factory::mergeSeeds().
      *
-     * See full documentation.
-     *
-     * @param array|object|mixed $seed
-     * @param array|object|mixed $seed2
-     * @param array              $more_seeds
-     *
-     * @return object|array if at least one seed is an object, will return object
+     * @deprecated will be removed in 2021-jun
      */
-    public function mergeSeeds($seed, $seed2, ...$more_seeds)
+    public function mergeSeeds(...$seeds)
     {
-        // recursively merge extra seeds
-        if ($more_seeds) {
-            $seed2 = $this->mergeSeeds($seed2, ...$more_seeds);
-        }
-
-        if (is_object($seed)) {
-            if (is_array($seed2)) {
-                // set defaults but don't override existing properties
-                $arguments = array_filter($seed2, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
-                $injection = array_diff_key($seed2, $arguments); // with string keys
-                if ($injection) {
-                    if (isset($seed->_DIContainerTrait)) {
-                        $seed->setDefaults($injection, true);
-                    } else {
-                        throw (new Exception('factory() requested to passively inject some properties into existing object that does not use \atk4\core\DIContainerTrait'))
-                            ->addMoreInfo('object', $seed)
-                            ->addMoreInfo('injection', $injection);
-                    }
-                }
-            }
-
-            return $seed;
-        }
-
-        if (is_object($seed2)) {
-            // seed is not object, and setDefaults will complain if it's not array
-            if (is_array($seed)) {
-                $arguments = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
-                $injection = array_diff_key($seed, $arguments); // with string keys
-                if ($injection) {
-                    if (isset($seed2->_DIContainerTrait)) {
-                        $seed2->setDefaults($injection);
-                    } else {
-                        throw (new Exception('factory() requested to inject some properties into existing object that does not use \atk4\core\DIContainerTrait'))
-                            ->addMoreInfo('object', $seed2)
-                            ->addMoreInfo('injection', $seed);
-                    }
-                }
-            }
-
-            return $seed2;
-        }
-
-        if (!is_array($seed)) {
-            $seed = [$seed];
-        }
-
-        if (!is_array($seed2)) {
-            $seed2 = [$seed2];
-        }
-
-        // merge seeds but prefer seed over seed2
-        // move numerical keys to the beginning and sort them
-        $res = [];
-        $res2 = [];
-        foreach ($seed as $k => $v) {
-            if (is_numeric($k)) {
-                $res[$k] = $v;
-            } elseif ($v !== null) {
-                $res2[$k] = $v;
-            }
-        }
-        foreach ($seed2 as $k => $v) {
-            if (is_numeric($k)) {
-                if (!isset($res[$k])) {
-                    $res[$k] = $v;
-                }
-            } elseif ($v !== null) {
-                if (!isset($res2[$k])) {
-                    $res2[$k] = $v;
-                }
-            }
-        }
-        ksort($res, SORT_NUMERIC);
-        $res = $res + $res2;
-
-        return $res;
+        return Factory::mergeSeeds(...$seeds);
     }
 
     /**
-     * Given a Seed (see doc) as a first argument, will create object of a corresponding
-     * class, call constructor with numerical arguments of a seed and inject key/value
-     * arguments.
+     * See \atk4\core\Factory::factory().
      *
-     * Argument $defaults has the same effect as the seed, but will not contain the class.
-     * Class is always determined by seed, except if you pass object into defaults.
-     *
-     * To learn more about mechanics of factory trait, see documentation
-     *
-     * @param mixed  $seed
-     * @param array  $defaults
-     * @param string $prefix   No longer supported
+     * @deprecated will be removed in 2021-jun
      */
-    public function factory($seed, $defaults = [], string $prefix = null): object
+    public function factory($seed, $defaults = []): object
     {
-        if ($prefix !== null) { // remove in 2021-june
-            throw new Exception('Factory does no longer support relative names, pass full class name without prefix');
+        if (func_num_args() > 2) { // prevent bad usage
+            throw new \Error('Too many method arguments, factory does no longer support prefix');
         }
 
-        if ($defaults === null) {
-            $defaults = [];
-        }
-
-        if (!$seed) {
-            $seed = [];
-        }
-
-        if (!is_array($seed)) {
-            $seed = [$seed];
-        }
-
-        if (is_array($defaults)) {
-            array_unshift($defaults, null); // insert argument 0
-        } elseif (!is_object($defaults)) {
-            $defaults = [null, $defaults];
-        }
-        $seed = $this->mergeSeeds($seed, $defaults);
-
-        if (is_object($seed)) {
-            // setDefaults already called
-            return $seed;
-        }
-
-        $arguments = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
-        $injection = array_diff_key($seed, $arguments); // with string keys
-        $object = array_shift($arguments); // first numeric key argument is object
-
-        if (!is_object($object)) {
-            if (!is_string($object)) {
-                throw (new Exception('Class name was not specified by the seed'))
-                    ->addMoreInfo('seed', $seed);
-            }
-
-            $object = new $object(...$arguments);
-        }
-
-        if ($injection) {
-            if (isset($object->_DIContainerTrait)) {
-                $object->setDefaults($injection);
-            } else {
-                throw (new Exception('factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait'))
-                    ->addMoreInfo('object', $object)
-                    ->addMoreInfo('seed', $seed)
-                    ->addMoreInfo('injection', $injection);
-            }
-        }
-
-        return $object;
+        return Factory::factory($seed, $defaults);
     }
 }

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -6,9 +6,13 @@ namespace atk4\core;
 
 /**
  * Trait StaticAddToTrait.
+ *
+ * Intended to be always used with DIContainerTrait trait.
  */
 trait StaticAddToTrait
 {
+    // use DIContainerTrait; // uncomment once PHP7.2 support is dropped
+
     /**
      * Check this property to see if trait is present in the object.
      *
@@ -16,70 +20,18 @@ trait StaticAddToTrait
      */
     public $_staticAddToTrait = true;
 
-    /** @var FactoryTrait */
-    private static $_defaultFactory;
-
-    /**
-     * Return the argument and check if it is instance of current class. Typehinting-friendly.
-     *
-     * Best way to annotate object type if it not defined as function parameter or strong typing can not be used.
-     *
-     * @return static
-     */
-    public static function checkInstanceOf(object $object)// :static supported by PHP8+
+    private static function _addTo_add(object $parent, object $object, array $addArgs, bool $skipAdd = false): void
     {
-        if (!($object instanceof static)) {
-            throw (new Exception('Seed class name is not a subtype of the current class'))
-                ->addMoreInfo('seed_class', get_class($object))
-                ->addMoreInfo('current_class', static::class);
+        if (!$skipAdd) {
+            $parent->add($object, ...$addArgs);
         }
-
-        return $object;
     }
 
     /**
-     * @return FactoryTrait
-     */
-    private static function _getDefaultFactory()
-    {
-        if (self::$_defaultFactory === null) {
-            self::$_defaultFactory = new class() {
-                use FactoryTrait;
-            };
-        }
-
-        return self::$_defaultFactory;
-    }
-
-    /**
-     * Create new object and check if it is instance of current class. Typehinting-friendly.
+     * Initialize and add new object into parent. The new object is asserted to be an instance of current class.
      *
-     * Best way to create object if it should not be immediatelly added to a parent (otherwise use addTo()).
-     *
-     * @param array|string $seed
-     *
-     * @return static
-     */
-    public static function fromSeed($seed = [])// :static supported by PHP8+
-    {
-        return static::addTo(self::_getDefaultFactory(), $seed, [], true);
-    }
-
-    /**
-     * Same as ::fromSeed(), but the first element of seed specifies a class name instead of static::class.
-     *
-     * @param array|string $seed The first element specifies a class name, other element are seed
-     *
-     * @return static
-     */
-    public static function fromSeedWithCl($seed = [])// :static supported by PHP8+
-    {
-        return static::addToWithCl(self::_getDefaultFactory(), $seed, [], true);
-    }
-
-    /**
-     * A better way to initialize and add new object into parent - more typehinting-friendly.
-     * The new object is checked if it is instance of current class.
+     * The best, typehinting-friendly, way to create an object if it should be immediately
+     * added to a parent (otherwise use fromSeed() method).
      *
      * $crud = CRUD::addTo($app, ['displayFields' => ['name']]);
      *   is equivalent to
@@ -90,102 +42,53 @@ trait StaticAddToTrait
      *
      * @return static
      */
-    public static function addTo(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)// :static supported by PHP8+
+    public static function addTo(object $parent, $seed = [], array $addArgs = [], bool $skipAdd = false)// :static supported by PHP8+
     {
-        if (is_object($seed)) {
-            $object = $seed;
-        } else {
-            if (!is_array($seed)) {
-                if (!is_scalar($seed)) { // allow single element seed but prevent bad usage
-                    throw (new Exception('Seed must be an array or a scalar'))
-                        ->addMoreInfo('seed_type', gettype($seed));
-                }
-
-                $seed = [$seed];
+        if (!is_object($seed) && !is_array($seed)) {
+            if (!is_scalar($seed)) { // allow single element seed but prevent bad usage
+                throw (new Exception('Seed must be an array, a scalar or an object'))
+                    ->addMoreInfo('seed_type', gettype($seed));
             }
 
-            if (isset($parent->_factoryTrait)) {
-                $object = $parent->factory(static::class, $seed);
-            } else {
-                $object = new static(...$seed);
-            }
+            $seed = [$seed];
         }
 
-        return static::_addTo_add($parent, $object, false, $add_args, $skip_add);
-    }
+        $object = static::fromSeed(static::class, $seed);
 
-    /**
-     * @return static
-     */
-    private static function _addTo_add(object $parent, object $object, bool $unsafe, array $add_args, bool $skip_add = false)
-    {
-        // check if object is instance of this class
-        if (!$unsafe) {
-            static::checkInstanceOf($object);
-        }
-
-        // add to parent
-        if (!$skip_add) {
-            $parent->add($object, ...$add_args);
-        }
+        static::_addTo_add($parent, $object, $addArgs, $skipAdd);
 
         return $object;
     }
 
     /**
-     * Same as ::addTo(), but the first element of seed specifies a class name instead of static::class.
+     * Same as addTo(), but the first element of seed specifies a class name instead of static::class.
      *
-     * @param array|string $seed The first element specifies a class name, other element are seed
+     * @param array|string|object $seed the first element specifies a class name, other elements are seed
      *
      * @return static
      */
-    public static function addToWithCl(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)// :static supported by PHP8+
+    public static function addToWithCl(object $parent, $seed = [], array $addArgs = [], bool $skipAdd = false)// :static supported by PHP8+
     {
-        return static::_addToWithCl($parent, $seed, false, $add_args, $skip_add);
+        $object = static::fromSeed($seed);
+
+        static::_addTo_add($parent, $object, $addArgs, $skipAdd);
+
+        return $object;
     }
 
     /**
-     * Same as ::addToWithCl(), but the new object is not checked if it is instance of this class.
+     * Same as addToWithCl(), but the new object is not asserted to be an instance of this class.
      *
-     * @param array|string $seed The first element specifies a class name, other element are seed
+     * @param array|string|object $seed the first element specifies a class name, other elements are seed
      *
      * @return static
      */
-    public static function addToWithClUnsafe(object $parent, $seed = [], array $add_args = [], bool $skip_add = false)// :self is too strict with unsafe behaviour
+    public static function addToWithClUnsafe(object $parent, $seed = [], array $addArgs = [], bool $skipAdd = false)// :self is too strict with unsafe behaviour
     {
-        return static::_addToWithCl($parent, $seed, true, $add_args, $skip_add);
-    }
+        $object = static::fromSeedUnsafe($seed);
 
-    /**
-     * @return static
-     */
-    private static function _addToWithCl(object $parent, $seed, bool $unsafe, array $add_args, bool $skip_add = false)
-    {
-        if (is_object($seed)) {
-            $object = $seed;
-        } else {
-            if (!is_array($seed)) {
-                if (!is_scalar($seed)) { // allow single element seed but prevent bad usage
-                    throw (new Exception('Seed must be an array or a scalar'))
-                        ->addMoreInfo('seed_type', gettype($seed));
-                }
+        static::_addTo_add($parent, $object, $addArgs, $skipAdd);
 
-                $seed = [$seed];
-            }
-
-            if (!isset($seed[0])) {
-                throw new Exception('Class name in seed is not defined');
-            }
-
-            if (isset($parent->_factoryTrait)) {
-                $object = $parent->factory($seed);
-            } else {
-                $cl = $seed[0];
-                unset($seed[0]);
-                $object = new $cl(...$seed);
-            }
-        }
-
-        return static::_addTo_add($parent, $object, $unsafe, $add_args, $skip_add);
+        return $object;
     }
 }

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -14,6 +14,16 @@ use atk4\core\FactoryTrait;
  */
 class DIContainerTraitTest extends AtkPhpunit\TestCase
 {
+    public function testFromSeed()
+    {
+        $this->assertSame(StdSAT::class, get_class(StdSAT::fromSeed([StdSAT::class])));
+        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeed([StdSAT2::class])));
+        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeed(StdSAT2::class)));
+
+        $this->expectException(Exception::class);
+        StdSAT2::fromSeed([StdSAT::class]);
+    }
+
     /**
      * Ignore numeric property names (array keys).
      *

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -137,16 +137,18 @@ class ExceptionTest extends AtkPhpunit\TestCase
 
     public function testExceptionFallback(): void
     {
-        $m = new ExceptionTestThrowError('test');
-        $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getHTML());
-        $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getHTMLText());
-        $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getColorfulText());
+        $m = new ExceptionTestThrowError('test', 2);
+        $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
+            . ExceptionTestThrowError::class . '(2): test !!';
+        $this->assertSame($expectedFallbackText, $m->getHTML());
+        $this->assertSame($expectedFallbackText, $m->getHTMLText());
+        $this->assertSame($expectedFallbackText, $m->getColorfulText());
         $this->assertSame(
             json_encode(
                 [
                     'success' => false,
-                    'code' => 0,
-                    'message' => 'Error during JSON renderer : test',
+                    'code' => 2,
+                    'message' => 'Error during JSON renderer: test',
                     'title' => ExceptionTestThrowError::class,
                     'class' => ExceptionTestThrowError::class,
                     'params' => [],

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -14,6 +14,7 @@ use atk4\core\TrackableTrait;
 // @codingStandardsIgnoreStart
 class StdSAT extends \StdClass
 {
+    use DIContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
 }
 
@@ -30,6 +31,7 @@ class ContainerFactoryMockSAT
 class TrackableMockSAT
 {
     use TrackableTrait;
+    use DIContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
 }
 class DIMockSAT
@@ -70,11 +72,6 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $m = new ContainerMock();
         $this->assertTrue(isset($m->_containerTrait));
 
-        // create object using default factory
-        $this->assertSame(StdSAT::class, get_class(StdSAT::fromSeed()));
-        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeedWithCl(StdSAT2::class)));
-        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeedWithCl([StdSAT2::class])));
-
         // add to return object
         $tr = StdSAT::addTo($m);
         $this->assertNotNull($tr);
@@ -93,19 +90,19 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $tr = StdSAT::addTo($m, $tr);
     }
 
-    public function testCheckInstanceOf()
+    public function testAssertInstanceOf()
     {
         // object is of the same class
-        StdSAT::checkInstanceOf(new StdSAT());
+        StdSAT::assertInstanceOf(new StdSAT());
         $o = new StdSAT();
-        $this->assertSame($o, StdSAT::checkInstanceOf($o));
+        $this->assertSame($o, StdSAT::assertInstanceOf($o));
 
         // object is a subtype
-        StdSAT::checkInstanceOf(new StdSAT2());
+        StdSAT::assertInstanceOf(new StdSAT2());
 
         // object is not a subtype
         $this->expectException(\atk4\core\Exception::class);
-        StdSAT2::checkInstanceOf(new StdSAT());
+        StdSAT2::assertInstanceOf(new StdSAT());
     }
 
     public function testWithClassName()
@@ -125,13 +122,13 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $tr = StdSAT::addToWithCl($m, StdSAT2::class);
         $this->assertSame(StdSAT2::class, get_class($tr));
 
-        // not the same or extended class - unsafe disabled
-        $this->expectException(\atk4\core\Exception::class);
-        $tr = StdSAT::addToWithCl($m, \stdClass::class);
-
         // not the same or extended class - unsafe enabled
         $tr = StdSAT::addToWithClUnsafe($m, \stdClass::class);
         $this->assertSame(\stdClass::class, get_class($tr));
+
+        // not the same or extended class - unsafe disabled
+        $this->expectException(\atk4\core\Exception::class);
+        $tr = StdSAT::addToWithCl($m, \stdClass::class);
     }
 
     public function testUniqueNames()


### PR DESCRIPTION
no BC break

merge after: https://github.com/atk4/ui/pull/1251 (one line fix needed for ui/Template because of php7.2 limitation of traits)

By using single point factory we can offer extreme magic - user can inject own Factory and he can return any implementation he wants for any object (based on stacktrace even different) thru the whole project.

For these reasons you should never use direct instantiation:
```
new Class($arg1, $args2, ...)
```
in Atk code but always create new instance thru `\atk4\core\Factory` like:
```
Factory::factory([Class::class, $arg1, $rg2, ...])
```

FactoryTrait was quite a bad design pattern - there is currently no need to remove it, as it can be deprecated only for now without any negative side effect.