### PR TITLE
Do not silence missing numeric property in setDefaults()

### DIFF
--- a/docs/di.rst
+++ b/docs/di.rst
@@ -63,7 +63,7 @@ How to use DIContainerTrait
 
 .. php:trait: DIContainerTrait
 
-.. php:method: setDefaults($array)
+.. php:method: setDefaults($properties, $passively = false)
 
 .. php:method: setMissingProperty($propertyName, $value)
 

--- a/docs/di.rst
+++ b/docs/di.rst
@@ -65,7 +65,7 @@ How to use DIContainerTrait
 
 .. php:method: setDefaults($array)
 
-.. php:method: setMissingProperty($key, $value)
+.. php:method: setMissingProperty($propertyName, $value)
 
 Calling this method will set object's properties. If any specified property
 is undefined then it will be skipped. Here is how you should use trait::

--- a/docs/di.rst
+++ b/docs/di.rst
@@ -63,9 +63,9 @@ How to use DIContainerTrait
 
 .. php:trait: DIContainerTrait
 
-.. php:method: setDefaults($array, $strict = false)
+.. php:method: setDefaults($array)
 
-.. php:method: setMissingProperty($array, $strict = false)
+.. php:method: setMissingProperty($key, $value)
 
 Calling this method will set object's properties. If any specified property
 is undefined then it will be skipped. Here is how you should use trait::
@@ -95,11 +95,11 @@ This is done by overriding setMissingProperty method::
             $this->setDefaults($defaults, true);
         }
 
-        function setMissingProperty($key, $value, $strict = false) {
+        function setMissingProperty($key, $value) {
             // do something with $key / $value
 
             // will either cause exception or will ignorance
-            $this->_setMissingProperty($key, $value, $strict);
+            $this->_setMissingProperty($key, $value);
         }
     }
 

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -43,7 +43,7 @@ trait DIContainerTrait
      * Call from __construct() to initialize the properties allowing
      * developer to pass Dependency Injector Container.
      *
-     * @param bool $passively If true, existing non-null argument values will be kept
+     * @param bool $passively If true, existing non-null values will be kept
      *
      * @return $this
      */
@@ -67,12 +67,8 @@ trait DIContainerTrait
     }
 
     /**
-     * Sets object property.
-     * Throws exception.
-     *
      * @param mixed $key
      * @param mixed $value
-     * @param bool  $strict
      *
      * @return $this
      */

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -50,7 +50,7 @@ trait DIContainerTrait
     public function setDefaults(array $properties, bool $passively = false)
     {
         foreach ($properties as $key => $val) {
-            if (!is_numeric($key) && property_exists($this, $key)) {
+            if (property_exists($this, $key)) {
                 if ($passively && $this->{$key} !== null) {
                     continue;
                 }
@@ -67,16 +67,13 @@ trait DIContainerTrait
     }
 
     /**
-     * @param mixed $key
      * @param mixed $value
-     *
-     * @return $this
      */
-    protected function setMissingProperty($key, $value)
+    protected function setMissingProperty(string $propertyName, $value): void
     {
         throw (new Exception('Property for specified object is not defined'))
             ->addMoreInfo('object', $this)
-            ->addMoreInfo('property', $key)
+            ->addMoreInfo('property', $propertyName)
             ->addMoreInfo('value', $value);
     }
 

--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -78,11 +78,6 @@ trait DIContainerTrait
      */
     protected function setMissingProperty($key, $value)
     {
-        // ignore numeric properties by default
-        if (is_numeric($key)) {
-            return $this;
-        }
-
         throw (new Exception('Property for specified object is not defined'))
             ->addMoreInfo('object', $this)
             ->addMoreInfo('property', $key)

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -88,7 +88,7 @@ TEXT;
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
-            if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
+            if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
             }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -82,12 +82,12 @@ TEXT;
 TEXT;
 
         $in_atk = true;
-        $escape_frame = false;
         $short_trace = $this->getStackTrace(true);
         $is_shortened = end($short_trace) && key($short_trace) !== 0 && key($short_trace) !== 'self';
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
+            $escape_frame = false;
             if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
@@ -104,16 +104,16 @@ TEXT;
 
             if ($index === 'self') {
                 $tokens['{FUNCTION_ARGS}'] = '';
-            } elseif (!$escape_frame) {
+            } elseif (count($call['args']) === 0) {
                 $tokens['{FUNCTION_ARGS}'] = '()';
             } else {
-                $escape_frame = false;
-                $args = [];
-                foreach ($call['args'] as $arg) {
-                    $args[] = static::toSafeString($arg);
+                if ($escape_frame) {
+                    $tokens['{FUNCTION_ARGS}'] = "\e[0;31m(" . PHP_EOL . str_repeat(' ', 40) . implode(',' . PHP_EOL . str_repeat(' ', 40), array_map(function ($arg) {
+                        return static::toSafeString($arg);
+                    }, $call['args'])) . ')';
+                } else {
+                    $tokens['{FUNCTION_ARGS}'] = '(...)';
                 }
-
-                $tokens['{FUNCTION_ARGS}'] = "\e[0;31m(" . PHP_EOL . str_repeat(' ', 40) . implode(',' . PHP_EOL . str_repeat(' ', 40), $args) . ')';
             }
 
             $this->output .= $this->replaceTokens($tokens, $text);

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -136,7 +136,7 @@ class HTML extends RendererAbstract
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
-            if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
+            if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
             }

--- a/src/ExceptionRenderer/HTML.php
+++ b/src/ExceptionRenderer/HTML.php
@@ -130,12 +130,12 @@ class HTML extends RendererAbstract
         ';
 
         $in_atk = true;
-        $escape_frame = false;
         $short_trace = $this->getStackTrace(true);
         $is_shortened = end($short_trace) && key($short_trace) !== 0 && key($short_trace) !== 'self';
         foreach ($short_trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
+            $escape_frame = false;
             if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
@@ -149,18 +149,18 @@ class HTML extends RendererAbstract
             $tokens['{CSS_CLASS}'] = $escape_frame ? 'negative' : '';
 
             $tokens['{FUNCTION}'] = $call['function'];
-            $tokens['{FUNCTION_ARGS}'] = $index === 'self' ? '' : '()';
 
-            if ($escape_frame) {
-                $escape_frame = false;
-
-                $args = [];
-                foreach ($call['args'] as $arg) {
-                    $args[] = static::toSafeString($arg);
-                }
-
-                if (!empty($args)) {
-                    $tokens['{FUNCTION_ARGS}'] = '(<br />' . implode(',' . '<br />', $args) . ')';
+            if ($index === 'self') {
+                $tokens['{FUNCTION_ARGS}'] = '';
+            } elseif (count($call['args']) === 0) {
+                $tokens['{FUNCTION_ARGS}'] = '()';
+            } else {
+                if ($escape_frame) {
+                    $tokens['{FUNCTION_ARGS}'] = '(<br />' . implode(',' . '<br />', array_map(function ($arg) {
+                        return static::toSafeString($arg);
+                    }, $call['args'])) . ')';
+                } else {
+                    $tokens['{FUNCTION_ARGS}'] = '(...)';
                 }
             }
 

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -78,25 +78,20 @@ HTML;
     protected function processStackTraceInternal(): void
     {
         $in_atk = true;
-        $escape_frame = false;
         $trace = $this->getStackTrace(false);
         foreach ($trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
+            $escape_frame = false;
             if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
             }
 
             if ($escape_frame) {
-                $escape_frame = false;
-
-                $args = [];
-                foreach ($call['args'] as $arg) {
-                    $args[] = static::toSafeString($arg);
-                }
-
-                $call['args'] = $args;
+                $call['args'] = array_map(function ($arg) {
+                    return static::toSafeString($arg);
+                }, $call['args']);
             }
 
             $this->json['stack'][] = $call;

--- a/src/ExceptionRenderer/JSON.php
+++ b/src/ExceptionRenderer/JSON.php
@@ -83,7 +83,7 @@ HTML;
         foreach ($trace as $index => $call) {
             $call = $this->parseStackTraceCall($call);
 
-            if ($in_atk && !preg_match('/atk4\/.*\/src\//', $call['file'])) {
+            if ($in_atk && !preg_match('~atk4[/\\\\][^/\\\\]+[/\\\\]src[/\\\\]~', $call['file'])) {
                 $escape_frame = true;
                 $in_atk = false;
             }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -101,7 +101,7 @@ class Factory
         return $res;
     }
 
-    protected function createNewObject(string $className, array $ctorArgs): object
+    protected function _newObject(string $className, array $ctorArgs): object
     {
         return new $className(...$ctorArgs);
     }
@@ -141,7 +141,7 @@ class Factory
                     ->addMoreInfo('seed', $seed);
             }
 
-            $object = $this->createNewObject($object, $arguments);
+            $object = $this->_newObject($object, $arguments);
         }
 
         if (count($injection) > 0) {

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -24,30 +24,20 @@ class DIContainerTraitTest extends AtkPhpunit\TestCase
         StdSAT2::fromSeed([StdSAT::class]);
     }
 
-    /**
-     * Ignore numeric property names (array keys).
-     *
-     * @doesNotPerformAssertions
-     */
-    public function testException1()
+    public function testNoPropExNumeric()
     {
+        $this->expectException(Exception::class);
         $m = new FactoryDIMock2();
         $m->setDefaults([5 => 'qwerty']);
     }
 
-    /**
-     * Do not allow non existant property names (array keys).
-     */
-    public function testException2()
+    public function testNoPropExStandard()
     {
         $this->expectException(Exception::class);
         $m = new FactoryDIMock2();
         $m->setDefaults(['not_exist' => 'qwerty']);
     }
 
-    /**
-     * Test properties.
-     */
     public function testProperties()
     {
         $m = new FactoryDIMock2();
@@ -60,9 +50,6 @@ class DIContainerTraitTest extends AtkPhpunit\TestCase
         $this->assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
     }
 
-    /**
-     * Test properties.
-     */
     public function testPropertiesPassively()
     {
         $m = new FactoryDIMock2();

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -26,7 +26,7 @@ class DIContainerTraitTest extends AtkPhpunit\TestCase
 
     public function testNoPropExNumeric()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(\Error::class);
         $m = new FactoryDIMock2();
         $m->setDefaults([5 => 'qwerty']);
     }


### PR DESCRIPTION
ui tests passing

must be merged at once with https://github.com/atk4/ui/pull/1274

`!is_numeric($key)` check is not needed as `property_exists($this, $key)` will fail due strict types (and `$key` will be int because numeric array keys are always `int`)