### PR TITLE
Fix too big segment div in html exception param render

### DIFF
--- a/src/ExceptionRenderer/Html.php
+++ b/src/ExceptionRenderer/Html.php
@@ -44,7 +44,7 @@ class Html extends RendererAbstract
 
         $text = '
             <div class="ui stacked segments">
-                <div class="ui inverted red segment fitted">Exception Parameters</div>
+                <div class="ui inverted red segment" style="padding-top: 5px; padding-bottom: 5px;">Exception Parameters</div>
                 {PARAMS}
             </div>
         ';
@@ -52,7 +52,7 @@ class Html extends RendererAbstract
         $tokens = [
             '{PARAMS}' => '',
         ];
-        $text_inner = '<div class="ui segment"><b>{KEY}:</b> {VAL}</div>';
+        $text_inner = '<div class="ui segment" style="padding-top: 5px; padding-bottom: 5px;"><b>{KEY}:</b> {VAL}</div>';
         foreach ($this->exception->getParams() as $key => $val) {
             $key = str_pad((string) $key, 19, ' ', STR_PAD_LEFT);
             $key = htmlentities($key);


### PR DESCRIPTION
fixed style seems bad to me, should be probably solved like the table below with `very compact` style and both table headers should be reduced

important for huge nested exceptions

Example of current renderer:
![image](https://user-images.githubusercontent.com/2228672/83970242-f4b11300-a8d4-11ea-9b67-89821a5f1405.png)


all header/row heights and indentations from left/right should be unified.

help wanted