### PR TITLE
HasXxx() methods now return bool only

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -245,8 +245,8 @@ Methods
 
 .. php:method:: hasElement($short_name)
 
-    Given a short-name of the element, will return the object. If object with
-    such short_name does not exist, will return false instead.
+    Given a short-name of the element, will return true if object with
+    such short_name exists, otherwise false.
 
 .. php:method:: _unique_element
 

--- a/docs/container.rst
+++ b/docs/container.rst
@@ -83,9 +83,9 @@ Example::
             return $this->_addIntoCollection($name, $field, 'fields');
         }
 
-        public function tryGetField($name)
+        public function hasField($name): bool
         {
-            return $this->_tryGetFromCollection($name, 'fields');
+            return $this->_hasInCollection($name, 'fields');
         }
 
         public function getField($name)

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -41,7 +41,7 @@ trait CollectionTrait
                 ->addMoreInfo('name', $name);
         }
 
-        if ($this->_tryGetFromCollection($name, $collection) !== null) {
+        if ($this->_hasInCollection($name, $collection)) {
             throw (new Exception('Element with the same name already exist in the collection'))
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);
@@ -85,7 +85,7 @@ trait CollectionTrait
      */
     public function _removeFromCollection(string $name, string $collection): void
     {
-        if ($this->_tryGetFromCollection($name, $collection) === null) {
+        if (!$this->_hasInCollection($name, $collection)) {
             throw (new Exception('Element is NOT in the collection'))
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);
@@ -112,25 +112,15 @@ trait CollectionTrait
     }
 
     /**
-     * Returns object from collection or null if object is not found.
+     * Returns true if and only if collection exists and object with given name is presented in it.
      *
      * @param string $collection property name
      */
-    public function _tryGetFromCollection(string $name, string $collection): ?object
+    public function _hasInCollection(string $name, string $collection): bool
     {
         $data = $this->{$collection};
 
-        return $data[$name] ?? null;
-    }
-
-    /**
-     * Use _tryGetFromCollection() instead and note it return null instead of false on non-match.
-     *
-     * @deprecated will be removed in 2021-jun
-     */
-    public function _hasInCollection(string $name, string $collection)
-    {
-        return $this->_tryGetFromCollection($name, $collection) ?? false;
+        return isset($data[$name]);
     }
 
     /**
@@ -140,14 +130,13 @@ trait CollectionTrait
      */
     public function _getFromCollection(string $name, string $collection): object
     {
-        $item = $this->_tryGetFromCollection($name, $collection);
-        if ($item === null) {
+        if ($this->_hasInCollection($name, $collection)) {
             throw (new Exception('Element is NOT in the collection'))
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);
         }
 
-        return $item;
+        return $this->{$collection}[$name];
     }
 
     /**

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -130,7 +130,7 @@ trait CollectionTrait
      */
     public function _getFromCollection(string $name, string $collection): object
     {
-        if ($this->_hasInCollection($name, $collection)) {
+        if (!$this->_hasInCollection($name, $collection)) {
             throw (new Exception('Element is NOT in the collection'))
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -237,16 +237,12 @@ trait ContainerTrait
     }
 
     /**
-     * Find child element. Use in condition.
-     *
      * @param string $short_name Short name of the child element
      *
      * @return object|bool
      */
-    public function hasElement($short_name)
+    public function hasElement($short_name): bool
     {
-        return isset($this->elements[$short_name])
-            ? $this->elements[$short_name]
-            : false;
+        return isset($this->elements[$short_name]);
     }
 }

--- a/tests/CollectionMock.php
+++ b/tests/CollectionMock.php
@@ -27,9 +27,9 @@ class CollectionMock
         return $this->_addIntoCollection($name, $field, 'fields');
     }
 
-    public function tryGetField($name)
+    public function hasField($name): bool
     {
-        return $this->_tryGetFromCollection($name, 'fields');
+        return $this->_hasInCollection($name, 'fields');
     }
 
     /**

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -23,15 +23,15 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
             $m = new CollectionMock();
             $m->addField('name');
 
-            $this->assertNotNull($m->tryGetField('name'));
+            $this->assertTrue($m->hasField('name'));
 
             $m->addField('surname', [CustomFieldMock::class]);
 
-            $this->assertSame(CustomFieldMock::class, get_class($m->tryGetField('surname')));
+            $this->assertSame(CustomFieldMock::class, get_class($m->getField('surname')));
             $this->assertTrue($m->getField('surname')->var);
 
             $m->removeField('name');
-            $this->assertNull($m->tryGetField('name'));
+            $this->assertFalse($m->hasField('name'));
         } catch (core\Exception $e) {
             echo $e->getColorfulText();
 
@@ -147,8 +147,8 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
             $m->addField('surname', [CustomFieldMock::class]);
 
             $c = clone $m;
-            $this->assertNotNull($c->tryGetField('name'));
-            $this->assertSame(CustomFieldMock::class, get_class($c->tryGetField('surname')));
+            $this->assertTrue($c->hasField('name'));
+            $this->assertSame(CustomFieldMock::class, get_class($c->getField('surname')));
             $this->assertTrue($c->getField('surname')->var);
         } catch (core\Exception $e) {
             echo $e->getColorfulText();

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -41,9 +41,9 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
         $m->add(new TrackableMock(), '123');
         $m->add(new TrackableMock(), 'false');
 
-        $this->assertTrue((bool) $m->hasElement('foo bar'));
-        $this->assertTrue((bool) $m->hasElement('123'));
-        $this->assertTrue((bool) $m->hasElement('false'));
+        $this->assertTrue($m->hasElement('foo bar'));
+        $this->assertTrue($m->hasElement('123'));
+        $this->assertTrue($m->hasElement('false'));
         $this->assertSame(5, $m->getElementCount());
 
         $m->getElement('foo bar')->destroy();
@@ -130,7 +130,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
         $m2 = $m->add(new class() extends TrackableMock {
             use core\DIContainerTrait;
         }, ['name' => 'foo']);
-        $this->assertTrue((bool) $m->hasElement('foo'));
+        $this->assertTrue($m->hasElement('foo'));
         $this->assertSame('foo', $m2->short_name);
     }
 
@@ -148,7 +148,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
         $m->add(new TrackableMock(), ['desired_name' => 'foo']);
         $m->add(new TrackableMock(), ['desired_name' => 'foo']);
 
-        $this->assertNotEmpty($m->hasElement('foo'));
+        $this->assertTrue($m->hasElement('foo'));
     }
 
     public function testExceptionShortName()

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -142,9 +142,9 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         TrackableMockSAT::addTo($m, [], ['123']);
         TrackableMockSAT::addTo($m, [], ['false']);
 
-        $this->assertTrue((bool) $m->hasElement('foo bar'));
-        $this->assertTrue((bool) $m->hasElement('123'));
-        $this->assertTrue((bool) $m->hasElement('false'));
+        $this->assertTrue($m->hasElement('foo bar'));
+        $this->assertTrue($m->hasElement('123'));
+        $this->assertTrue($m->hasElement('false'));
         $this->assertSame(5, $m->getElementCount());
 
         $m->getElement('foo bar')->destroy();


### PR DESCRIPTION
Cleaner approach to https://github.com/atk4/core/pull/233

I think it is much better fix to hasXxx methods - originally I was targetting to solve to not return `object|false` type, but the whole concept was not that good - I understand, that tryGetXxx might be handy in a few cases, but the argument can be stored in var, checked for existence, and the used with getXxx. In other (most) cases, this was used to check solely for existance which we continue to support without change.