### PR TITLE
Display exception location as another stack trace call

### DIFF
--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -84,7 +84,7 @@ TEXT;
         $in_atk = true;
         $escape_frame = false;
         $short_trace = $this->getStackTrace(true);
-        $is_shortened = end($short_trace) && key($short_trace) !== 0;
+        $is_shortened = end($short_trace) && key($short_trace) !== 0 && key($short_trace) !== 'self';
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -101,9 +101,12 @@ TEXT;
 
             $tokens['{FUNCTION_COLOR}'] = $escape_frame ? "\e[0;31m" : "\e[0;33m";
             $tokens['{FUNCTION}'] = $call['function'];
-            $tokens['{FUNCTION_ARGS}'] = '()';
 
-            if ($escape_frame) {
+            if ($index === 'self') {
+                $tokens['{FUNCTION_ARGS}'] = '';
+            } elseif (!$escape_frame) {
+                $tokens['{FUNCTION_ARGS}'] = '()';
+            } else {
                 $escape_frame = false;
                 $args = [];
                 foreach ($call['args'] as $arg) {

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -142,14 +142,14 @@ class HTML extends RendererAbstract
             }
 
             $tokens = [];
-            $tokens['{INDEX}'] = $index + 1;
+            $tokens['{INDEX}'] = $index === 'self' ? '' : $index + 1;
             $tokens['{FILE_LINE}'] = $call['file_rel'] !== '' ? $call['file_rel'] . ':' . $call['line'] : '';
             $tokens['{OBJECT}'] = $call['object'] !== false ? $call['object_formatted'] : '-';
             $tokens['{CLASS}'] = $call['class'] !== false ? $call['class'] . '::' : '';
             $tokens['{CSS_CLASS}'] = $escape_frame ? 'negative' : '';
 
             $tokens['{FUNCTION}'] = $call['function'];
-            $tokens['{FUNCTION_ARGS}'] = '()';
+            $tokens['{FUNCTION_ARGS}'] = $index === 'self' ? '' : '()';
 
             if ($escape_frame) {
                 $escape_frame = false;

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -132,7 +132,7 @@ class HTML extends RendererAbstract
         $in_atk = true;
         $escape_frame = false;
         $short_trace = $this->getStackTrace(true);
-        $is_shortened = end($short_trace) && key($short_trace) !== 0;
+        $is_shortened = end($short_trace) && key($short_trace) !== 0 && key($short_trace) !== 'self';
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -108,9 +108,12 @@ HTML;
 
             $tokens['{FUNCTION_COLOR}'] = $escape_frame ? 'pink' : 'gray';
             $tokens['{FUNCTION}'] = $call['function'];
-            $tokens['{FUNCTION_ARGS}'] = '()';
 
-            if ($escape_frame) {
+            if ($index === 'self') {
+                $tokens['{FUNCTION_ARGS}'] = '';
+            } elseif (!$escape_frame) {
+                $tokens['{FUNCTION_ARGS}'] = '()';
+            } else {
                 $escape_frame = false;
 
                 $args = [];

--- a/src/ExceptionRenderer/HTMLText.php
+++ b/src/ExceptionRenderer/HTMLText.php
@@ -91,7 +91,7 @@ HTML;
         $in_atk = true;
         $escape_frame = false;
         $short_trace = $this->getStackTrace(true);
-        $is_shortened = end($short_trace) && key($short_trace) !== 0;
+        $is_shortened = end($short_trace) && key($short_trace) !== 0 && key($short_trace) !== 'self';
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -190,6 +190,6 @@ abstract class RendererAbstract
             array_shift($vendorRootArr);
         }
 
-        return (count($vendorRootArr) > 0 ? str_repeat('../', count($vendorRootArr)) : './') . implode('/', $filePathArr);
+        return (count($vendorRootArr) > 0 ? str_repeat('../', count($vendorRootArr)) : '') . implode('/', $filePathArr);
     }
 }

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -130,12 +130,7 @@ abstract class RendererAbstract
         };
 
         $trace = $custTraceFunc($this->exception);
-
-        if ($shorten && $this->parent_exception !== null) {
-            $parent_trace = $custTraceFunc($this->parent_exception);
-        } else {
-            $parent_trace = [];
-        }
+        $parent_trace = $shorten && $this->parent_exception !== null ? $custTraceFunc($this->parent_exception) : [];
 
         $both_atk = $this->exception instanceof Exception && $this->parent_exception instanceof Exception;
         $c = min(count($trace), count($parent_trace));

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -126,7 +126,7 @@ abstract class RendererAbstract
                 ? $ex->getMyTrace()
                 : $ex->getTrace();
 
-            return array_combine(range(count($trace) - 1, 0, -1), $trace);
+            return count($trace) > 0 ? array_combine(range(count($trace) - 1, 0, -1), $trace) : [];
         };
 
         $trace = $custTraceFunc($this->exception);

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -157,9 +157,9 @@ abstract class RendererAbstract
 
         // display location as another stack trace call
         $trace = ['self' => [
-                'line' => $this->exception->getLine(),
-                'file' => $this->exception->getFile(),
-            ]] + $trace;
+            'line' => $this->exception->getLine(),
+            'file' => $this->exception->getFile(),
+        ]] + $trace;
 
         return $trace;
     }


### PR DESCRIPTION
fixes #213

Example of this PR in action:
```
try {
  (function() {
        throw new \atk4\ui\Exception('No database connection');
  })();
} catch (\Exception $e) {
    throw new \Exception('x', 0, $e);
}
```

![image](https://user-images.githubusercontent.com/2228672/83818783-797b1180-a6c8-11ea-9701-51167556cd2f.png)
