### PR TITLE
Drop PHP 7.2 support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', 'latest', '8.0']
+        php: ['7.3', 'latest', '8.0']
         type: ['Phpunit']
         include:
           - php: 'latest'

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.2.0",
+    "php": ">=7.3.0",
     "ext-json": "*",
     "psr/log": "~1.0",
     "symfony/polyfill-php73": "^1.15",


### PR DESCRIPTION
now the time has ripen

to support better trait, nowdoc, ...

then apply as patch for all other major repos and update code with new features as well as CS rules