### PR TITLE
Prevent item to be associated with two parents (prevent owner replace)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,6 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.1
+        threshold: 0.025
     patch: false
     changes: false

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -54,6 +54,9 @@ trait CollectionTrait
         // Calculate long "name" but only if both are trackables
         if (isset($item->_trackableTrait)) {
             $item->short_name = $name;
+            if ($item->owner !== null) {
+                throw new Exception('Element owner is already set');
+            }
             $item->owner = $this;
             if (isset($this->_trackableTrait)) {
                 $item->name = $this->_shorten_ml($this->name . '-' . $collection . '_' . $name);

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -83,16 +83,10 @@ trait ContainerTrait
      * Extension to add() method which will perform linking of
      * the object with the current class.
      *
-     * @param object       $element
      * @param array|string $args
      */
-    protected function _add_Container($element, $args = []): object
+    protected function _add_Container(object $element, $args = []): object
     {
-        if (!is_object($element)) {
-            throw (new Exception('Only objects may be added into containers'))
-                ->addMoreInfo('arg', $element);
-        }
-
         // Carry on reference to application if we have appScopeTraits set
         if (isset($this->_appScopeTrait) && isset($element->_appScopeTrait)) {
             $element->app = $this->app;
@@ -136,6 +130,9 @@ trait ContainerTrait
                 ->addMoreInfo('arg2', $args);
         }
 
+        if ($element->owner !== null) {
+            throw new Exception('Element owner is already set');
+        }
         $element->owner = $this;
         $element->short_name = $args[0];
         if (isset($this->_nameTrait)) {


### PR DESCRIPTION
fix https://github.com/atk4/core/issues/237

tests for dsql/data/ui seems to be passing as well without any change needed (for these reasons not marked as breaking)

example in action:
![image](https://user-images.githubusercontent.com/2228672/86057903-46763480-ba60-11ea-8534-55f0f3e6506b.png)

![image](https://user-images.githubusercontent.com/2228672/86057926-4f670600-ba60-11ea-8e4e-bddb2b7234db.png)
