### PR TITLE
Remove totally unmaintained @throws phpdocs

### DIFF
--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -25,8 +25,6 @@ trait CollectionTrait
      * }
      *
      * @param string $collection property name
-     *
-     * @throws Exception
      */
     public function _addIntoCollection(string $name, object $item, string $collection): object
     {
@@ -80,8 +78,6 @@ trait CollectionTrait
      * Removes element from specified collection.
      *
      * @param string $collection property name
-     *
-     * @throws Exception
      */
     public function _removeFromCollection(string $name, string $collection): void
     {
@@ -135,8 +131,6 @@ trait CollectionTrait
 
     /**
      * @param string $collection property name
-     *
-     * @throws Exception
      */
     public function _getFromCollection(string $name, string $collection): object
     {

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -41,8 +41,6 @@ trait ConfigTrait
      * @param string|array $files  One or more filenames
      * @param string       $format Optional format for config files
      *
-     * @throws Exception
-     *
      * @return $this
      */
     public function readConfig($files = ['config.php'], string $format = 'php')

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -53,8 +53,6 @@ trait ContainerTrait
      *
      * @param mixed        $obj
      * @param array|string $args
-     *
-     * @throws Exception
      */
     public function add($obj, $args = []): object
     {
@@ -87,8 +85,6 @@ trait ContainerTrait
      *
      * @param object       $element
      * @param array|string $args
-     *
-     * @throws Exception
      */
     protected function _add_Container($element, $args = []): object
     {
@@ -162,8 +158,6 @@ trait ContainerTrait
      * Remove child element if it exists.
      *
      * @param string|TrackableTrait $short_name short name of the element
-     *
-     * @throws Exception
      */
     public function removeElement($short_name)
     {
@@ -222,8 +216,6 @@ trait ContainerTrait
      * Exception if not found.
      *
      * @param string $short_name Short name of the child element
-     *
-     * @throws Exception
      */
     public function getElement(string $short_name): object
     {

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -118,8 +118,6 @@ trait HookTrait
      * @param string $spot Hook identifier
      * @param array  $args Additional arguments to callables
      *
-     * @throws Exception
-     *
      * @return mixed Array of responses indexed by hook indexes or value specified to breakHook
      */
     public function hook(string $spot, array $args = [], HookBreaker &$brokenBy = null)

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -104,8 +104,6 @@ class Generic implements ITranslatorAdapter
 
     /**
      * Load definitions from file.
-     *
-     * @throws \atk4\core\Exception
      */
     public function addDefinitionFromFile(string $file, string $locale, string $domain, string $format): void
     {

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -38,9 +38,7 @@ class Translator
     }
 
     /**
-     * Set property like Depedency injection.
-     *
-     * @throws Exception
+     * Set property like dependency injection.
      */
     public function setDefaults(array $properties, bool $passively = false): void
     {
@@ -92,8 +90,6 @@ class Translator
      * No serialize.
      *
      * @codeCoverageIgnore
-     *
-     * @throws Exception
      */
     public function __wakeup(): void
     {

--- a/tests/CollectionMock.php
+++ b/tests/CollectionMock.php
@@ -14,8 +14,6 @@ class CollectionMock
     protected $fields = [];
 
     /**
-     * @throws core\Exception
-     *
      * @return mixed|object
      */
     public function addField($name, $seed = null)
@@ -33,8 +31,6 @@ class CollectionMock
     }
 
     /**
-     * @throws core\Exception
-     *
      * @return mixed
      */
     public function getField($name)

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -14,8 +14,6 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
 {
     /**
      * Test constructor.
-     *
-     * @throws core\Exception
      */
     public function testBasic()
     {
@@ -41,8 +39,6 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
 
     /**
      * Test Trackable and AppScope.
-     *
-     * @throws core\Exception
      */
     public function testBasicWithApp()
     {


### PR DESCRIPTION
In top notch code they may help, but in Atk there are defined very randomly, better to remove all @throws phpdocs except some very specific/meaningful.

Example before this commit - what is the difference? Confusion only.
![image](https://user-images.githubusercontent.com/2228672/84317174-a5850f80-ab6c-11ea-8dbe-0e354115eeab.png)
