### PR TITLE
Remove trait identification property

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,30 +16,13 @@ parameters:
         # fix unresolved \Atk4\Ui\App class
         - '~^(.+(?<!\w)Atk4\\Ui\\App.+|Call to an undefined method .+::(issetApp|getApp)\(\)\.)$~'
 
-        # for AppScopeTrait.php
-        - '~^Call to an undefined method .+::setApp\(\)\.$~'
-        - '~^Access to an undefined property .+::\$_appScopeTrait\.$~'
-        - '~^Access to an undefined property .+::\$_app\.$~'
-        # for ContainerTrait.php
-        - '~^Call to an undefined method .+::removeElement\(\)\.$~'
-        # for DiContainerTrait.php
-        - '~^Call to an undefined method .+::setDefaults\(\)\.$~'
         # for HookTrait.php
         - '~^Call to an undefined method .+::onHook\(\)\.$~'
         - '~^Call to an undefined method .+::removeHook\(\)\.$~'
         - '~^Call to an undefined method .+::hookHasCallbacks\(\)\.$~'
         - '~^Call to an undefined method .+::hook\(\)\.$~'
-        # for InitializerTrait.php
-        - '~^Call to an undefined method .+::invokeInit\(\)\.$~'
-        - '~^Access to an undefined property .+::\$_initialized\.$~'
         # for NameTrait.php
         - '~^Access to an undefined property .+::\$name\.$~'
-        # for TrackableTrait.php
-        - '~^Call to an undefined method .+::issetOwner\(\)\.$~'
-        - '~^Call to an undefined method .+::setOwner\(\)\.$~'
-        - '~^Call to an undefined method .+::unsetOwner\(\)\.$~'
-        - '~^Call to an undefined method .+::getDesiredName\(\)\.$~'
-        - '~^Access to an undefined property .+::\$short_name\.$~'
 
         - '~^Cannot access property \$(foo|def) on array\|object\.$~'
         - '~^Call to an undefined method Atk4\\Core\\Tests\\(DynamicMethodMock|DynamicMethodWithoutHookMock|GlobalMethodObjectMock)::\w+\(\)\.$~'

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -15,13 +15,6 @@ namespace Atk4\Core;
 trait AppScopeTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_appScopeTrait = true;
-
-    /**
      * @internal to be removed in Jan 2021, keep until then to prevent wrong assignments
      */
     private $app;

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -47,20 +47,20 @@ trait CollectionTrait
         $this->{$collection}[$name] = $item;
 
         // Carry on reference to application if we have appScopeTraits set
-        if (isset($this->_appScopeTrait) && isset($item->_appScopeTrait)) {
+        if (TraitUtil::hasAppScopeTrait($this) && TraitUtil::hasAppScopeTrait($item)) {
             $item->setApp($this->getApp());
         }
 
         // Calculate long "name" but only if both are trackables
-        if (isset($item->_trackableTrait)) {
+        if (TraitUtil::hasTrackableTrait($item)) {
             $item->short_name = $name;
             $item->setOwner($this);
-            if (isset($this->_trackableTrait)) {
+            if (TraitUtil::hasTrackableTrait($this)) {
                 $item->name = $this->_shorten_ml($this->name . '-' . $collection . '_' . $name);
             }
         }
 
-        if (isset($item->_initializerTrait)) {
+        if (TraitUtil::hasInitializerTrait($item)) {
             if (!$item->_initialized) {
                 $item->invokeInit();
             }
@@ -99,7 +99,7 @@ trait CollectionTrait
     {
         $this->{$collectionName} = array_map(function ($item) {
             $item = clone $item;
-            if (isset($item->_trackableTrait) && $item->issetOwner()) {
+            if (TraitUtil::hasTrackableTrait($item) && $item->issetOwner()) {
                 $item->unsetOwner()->setOwner($this);
             }
 
@@ -154,8 +154,6 @@ trait CollectionTrait
 
                     public function shorten(?object $app, string $desired): string
                     {
-                        $this->_appScopeTrait = $app !== null;
-
                         try {
                             $this->setApp($app);
 
@@ -171,6 +169,6 @@ trait CollectionTrait
             return $factory->collectionTraitHelper;
         }, null, Factory::class)();
 
-        return $collectionTraitHelper->shorten($this->_appScopeTrait ? $this->getApp() : null, $desired);
+        return $collectionTraitHelper->shorten(TraitUtil::hasAppScopeTrait($this) ? $this->getApp() : null, $desired);
     }
 }

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -17,13 +17,6 @@ namespace Atk4\Core;
 trait ConfigTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_configTrait = true;
-
-    /**
      * This property stores config values. Use getConfig() method to access its values.
      *
      * @var array

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -59,7 +59,7 @@ trait ContainerTrait
         }
         $obj = $this->_add_Container($obj, $args);
 
-        if (isset($obj->_initializerTrait)) {
+        if (TraitUtil::hasInitializerTrait($obj)) {
             if (!$obj->_initialized) {
                 $obj->invokeInit();
             }
@@ -81,12 +81,12 @@ trait ContainerTrait
     protected function _add_Container(object $element, $args = []): object
     {
         // Carry on reference to application if we have appScopeTraits set
-        if (isset($this->_appScopeTrait) && isset($element->_appScopeTrait)) {
+        if (TraitUtil::hasAppScopeTrait($this) && TraitUtil::hasAppScopeTrait($element)) {
             $element->setApp($this->getApp());
         }
 
         // If element is not trackable, then we don't need to do anything with it
-        if (!isset($element->_trackableTrait)) {
+        if (!TraitUtil::hasTrackableTrait($element)) {
             return $element;
         }
 
@@ -125,7 +125,7 @@ trait ContainerTrait
 
         $element->setOwner($this);
         $element->short_name = $args[0];
-        if (isset($this->_nameTrait)) {
+        if (TraitUtil::hasNameTrait($this)) {
             $element->name = $this->_shorten($this->name . '_' . $element->short_name);
         }
         $this->elements[$element->short_name] = $element;
@@ -172,9 +172,11 @@ trait ContainerTrait
      */
     protected function _shorten(string $desired): string
     {
-        if (isset($this->_appScopeTrait)
+        if (
+            TraitUtil::hasAppScopeTrait($this)
             && isset($this->getApp()->max_name_length)
-            && mb_strlen($desired) > $this->getApp()->max_name_length) {
+            && mb_strlen($desired) > $this->getApp()->max_name_length
+        ) {
             $left = mb_strlen($desired) + 35 - $this->getApp()->max_name_length;
             $key = mb_substr($desired, 0, $left);
             $rest = mb_substr($desired, $left);

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -11,13 +11,6 @@ namespace Atk4\Core;
 trait ContainerTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_containerTrait = true;
-
-    /**
      * short_name => object hash of children objects. If the child is not
      * trackable, then object will be set to "true" (to avoid extra reference).
      *

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -8,13 +8,6 @@ use Psr\Log\LogLevel;
 
 trait DebugTrait
 {
-    /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_debugTrait = true;
-
     /** @var bool Is debug enabled? */
     public $debug = false;
 

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -42,7 +42,7 @@ trait DebugTrait
 
         // if debug is enabled, then log it
         if ($this->debug) {
-            if (!isset($this->_appScopeTrait) || !$this->issetApp() || !$this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
+            if (!TraitUtil::hasAppScopeTrait($this) || !$this->issetApp() || !$this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
                 $message = '[' . static::class . ']: ' . $message;
             }
             $this->log(LogLevel::DEBUG, $message, $context);
@@ -61,7 +61,7 @@ trait DebugTrait
      */
     public function log($level, $message, array $context = [])
     {
-        if (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
+        if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
             $this->getApp()->logger->log($level, $message, $context);
         } else {
             $this->_echo_stderr($message . "\n");
@@ -78,9 +78,9 @@ trait DebugTrait
      */
     public function userMessage(string $message, array $context = [])
     {
-        if (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \Atk4\Core\AppUserNotificationInterface) {
+        if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp() instanceof \Atk4\Core\AppUserNotificationInterface) {
             $this->getApp()->userNotification($message, $context);
-        } elseif (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \Psr\Log\LoggerInterface) {
+        } elseif (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp() instanceof \Psr\Log\LoggerInterface) {
             $this->getApp()->log('warning', 'Could not notify user about: ' . $message, $context);
         } else {
             $this->_echo_stderr("Could not notify user about: {$message}\n");

--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -33,13 +33,6 @@ namespace Atk4\Core;
 trait DiContainerTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_DiContainerTrait = true;
-
-    /**
      * Call from __construct() to initialize the properties allowing
      * developer to pass Dependency Injector Container.
      *

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -11,13 +11,6 @@ namespace Atk4\Core;
 trait DynamicMethodTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_dynamicMethodTrait = true;
-
-    /**
      * Magic method - tries to call dynamic method and throws exception if
      * this was not possible.
      *

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -44,11 +44,11 @@ trait DynamicMethodTrait
      */
     public function tryCall($name, $args)
     {
-        if (isset($this->_hookTrait) && $ret = $this->hook($this->buildMethodHookName($name, false), $args)) {
+        if (TraitUtil::hasHookTrait($this) && $ret = $this->hook($this->buildMethodHookName($name, false), $args)) {
             return $ret;
         }
 
-        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
+        if (TraitUtil::hasAppScopeTrait($this) && TraitUtil::hasHookTrait($this->getApp())) {
             array_unshift($args, $this);
             if ($ret = $this->getApp()->hook($this->buildMethodHookName($name, true), $args)) {
                 return $ret;
@@ -68,7 +68,7 @@ trait DynamicMethodTrait
     public function addMethod(string $name, \Closure $fx)
     {
         // HookTrait is mandatory
-        if (!isset($this->_hookTrait)) {
+        if (!TraitUtil::hasHookTrait($this)) {
             throw new Exception('Object must use hookTrait for Dynamic Methods to work');
         }
 
@@ -90,7 +90,7 @@ trait DynamicMethodTrait
     public function hasMethod(string $name): bool
     {
         return method_exists($this, $name)
-            || (isset($this->_hookTrait) && $this->hookHasCallbacks($this->buildMethodHookName($name, false)))
+            || (TraitUtil::hasHookTrait($this) && $this->hookHasCallbacks($this->buildMethodHookName($name, false)))
             || $this->hasGlobalMethod($name);
     }
 
@@ -101,7 +101,7 @@ trait DynamicMethodTrait
      */
     public function removeMethod(string $name)
     {
-        if (isset($this->_hookTrait)) {
+        if (TraitUtil::hasHookTrait($this)) {
             $this->removeHook($this->buildMethodHookName($name, false));
         }
 
@@ -131,7 +131,7 @@ trait DynamicMethodTrait
     public function addGlobalMethod(string $name, \Closure $fx): void
     {
         // AppScopeTrait and HookTrait for app are mandatory
-        if (!isset($this->_appScopeTrait) || !isset($this->getApp()->_hookTrait)) {
+        if (!TraitUtil::hasAppScopeTrait($this) || !TraitUtil::hasHookTrait($this->getApp())) {
             throw new Exception('You need AppScopeTrait and HookTrait traits, see docs');
         }
 
@@ -150,8 +150,9 @@ trait DynamicMethodTrait
      */
     public function hasGlobalMethod(string $name): bool
     {
-        return isset($this->_appScopeTrait)
-            && isset($this->getApp()->_hookTrait)
+        return
+            TraitUtil::hasAppScopeTrait($this)
+            && TraitUtil::hasHookTrait($this->getApp())
             && $this->getApp()->hookHasCallbacks($this->buildMethodHookName($name, true));
     }
 
@@ -162,7 +163,7 @@ trait DynamicMethodTrait
      */
     public function removeGlobalMethod(string $name): void
     {
-        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
+        if (TraitUtil::hasAppScopeTrait($this) && TraitUtil::hasHookTrait($this->getApp())) {
             $this->getApp()->removeHook($this->buildMethodHookName($name, true));
         }
     }

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -108,9 +108,7 @@ abstract class RendererAbstract
         if ($val instanceof \Closure) {
             return 'closure';
         } elseif (is_object($val)) {
-            $objProps = get_object_vars($val);
-
-            return get_class($val) . (isset($objProps['_trackableTrait']) ? ' (' . $objProps['name'] . ')' : '');
+            return get_class($val) . (\Atk4\Core\TraitUtil::hasTrackableTrait($val) ? ' (' . get_object_vars($val)['name'] . ')' : '');
         } elseif (is_resource($val)) {
             return 'resource';
         } elseif (is_scalar($val) || $val === null) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -142,7 +142,7 @@ class Factory
         }
 
         if (count($injection) > 0) {
-            if (!isset($obj->_DiContainerTrait)) {
+            if (!TraitUtil::hasDiContainerTrait($obj)) {
                 throw (new Exception('Property injection is possible only to objects that use \Atk4\Core\DiContainerTrait trait'))
                     ->addMoreInfo('object', $obj)
                     ->addMoreInfo('injection', $injection);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -160,6 +160,9 @@ class Factory
         return $obj;
     }
 
+    /**
+     * @param class-string $className
+     */
     protected function _newObject(string $className, array $ctorArgs): object
     {
         return new $className(...$ctorArgs);

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -7,10 +7,11 @@ namespace Atk4\Core;
 /** @deprecated will be removed in v2.5 */
 trait FactoryTrait
 {
-    /** @deprecated will be removed in v2.5 */
-    private $_factoryTrait = true;
-
-    /** @deprecated will be removed in v2.5 */
+    /**
+     * See \Atk4\Core\Factory::mergeSeeds().
+     *
+     * @deprecated will be removed in 2021-jun
+     */
     public function mergeSeeds(...$seeds)
     {
         'trigger_error'('Method mergeSeeds is deprecated. Use Factory::mergeSeeds instead', E_USER_DEPRECATED);

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -7,13 +7,6 @@ namespace Atk4\Core;
 trait HookTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_hookTrait = true;
-
-    /**
      * Contains information about configured hooks (callbacks).
      *
      * @var array

--- a/src/InitializerTrait.php
+++ b/src/InitializerTrait.php
@@ -11,13 +11,6 @@ namespace Atk4\Core;
 trait InitializerTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_initializerTrait = true;
-
-    /**
      * To make sure you have called parent::init() properly.
      *
      * @var bool

--- a/src/NameTrait.php
+++ b/src/NameTrait.php
@@ -10,13 +10,6 @@ namespace Atk4\Core;
 trait NameTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_nameTrait = true;
-
-    /**
      * Unique object name.
      *
      * @var string

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -7,13 +7,6 @@ namespace Atk4\Core;
 trait SessionTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_sessionTrait = true;
-
-    /**
      * Session container key.
      *
      * @var string

--- a/src/SessionTrait.php
+++ b/src/SessionTrait.php
@@ -22,7 +22,7 @@ trait SessionTrait
     {
         // all methods use this method to start session, so we better check
         // NameTrait existence here in one place.
-        if (!isset($this->_nameTrait)) {
+        if (!TraitUtil::hasNameTrait($this)) {
             throw new Exception('Object should have NameTrait applied to use session');
         }
 

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -13,13 +13,6 @@ trait StaticAddToTrait
 {
     // use DiContainerTrait; // uncomment once PHP7.2 support is dropped
 
-    /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_staticAddToTrait = true;
-
     private static function _addTo_add(object $parent, object $object, array $addArgs, bool $skipAdd = false): void
     {
         if (!$skipAdd) {

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -119,12 +119,12 @@ trait TrackableTrait
      */
     public function destroy(): void
     {
-        if ($this->_owner !== null && isset($this->_owner->_containerTrait)) {
+        if ($this->_owner !== null && TraitUtil::hasContainerTrait($this->_owner)) {
             $this->_owner->removeElement($this->short_name);
 
             // GC remove reference to app is AppScope in use
-            if (isset($this->_appScopeTrait) && $this->issetApp()) {
-                $this->_app = null;
+            if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp()) {
+                $this->_app = null; // @phpstan-ignore-line
             }
 
             // GC : remove reference to owner

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -14,13 +14,6 @@ trait TrackableTrait
     use NameTrait;
 
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_trackableTrait = true;
-
-    /**
      * @internal to be removed in Jan 2021, keep until then to prevent wrong assignments
      *
      * @var object

--- a/src/TraitUtil.php
+++ b/src/TraitUtil.php
@@ -8,7 +8,7 @@ namespace Atk4\Core;
 
 final class TraitUtil
 {
-    /** @var bool[className][traitName] */
+    /** @var array<class-string, array<string, bool>> */
     private static $_hasTraitMap = [];
 
     private function __construct()
@@ -17,7 +17,7 @@ final class TraitUtil
     }
 
     /**
-     * @param object|string $class
+     * @param object|class-string $class
      */
     public static function hasTrait($class, string $traitName): bool
     {

--- a/src/TraitUtil.php
+++ b/src/TraitUtil.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core;
+
+final class TraitUtil
+{
+    /** @var bool[className][traitName] */
+    private static $_hasTraitMap = [];
+
+    private function __construct()
+    {
+        // zeroton
+    }
+
+    /**
+     * @param object|string $class
+     */
+    public static function hasTrait($class, string $traitName): bool
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        // prevent mass use for other than internal use then we can decide
+        //if we want to keep support this or replace with pure interfaces
+        if (!str_starts_with($traitName, 'Atk4\Core\\')) {
+            throw new Exception('Core::hasTrait is not indended for use with other than \Atk4\Core\* traits.');
+        }
+
+        if (!isset(self::$_hasTraitMap[$class][$traitName])) {
+            $getUsesFunc = function (string $trait) use (&$getUsesFunc): array {
+                $uses = class_uses($trait);
+                foreach ($uses as $use) {
+                    $uses += $getUsesFunc($use);
+                }
+
+                return $uses;
+            };
+
+            $uses = [];
+            foreach (array_reverse(class_parents($class) ?: []) + [-1 => $class] as $class) {
+                $uses += $getUsesFunc($class);
+            }
+            $uses = array_unique($uses);
+
+            self::$_hasTraitMap[$class][$traitName] = in_array($traitName, $uses, true);
+        }
+
+        return self::$_hasTraitMap[$class][$traitName];
+    }
+}

--- a/src/TraitUtil.php
+++ b/src/TraitUtil.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atk4\Core;
 
+// !!! INTENDED TO BE REMOVED LATER - ONLY FOR TRAIT IDENTIFICATION PROPERTIES TO INTERFACES MIGRATION !!!
+
 final class TraitUtil
 {
     /** @var bool[className][traitName] */
@@ -49,5 +51,65 @@ final class TraitUtil
         }
 
         return self::$_hasTraitMap[$class][$traitName];
+    }
+
+    /*
+     * ConfigTrait - not used
+     * DebugTrait - not used
+     * DynamicMethodTrait - not used
+     * FactoryTrait - not used
+     * StaticAddToTrait - not used
+     * TranslatableTrait - not used
+     *
+     * QuickExceptionTrait - QuickException will be removed, not used outside QuickException class
+     */
+
+    public static function hasAppScopeTrait(object $class): bool
+    {
+        return self::hasTrait($class, AppScopeTrait::class);
+    }
+
+    public static function hasContainerTrait(object $class): bool
+    {
+        return self::hasTrait($class, ContainerTrait::class);
+    }
+
+    /**
+     * Used in Factory and in ui/View only.
+     */
+    public static function hasDiContainerTrait(object $class): bool
+    {
+        return self::hasTrait($class, DiContainerTrait::class);
+    }
+
+    /**
+     * Used in DynamicMethodTrait only.
+     */
+    public static function hasHookTrait(object $class): bool
+    {
+        return self::hasTrait($class, HookTrait::class);
+    }
+
+    public static function hasInitializerTrait(object $class): bool
+    {
+        return self::hasTrait($class, InitializerTrait::class);
+    }
+
+    public static function hasNameTrait(object $class): bool
+    {
+        return self::hasTrait($class, NameTrait::class);
+    }
+
+    /**
+     * Used in ui\TableColumn\FilterModel\Generic only.
+     */
+    public static function hasSessionTrait(object $class): bool
+    {
+        return self::hasTrait($class, SessionTrait::class);
+    }
+
+    public static function hasTrackableTrait(object $class): bool
+    {
+        return self::hasTrait($class, TrackableTrait::class);
     }
 }

--- a/src/TranslatableTrait.php
+++ b/src/TranslatableTrait.php
@@ -23,7 +23,7 @@ trait TranslatableTrait
      */
     public function _($message, array $parameters = [], string $domain = null, string $locale = null): string
     {
-        if (isset($this->_appScopeTrait) && $this->issetApp() && method_exists($this->getApp(), '_')) {
+        if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && method_exists($this->getApp(), '_')) {
             return $this->getApp()->_($message, $parameters, $domain, $locale);
         }
 

--- a/src/TranslatableTrait.php
+++ b/src/TranslatableTrait.php
@@ -12,13 +12,6 @@ use Atk4\Core\Translator\Translator;
 trait TranslatableTrait
 {
     /**
-     * Check this property to see if trait is present in the object.
-     *
-     * @var bool
-     */
-    public $_translatableTrait = true;
-
-    /**
      * Translates the given message.
      *
      * @param string      $message    The message to be translated

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -18,7 +18,6 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
     public function testBasic()
     {
         $m = new ContainerMock();
-        $this->assertTrue(isset($m->_containerTrait));
 
         // add to return object
         $tr = $m->add($tr2 = new \StdClass());

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -66,7 +66,6 @@ class StaticAddToTest extends AtkPhpunit\TestCase
     public function testBasic()
     {
         $m = new ContainerMock();
-        $this->assertTrue(isset($m->_containerTrait));
 
         // add to return object
         $tr = StdSat::addTo($m);
@@ -100,7 +99,6 @@ class StaticAddToTest extends AtkPhpunit\TestCase
     public function testWithClassName()
     {
         $m = new ContainerMock();
-        $this->assertTrue(isset($m->_containerTrait));
 
         // the same class
         $tr = StdSat::addToWithCl($m, [StdSat::class]);

--- a/tests/TraitUtilTest.php
+++ b/tests/TraitUtilTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Core\tests;
 
 use Atk4\Core\AtkPhpunit;
+use Atk4\Core\HookTrait;
 use Atk4\Core\NameTrait;
 use Atk4\Core\TraitUtil;
 
@@ -29,6 +30,10 @@ class TraitUtilTest extends AtkPhpunit\TestCase
         }, NameTrait::class));
         $this->assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestC {
         }, NameTrait::class));
+
+        $this->assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, HookTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, HookTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, HookTrait::class));
     }
 }
 
@@ -36,9 +41,15 @@ class TraitUtilTestA
 {
 }
 
+trait TraitUtilTestTrait
+{
+    use HookTrait;
+}
+
 class TraitUtilTestB extends TraitUtilTestA
 {
     use NameTrait;
+    use TraitUtilTestTrait;
 }
 
 class TraitUtilTestC extends TraitUtilTestB

--- a/tests/TraitUtilTest.php
+++ b/tests/TraitUtilTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core\tests;
+
+use Atk4\Core\AtkPhpunit;
+use Atk4\Core\NameTrait;
+use Atk4\Core\TraitUtil;
+
+/**
+ * @coversDefaultClass \Atk4\Core\TraitUtil
+ */
+class TraitUtilTest extends AtkPhpunit\TestCase
+{
+    public function testHasTrait()
+    {
+        $this->assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, NameTrait::class));
+
+        $this->assertFalse(TraitUtil::hasTrait(new TraitUtilTestA(), NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(new TraitUtilTestB(), NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(new TraitUtilTestC(), NameTrait::class));
+
+        $this->assertFalse(TraitUtil::hasTrait(new class() extends TraitUtilTestA {
+        }, NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestB {
+        }, NameTrait::class));
+        $this->assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestC {
+        }, NameTrait::class));
+    }
+}
+
+class TraitUtilTestA
+{
+}
+
+class TraitUtilTestB extends TraitUtilTestA
+{
+    use NameTrait;
+}
+
+class TraitUtilTestC extends TraitUtilTestB
+{
+}


### PR DESCRIPTION
finish after: https://github.com/atk4/core/pull/221

then remove dummy properties like:
![image](https://user-images.githubusercontent.com/2228672/83941240-2ef1b600-a7ea-11ea-89d6-4b4141cfd2b2.png)

and refactor in other repos

Trait identification properties declared in `core`:
```
_appScopeTrait|_configTrait|_containerTrait|_debugTrait|_DIContainerTrait|_dynamicMethodTrait|_factoryTrait|_hookTrait|_initializerTrait|_nameTrait|_quickExceptionTrait|_sessionTrait|_staticAddToTrait|_trackableTrait|_translatableTrait
```
-> they are used solely in `core` repo except 3 usages in `ui` repo