### PR TITLE
Exception constructor no longer accepts array of solutions/params

### DIFF
--- a/docs/exception.rst
+++ b/docs/exception.rst
@@ -21,7 +21,7 @@ the constructor or using addMoreInfo()
     This uses same format as a regular PHP exception, but error parameter will
     now support array::
 
-        throw new Exception(['Value is too big', 'max'=>$max]);
+        throw (new Exception('Value is too big'))->addMoreInfo('max', $max);
 
 The other option is to supply error is:
 

--- a/docs/exception.rst
+++ b/docs/exception.rst
@@ -21,7 +21,8 @@ the constructor or using addMoreInfo()
     This uses same format as a regular PHP exception, but error parameter will
     now support array::
 
-        throw (new Exception('Value is too big'))->addMoreInfo('max', $max);
+        throw (new Exception('Value is too big'))
+            ->addMoreInfo('max', $max);
 
 The other option is to supply error is:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -247,7 +247,7 @@ The same can be said about web output:
 Agile Core implements :php:class:`Exception` class which offers many benefits
 compared to standard PHP exceptions:
 
- - Pass additional information `new Exception(['Bad argument', 'arg'=>$arg'])`
+ - Pass additional information `(new Exception('Bad argument'))->addMoreInfo('arg', $arg')`
  - Visualize in ASCII or HTML
  - Better means of localization
 

--- a/examples/test4.php
+++ b/examples/test4.php
@@ -11,10 +11,8 @@ function faulty($test)
     if ($test > 5) {
         $exception_prev = new \Exception('Previous Exception');
 
-        $exception = new Exception([
-            'Test value is too high',
-            'test' => $test,
-        ], 200, $exception_prev);
+        $exception = (new Exception('Test value is too high', 200, $exception_prev))
+            ->addMoreInfo('test', $test);
         $exception->addSolution('Suggested solution test');
 
         throw $exception;

--- a/examples/test5.php
+++ b/examples/test5.php
@@ -9,10 +9,8 @@ function loopToCreateStack($test)
     if ($test > 5) {
         $exc_prev = new \Exception('Previous Exception');
 
-        $exc = new atk4\core\Exception([
-            'Test value is too high',
-            'test' => $test,
-        ], 200, $exc_prev);
+        $exc = (new atk4\core\Exception('Test value is too high', 200, $exc_prev))
+            ->addMoreInfo('test', $test);
 
         throw $exc->addSolution('Suggested solution test');
     }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -35,28 +35,22 @@ trait CollectionTrait
     public function _addIntoCollection(string $name, object $object, string $collection)
     {
         if (!$collection || !isset($this->{$collection}) || !is_array($this->{$collection})) {
-            throw new Exception([
-                'Name of collection is specified incorrectly',
-                'parent' => $this,
-                'collection' => $collection,
-            ]);
+            throw (new Exception('Name of collection is specified incorrectly'))
+                ->addMoreInfo('parent', $this)
+                ->addMoreInfo('collection', $collection);
         }
 
         if (!$name) {
-            throw new Exception([
-                'Object must be given a name when adding into this',
-                'child' => $object,
-                'parent' => $this,
-                'collection' => $collection,
-            ]);
+            throw (new Exception('Object must be given a name when adding into this'))
+                ->addMoreInfo('child', $object)
+                ->addMoreInfo('parent', $this)
+                ->addMoreInfo('collection', $collection);
         }
 
         if ($this->_hasInCollection($name, $collection) !== false) {
-            throw new Exception([
-                'Object with requested name already exist in collection',
-                'name' => $name,
-                'collection' => $collection,
-            ]);
+            throw (new Exception('Object with requested name already exist in collection'))
+                ->addMoreInfo('name', $name)
+                ->addMoreInfo('collection', $collection);
         }
         $this->{$collection}[$name] = $object;
 
@@ -79,10 +73,8 @@ trait CollectionTrait
                 $object->init();
             }
             if (!$object->_initialized) {
-                throw new Exception([
-                    'You should call parent::init() when you override initializer',
-                    'object' => $object,
-                ]);
+                throw (new Exception('You should call parent::init() when you override initializer'))
+                    ->addMoreInfo('object', $object);
             }
         }
 
@@ -97,12 +89,10 @@ trait CollectionTrait
     public function _removeFromCollection(string $name, string $collection): void
     {
         if ($this->_hasInCollection($name, $collection) === false) {
-            throw new Exception([
-                'Element by this name is NOT in the collection, cannot remove',
-                'parent' => $this,
-                'collection' => $collection,
-                'name' => $name,
-            ]);
+            throw (new Exception('Element by this name is NOT in the collection, cannot remove'))
+                ->addMoreInfo('parent', $this)
+                ->addMoreInfo('collection', $collection)
+                ->addMoreInfo('name', $name);
         }
         unset($this->{$collection}[$name]);
     }
@@ -142,12 +132,10 @@ trait CollectionTrait
     {
         $object = $this->_hasInCollection($name, $collection);
         if ($object === false) {
-            throw new Exception([
-                'Element is not found in collection',
-                'collection' => $collection,
-                'name' => $name,
-                'this' => $this,
-            ]);
+            throw (new Exception('Element is not found in collection'))
+                ->addMoreInfo('collection', $collection)
+                ->addMoreInfo('name', $name)
+                ->addMoreInfo('this', $this);
         }
 
         return $object;

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -54,7 +54,9 @@ trait ConfigTrait
         $configs = [];
         foreach ($files as $file) {
             if (!is_readable($file)) {
-                throw new Exception(['Can not read config file', 'file' => $file, 'format' => $format]);
+                throw (new Exception('Can not read config file'))
+                    ->addMoreInfo('file', $file)
+                    ->addMoreInfo('format', $format);
             }
 
             $tempConfig = [];
@@ -73,19 +75,15 @@ trait ConfigTrait
 
                     break;
                 default:
-                    throw new Exception([
-                        'Unknown Format. Allowed formats: php, json, yml.',
-                        'file' => $file,
-                        'format' => $format,
-                    ]);
+                    throw (new Exception('Unknown Format. Allowed formats: php, json, yml.'))
+                        ->addMoreInfo('file', $file)
+                        ->addMoreInfo('format', $format);
             }
 
             if (!is_array($tempConfig)) {
-                throw new Exception([
-                    'File was read but has a bad format',
-                    'file' => $file,
-                    'format' => $format,
-                ]);
+                throw (new Exception('File was read but has a bad format'))
+                    ->addMoreInfo('file', $file)
+                    ->addMoreInfo('format', $format);
             }
 
             $configs[] = $tempConfig;

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -76,10 +76,8 @@ trait ContainerTrait
                 $obj->init();
             }
             if (!$obj->_initialized) {
-                throw new Exception([
-                    'You should call parent::init() when you override initializer',
-                    'obj' => $obj,
-                ]);
+                throw (new Exception('You should call parent::init() when you override initializer'))
+                    ->addMoreInfo('obj', $obj);
             }
         }
 
@@ -98,7 +96,8 @@ trait ContainerTrait
     protected function _add_Container($element, $args = []): object
     {
         if (!is_object($element)) {
-            throw new Exception(['Only objects may be added into containers', 'arg' => $element]);
+            throw (new Exception('Only objects may be added into containers'))
+                ->addMoreInfo('arg', $element);
         }
 
         // Carry on reference to application if we have appScopeTraits set
@@ -116,7 +115,8 @@ trait ContainerTrait
             // passed as string
             $args = [$args];
         } elseif (!is_array($args) && $args !== null) {
-            throw new Exception(['Second argument must be array', 'arg2' => $args]);
+            throw (new Exception('Second argument must be array'))
+                ->addMoreInfo('arg2', $args);
         } elseif (isset($args['desired_name'])) {
             // passed as ['desired_name'=>'foo'];
             $args[0] = $this->_unique_element($args['desired_name']);
@@ -136,13 +136,11 @@ trait ContainerTrait
 
         // Maybe element already exists
         if (isset($this->elements[$args[0]])) {
-            throw new Exception([
-                'Element with requested name already exists',
-                'element' => $element,
-                'name' => $args[0],
-                'this' => $this,
-                'arg2' => $args,
-            ]);
+            throw (new Exception('Element with requested name already exists'))
+                ->addMoreInfo('element', $element)
+                ->addMoreInfo('name', $args[0])
+                ->addMoreInfo('this', $this)
+                ->addMoreInfo('arg2', $args);
         }
 
         $element->owner = $this;
@@ -177,11 +175,9 @@ trait ContainerTrait
         }
 
         if (!isset($this->elements[$short_name])) {
-            throw new Exception([
-                'Could not remove child from parent. Instead of destroy() try using removeField / removeColumn / ..',
-                'parent' => $this,
-                'name' => $short_name,
-            ]);
+            throw (new Exception('Could not remove child from parent. Instead of destroy() try using removeField / removeColumn / ..'))
+                ->addMoreInfo('parent', $this)
+                ->addMoreInfo('name', $short_name);
         }
 
         unset($this->elements[$short_name]);
@@ -235,11 +231,9 @@ trait ContainerTrait
     public function getElement(string $short_name): object
     {
         if (!isset($this->elements[$short_name])) {
-            throw new Exception([
-                'Child element not found',
-                'parent' => $this,
-                'element' => $short_name,
-            ]);
+            throw (new Exception('Child element not found'))
+                ->addMoreInfo('parent', $this)
+                ->addMoreInfo('element', $short_name);
         }
 
         return $this->elements[$short_name];

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -83,11 +83,9 @@ trait DIContainerTrait
             return $this;
         }
 
-        throw new Exception([
-            'Property for specified object is not defined',
-            'object' => $this,
-            'property' => $key,
-            'value' => $value,
-        ]);
+        throw (new Exception('Property for specified object is not defined'))
+            ->addMoreInfo('object', $this)
+            ->addMoreInfo('property', $key)
+            ->addMoreInfo('value', $value);
     }
 }

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -30,12 +30,10 @@ trait DynamicMethodTrait
             return reset($ret);
         }
 
-        throw new Exception([
-            'Method ' . $name . ' is not defined for this object',
-            'class' => static::class,
-            'method' => $name,
-            'args' => $args,
-        ]);
+        throw (new Exception('Method ' . $name . ' is not defined for this object'))
+            ->addMoreInfo('class', static::class)
+            ->addMoreInfo('method', $name)
+            ->addMoreInfo('args', $args);
     }
 
     private function buildMethodHookName(string $name, bool $isGlobal): string
@@ -76,11 +74,12 @@ trait DynamicMethodTrait
     {
         // HookTrait is mandatory
         if (!isset($this->_hookTrait)) {
-            throw new Exception(['Object must use hookTrait for Dynamic Methods to work']);
+            throw new Exception('Object must use hookTrait for Dynamic Methods to work');
         }
 
         if ($this->hasMethod($name)) {
-            throw new Exception(['Registering method twice', 'name' => $name]);
+            throw (new Exception('Registering method twice'))
+                ->addMoreInfo('name', $name);
         }
 
         $this->onHook($this->buildMethodHookName($name, false), $fx);
@@ -138,11 +137,12 @@ trait DynamicMethodTrait
     {
         // AppScopeTrait and HookTrait for app are mandatory
         if (!isset($this->_appScopeTrait) || !isset($this->app->_hookTrait)) {
-            throw new Exception(['You need AppScopeTrait and HookTrait traits, see docs']);
+            throw new Exception('You need AppScopeTrait and HookTrait traits, see docs');
         }
 
         if ($this->hasGlobalMethod($name)) {
-            throw new Exception(['Registering global method twice', 'name' => $name]);
+            throw (new Exception('Registering global method twice'))
+                ->addMoreInfo('name', $name);
         }
         $this->app->onHook($this->buildMethodHookName($name, true), $fx);
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -37,28 +37,8 @@ class Exception extends \Exception
     /** @var ITranslatorAdapter */
     private $adapter;
 
-    /**
-     * Constructor.
-     *
-     * @param string|array $message
-     */
-    public function __construct(
-        $message = '',
-        int $code = 0,
-        \Throwable $previous = null
-    ) {
-        if (is_array($message)) {
-            // message contain additional parameters
-            $this->params = $message;
-            $message = array_shift($this->params);
-            if (isset($this->params['solutions'])) {
-                foreach ((array) $this->params['solutions'] as $solution) {
-                    $this->addSolution($solution);
-                }
-                unset($this->params['solutions']);
-            }
-        }
-
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    {
         parent::__construct($message, $code, $previous);
 
         // save trace but skip constructors of this exception

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -42,11 +42,9 @@ trait FactoryTrait
                     if (isset($seed->_DIContainerTrait)) {
                         $seed->setDefaults($injection, true);
                     } else {
-                        throw new Exception([
-                            'factory() requested to passively inject some properties into existing object that does not use \atk4\core\DIContainerTrait',
-                            'object' => $seed,
-                            'injection' => $injection,
-                        ]);
+                        throw (new Exception('factory() requested to passively inject some properties into existing object that does not use \atk4\core\DIContainerTrait'))
+                            ->addMoreInfo('object', $seed)
+                            ->addMoreInfo('injection', $injection);
                     }
                 }
             }
@@ -63,11 +61,9 @@ trait FactoryTrait
                     if (isset($seed2->_DIContainerTrait)) {
                         $seed2->setDefaults($injection);
                     } else {
-                        throw new Exception([
-                            'factory() requested to inject some properties into existing object that does not use \atk4\core\DIContainerTrait',
-                            'object' => $seed2,
-                            'injection' => $seed,
-                        ]);
+                        throw (new Exception('factory() requested to inject some properties into existing object that does not use \atk4\core\DIContainerTrait'))
+                            ->addMoreInfo('object', $seed2)
+                            ->addMoreInfo('injection', $seed);
                     }
                 }
             }
@@ -128,7 +124,7 @@ trait FactoryTrait
     public function factory($seed, $defaults = [], string $prefix = null): object
     {
         if ($prefix !== null) { // remove in 2021-june
-            throw new Exception(['Factory does no longer support relative names, pass full class name without prefix']);
+            throw new Exception('Factory does no longer support relative names, pass full class name without prefix');
         }
 
         if ($defaults === null) {
@@ -161,10 +157,8 @@ trait FactoryTrait
 
         if (!is_object($object)) {
             if (!is_string($object)) {
-                throw new Exception([
-                    'Class name was not specified by the seed',
-                    'seed' => $seed,
-                ]);
+                throw (new Exception('Class name was not specified by the seed'))
+                    ->addMoreInfo('seed', $seed);
             }
 
             $object = new $object(...$arguments);
@@ -174,12 +168,10 @@ trait FactoryTrait
             if (isset($object->_DIContainerTrait)) {
                 $object->setDefaults($injection);
             } else {
-                throw new Exception([
-                    'factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait',
-                    'object' => $object,
-                    'seed' => $seed,
-                    'injection' => $injection,
-                ]);
+                throw (new Exception('factory() could not inject properties into new object. It does not use \atk4\core\DIContainerTrait'))
+                    ->addMoreInfo('object', $object)
+                    ->addMoreInfo('seed', $seed)
+                    ->addMoreInfo('injection', $injection);
             }
         }
 

--- a/src/InitializerTrait.php
+++ b/src/InitializerTrait.php
@@ -30,7 +30,8 @@ trait InitializerTrait
     public function init(): void
     {
         if ($this->_initialized) {
-            throw new Exception(['Attempting to initialize twice', 'this' => $this]);
+            throw (new Exception('Attempting to initialize twice'))
+                ->addMoreInfo('this', $this);
         }
         $this->_initialized = true;
     }

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -30,13 +30,13 @@ trait SessionTrait
         // all methods use this method to start session, so we better check
         // NameTrait existence here in one place.
         if (!isset($this->_nameTrait)) {
-            throw new Exception(['Object should have NameTrait applied to use session']);
+            throw new Exception('Object should have NameTrait applied to use session');
         }
 
         switch (session_status()) {
             case PHP_SESSION_DISABLED:
                 // @codeCoverageIgnoreStart - impossible to test
-                throw new Exception(['Sessions are disabled on server']);
+                throw new Exception('Sessions are disabled on server');
                 // @codeCoverageIgnoreEnd
                 break;
             case PHP_SESSION_NONE:

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -45,20 +45,20 @@ class Translator
     public function setDefaults(array $properties, bool $passively = false): void
     {
         if (null !== ($properties['instance'] ?? null)) {
-            throw new Exception(['$instance cannot be replaced']);
+            throw new Exception('$instance cannot be replaced');
         }
 
         $adapter = $properties['adapter'] ?? null;
         if ($adapter !== null && !($adapter instanceof ITranslatorAdapter)) {
-            throw new Exception(['$adapter must be an instance of ITranslatorAdapter']);
+            throw new Exception('$adapter must be an instance of ITranslatorAdapter');
         }
 
         if (!is_string($properties['default_domain'] ?? '')) {
-            throw new Exception(['default_domain must be string']);
+            throw new Exception('default_domain must be string');
         }
 
         if (!is_string($properties['default_locale'] ?? '')) {
-            throw new Exception(['default_locale must be string']);
+            throw new Exception('default_locale must be string');
         }
 
         $this->_setDefaults($properties);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -18,7 +18,9 @@ class ExceptionTest extends AtkPhpunit\TestCase
      */
     public function testColorfulText(): void
     {
-        $m = new Exception(['TestIt', 'a1' => 111, 'a2' => 222]);
+        $m = (new Exception('TestIt'))
+            ->addMoreInfo('a1', 111)
+            ->addMoreInfo('a2', 222);
 
         // params
         $this->assertSame(['a1' => 111, 'a2' => 222], $m->getParams());
@@ -97,7 +99,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
 
     public function testSolution(): void
     {
-        $m = new Exception(['Exception with solution']);
+        $m = new Exception('Exception with solution');
         $m->addSolution('One Solution');
 
         $ret = $m->getColorfulText();

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -118,21 +118,15 @@ class ExceptionTest extends AtkPhpunit\TestCase
 
     public function testSolution2(): void
     {
-        $m = new Exception([
-            'Exception with solution',
-            'solutions' => '1st Solution',
-        ]);
+        $m = (new Exception('Exception with solution'))
+            ->addSolution('1st Solution');
 
         $ret = $m->getColorfulText();
         $this->assertMatchesRegularExpression('/1st Solution/', $ret);
 
-        $m = new Exception([
-            'Exception with solution',
-            'solutions' => [
-                '1st Solution',
-                '2nd Solution',
-            ],
-        ]);
+        $m = (new Exception('Exception with solution'))
+            ->addSolution('1st Solution')
+            ->addSolution('2nd Solution');
 
         $ret = $m->getColorfulText();
         $this->assertMatchesRegularExpression('/1st Solution/', $ret);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -137,7 +137,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
 
     public function testExceptionFallback(): void
     {
-        $m = new ExceptionTestThrowError(['test']);
+        $m = new ExceptionTestThrowError('test');
         $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getHTML());
         $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getHTMLText());
         $this->assertSame(ExceptionTestThrowError::class . ' [0] Error: test', $m->getColorfulText());

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -261,7 +261,7 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m->result = 0;
 
         $m->onHook('inc', function ($obj) {
-            throw new \atk4\core\Exception(['stuff went wrong']);
+            throw new \atk4\core\Exception('stuff went wrong');
         });
         $ret = $m->hook('inc');
     }


### PR DESCRIPTION
merge after: https://github.com/atk4/ui/pull/1242

Remove bad design of this core component. Wrong usage will throw now `\TypeError`.

Previously there were also a lot of non-sense usages like:
```
throw new Exception(['Model is not associated with any database']);
```
which only underlays how much confusion the original design was introducing.

Regex for potential places to update: `new [^\n]*?exception\(\[`

To update your code refactor all usages of Exception constructor usages with array like:
```
throw new Exception([
    'Object with requested name already exist in collection',
    'name' => $name,
    'collection' => $collection,
]);
```
to:
```
throw (new Exception('Object with requested name already exist in collection'))
    ->addMoreInfo('name', $name)
    ->addMoreInfo('collection', $collection);
```

There was also a special `solutions` keys, see PR source, used nowhere except one test in core repo - regex `new [^\n]*?exception\(\[(?:.|\n)+?'solutions'`.

you can also fix your code by script: https://github.com/mvorisek/atk4_ui_add_migrate/tree/fix_array_exception_constructor (but run CS fixer then and check manually)