### PR TITLE
Better fix for vendor path discovery

### DIFF
--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -171,9 +171,13 @@ abstract class RendererAbstract
 
     protected function getVendorDirectory(): string
     {
-        $loaderFile = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
+        $loaderFile = realpath((new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName());
+        $coreDir = realpath(dirname(__DIR__, 2) . '/');
+        if (strpos($loaderFile, $coreDir . DIRECTORY_SEPARATOR) === 0) { // this repo is main project
+            return realpath(dirname($loaderFile, 2) . '/');
+        }
 
-        return realpath(dirname($loaderFile, 2) . '/');
+        return realpath(dirname(__DIR__, 4) . '/');
     }
 
     protected function makeRelativePath(string $path): string

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -173,7 +173,7 @@ abstract class RendererAbstract
     {
         $loaderFile = realpath((new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName());
         $coreDir = realpath(dirname(__DIR__, 2) . '/');
-        if (strpos($loaderFile, $coreDir . DIRECTORY_SEPARATOR) === 0) { // this repo is main project
+        if (strpos($loaderFile, $coreDir . \DIRECTORY_SEPARATOR) === 0) { // this repo is main project
             return realpath(dirname($loaderFile, 2) . '/');
         }
 


### PR DESCRIPTION
fix for usecases:
- `\atk4\core` is main composer project
- `\atk4\core` is dependency
- `\Composer\Autoload\ClassLoader` is loaded from other composer (special case but supported by Composer)