### PR TITLE
Require seed to be always an array or object

### DIFF
--- a/src/DIContainerTrait.php
+++ b/src/DIContainerTrait.php
@@ -105,6 +105,8 @@ trait DIContainerTrait
                         ->addMoreInfo('seed_type', gettype($seed));
                 }
 
+                Factory::mergeSeeds($seed, []); // emit deprecated warning, remove in 2020-dec once string seed is no longer supported
+
                 $seed = [$seed];
             }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -23,7 +23,7 @@ class Factory
         return self::$_instance;
     }
 
-    private function _printDeprecatedWarningWithTrace(string $msg): void // remove once not used within this class
+    protected function printDeprecatedWarningWithTrace(string $msg): void // remove once not used within this class
     {
         static $traceRenderer = null;
         if ($traceRenderer === null) {
@@ -46,7 +46,7 @@ class Factory
         $trace = preg_replace_callback('~[^\n\[\]<>]+\.php~', function ($matches) use ($traceRenderer) {
             return $traceRenderer->tryRelativizePath($matches[0]);
         }, $trace);
-        // echo (new Exception('xxx'))->getHTML();
+        // echo (new Exception($msg))->getHTML();
         'trigger_error'($msg . (!class_exists(\PHPUnit\Framework\Test::class, false) ? "\n" . $trace : ''), E_USER_DEPRECATED);
     }
 
@@ -59,7 +59,7 @@ class Factory
 
         if ((!is_array($seed) && !is_object($seed) && $seed !== null) || (!is_array($seed2) && !is_object($seed2) && $seed2 !== null)) { // remove/do not accept other seed than object/array type after 2020-dec
             $varName = !is_array($seed) && !is_object($seed) && $seed !== null ? 'seed' : 'seed2';
-            $this->_printDeprecatedWarningWithTrace(
+            $this->printDeprecatedWarningWithTrace(
                 'Use of non-array seed ($' . $varName . ' type = ' . gettype(${$varName}) . ') is deprecated and support will be removed shortly.'
             );
         }
@@ -152,7 +152,7 @@ class Factory
 
         if ((!is_array($seed) && !is_object($seed)) || (!is_array($defaults) && !is_object($defaults))) { // remove/do not accept other seed than object/array type after 2020-dec
             $varName = !is_array($seed) && !is_object($seed) ? 'seed' : 'defaults';
-            $this->_printDeprecatedWarningWithTrace(
+            $this->printDeprecatedWarningWithTrace(
                 'Use of non-array seed ($' . $varName . ' type = ' . gettype(${$varName}) . ') is deprecated and support will be removed shortly.'
             );
         }

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -53,7 +53,7 @@ trait StaticAddToTrait
             $seed = [$seed];
         }
 
-        $object = static::fromSeed(static::class, $seed);
+        $object = static::fromSeed([static::class], $seed);
 
         static::_addTo_add($parent, $object, $addArgs, $skipAdd);
 

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -115,10 +115,10 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
     public function testFactoryMock()
     {
         $m = new ContainerFactoryMock();
-        $m2 = $m->add(ContainerMock::class);
+        $m2 = $m->add([ContainerMock::class]);
         $this->assertSame(ContainerMock::class, get_class($m2));
 
-        $m3 = $m->add(TrackableContainerMock::class, 'name');
+        $m3 = $m->add([TrackableContainerMock::class], 'name');
         $this->assertSame(TrackableContainerMock::class, get_class($m3));
         $this->assertSame('name', $m3->short_name);
     }
@@ -175,7 +175,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
         $this->expectException(\Error::class);
         $this->expectExceptionMessage("Class 'hello' not found");
         $m = new ContainerMock();
-        $m->add('hello', 123);
+        $m->add(['hello'], 123);
     }
 
     public function testException4()

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -18,7 +18,6 @@ class DIContainerTraitTest extends AtkPhpunit\TestCase
     {
         $this->assertSame(StdSAT::class, get_class(StdSAT::fromSeed([StdSAT::class])));
         $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeed([StdSAT2::class])));
-        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeed(StdSAT2::class)));
 
         $this->expectException(Exception::class);
         StdSAT2::fromSeed([StdSAT::class]);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -61,7 +61,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $a = new TrackableMock2();
         $a->name = 'foo';
         $ret = $m->toString($a);
-        $this->assertSame('atk4\core\tests\TrackableMock2 (foo)', $ret);
+        $this->assertSame(TrackableMock2::class . ' (foo)', $ret);
     }
 
     public function testMore(): void

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -28,9 +28,14 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $m2 = $m->factory($m1);
         $this->assertSame($m1, $m2);
 
-        // pass classname
-        $m1 = $m->factory('atk4\core\tests\FactoryMock');
+        // from array seed
+        $m1 = $m->factory([FactoryMock::class]);
         $this->assertSame(FactoryMock::class, get_class($m1));
+
+        // from string seed
+        // $this->expectException(Exception::class);
+        $this->expectDeprecation(); // replace with line above once support is removed (expected in 2020-dec)
+        $m->factory(FactoryMock::class);
     }
 
     /**
@@ -52,20 +57,11 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $m = new FactoryDIMock();
 
         // as class name
-        $m1 = $m->factory('atk4\core\tests\FactoryMock');
+        $m1 = $m->factory([FactoryMock::class]);
         $this->assertSame(FactoryMock::class, get_class($m1));
 
-        $m1 = $m->factory(\atk4\core\tests\FactoryMock::class);
-        $this->assertSame(FactoryMock::class, get_class($m1));
-
-        $m1 = $m->factory(FactoryMock::class);
-        $this->assertSame(FactoryMock::class, get_class($m1));
-
-        $m1 = $m->factory(HB::class, ['ok']);
-        $this->assertSame(\atk4\core\HookBreaker::class, get_class($m1));
-
-        $m1 = $m->factory(['atk4\core\tests\FactoryMock']);
-        $this->assertSame(FactoryMock::class, get_class($m1));
+        $m2 = $m->factory([HB::class], ['ok']);
+        $this->assertSame(\atk4\core\HookBreaker::class, get_class($m2));
 
         // as object
         $m2 = $m->factory($m1);
@@ -75,30 +71,30 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $this->assertSame(FactoryMock::class, get_class($m2));
 
         // as class name with parameters
-        $m1 = $m->factory('atk4\core\tests\FactoryDIMock', ['a' => 'XXX', 'b' => 'YYY']);
+        $m1 = $m->factory([FactoryDIMock::class], ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m1->a);
         $this->assertSame('YYY', $m1->b);
         $this->assertNull($m1->c);
 
-        $m1 = $m->factory('atk4\core\tests\FactoryDIMock', ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
+        $m1 = $m->factory([FactoryDIMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
         $this->assertSame('AAA', $m1->a);
         $this->assertSame('YYY', $m1->b);
         $this->assertSame('ZZZ', $m1->c);
 
         // as object with parameters
-        $m1 = $m->factory('atk4\core\tests\FactoryDIMock');
+        $m1 = $m->factory([FactoryDIMock::class]);
         $m2 = $m->factory($m1, ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertNull($m2->c);
 
-        $m1 = $m->factory('atk4\core\tests\FactoryDIMock');
+        $m1 = $m->factory([FactoryDIMock::class]);
         $m2 = $m->factory($m1, ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
         $this->assertSame('AAA', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertSame('ZZZ', $m2->c);
 
-        $m1 = $m->factory('atk4\core\tests\FactoryDIMock', ['a' => null, 'b' => 'YYY', 'c' => 'SSS']);
+        $m1 = $m->factory([FactoryDIMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'SSS']);
         $m2 = $m->factory($m1, ['a' => 'XXX', 'b' => null, 'c' => 'ZZZ']);
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
@@ -114,7 +110,7 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         // wrong property in 2nd parameter
         $this->expectException(Exception::class);
         $m = new FactoryMock();
-        $m1 = $m->factory('atk4\core\tests\FactoryMock', ['not_exist' => 'test']);
+        $m1 = $m->factory([FactoryMock::class], ['not_exist' => 'test']);
     }
 
     /**
@@ -126,7 +122,7 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         // wrong property in 2nd parameter
         $this->expectException(Exception::class);
         $m = new FactoryMock();
-        $m1 = $m->factory('atk4\core\tests\FactoryMock');
+        $m1 = $m->factory([FactoryMock::class]);
         $m2 = $m->factory($m1, ['not_exist' => 'test']);
     }
 }

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -21,26 +21,26 @@ class SeedTest extends AtkPhpunit\TestCase
         // string become array
         $this->assertSame(
             ['hello'],
-            $this->mergeSeeds('hello', null)
+            $this->mergeSeeds(['hello'], null)
         );
 
         // left-most value is used
         $this->assertSame(
             ['one'],
-            $this->mergeSeeds('one', 'two', 'three', 'four')
+            $this->mergeSeeds(['one'], ['two'], ['three'], ['four'])
         );
 
         // nulls are ignored
         $this->assertSame(
             ['two'],
-            $this->mergeSeeds(null, 'two', 'three', 'four')
+            $this->mergeSeeds(null, ['two'], ['three'], ['four'])
         );
 
         // object takes precedence
         $o = new SeedDITestMock();
         $this->assertSame(
             $o,
-            $this->mergeSeeds(null, 'two', $o, 'four')
+            $this->mergeSeeds(null, ['two'], $o, ['four'])
         );
 
         // if more than one object, leftmost is returned
@@ -48,7 +48,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $o2 = new SeedDITestMock();
         $this->assertSame(
             $o2,
-            $this->mergeSeeds(null, 'two', $o2, $o1, 'four')
+            $this->mergeSeeds(null, ['two'], $o2, $o1, ['four'])
         );
     }
 
@@ -63,7 +63,7 @@ class SeedTest extends AtkPhpunit\TestCase
         // nulls are ignored
         $this->assertSame(
             ['b1', 'a2', 'c3'],
-            $this->mergeSeeds([null, 'a2', null], 'b1', ['c1', null, 'c3'])
+            $this->mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'])
         );
 
         // object takes precedence
@@ -77,7 +77,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $o = new SeedDITestMock();
         $this->assertSame(
             ['b1', 'a2', 'c3'],
-            $this->mergeSeeds([null, 'a2', null], 'b1', ['c1', null, 'c3'], [$o])
+            $this->mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'], [$o])
         );
 
         // we will still return it
@@ -230,7 +230,7 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testBasic()
     {
-        $s1 = $this->factory(SeedTestMock::class);
+        $s1 = $this->factory([SeedTestMock::class]);
         $this->assertEmpty($s1->args);
 
         $s1 = $this->factory(new SeedTestMock());
@@ -241,9 +241,6 @@ class SeedTest extends AtkPhpunit\TestCase
 
         $s1 = $this->factory(new SeedTestMock(null, 'world'));
         $this->assertSame([null, 'world'], $s1->args);
-
-        $s1 = $this->factory([SeedTestMock::class]);
-        $this->assertEmpty($s1->args);
     }
 
     public function testInjection()
@@ -382,12 +379,12 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testStringDefault()
     {
-        $s1 = $this->factory(SeedDITestMock::class, 'hello');
+        $s1 = $this->factory([SeedDITestMock::class], ['hello']);
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['hello'], $s1->args);
 
         // also OK if it's not a DIContainer object
-        $s1 = $this->factory(SeedTestMock::class, 'hello');
+        $s1 = $this->factory([SeedTestMock::class], ['hello']);
         $this->assertTrue($s1 instanceof SeedTestMock);
         $this->assertSame(['hello'], $s1->args);
     }
@@ -398,7 +395,7 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testNonDIInject()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory(SeedTestMock::class, ['foo' => 'hello']);
+        $s1 = $this->factory([SeedTestMock::class], ['foo' => 'hello']);
         $this->assertTrue($s1 instanceof SeedDITestMock);
         $this->assertSame(['hello'], $s1->args);
     }

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -111,7 +111,7 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $this->assertTrue(isset($m->_containerTrait));
 
         // the same class
-        $tr = StdSAT::addToWithCl($m, StdSAT::class);
+        $tr = StdSAT::addToWithCl($m, [StdSAT::class]);
         $this->assertSame(StdSAT::class, get_class($tr));
 
         // add object - for BC
@@ -119,16 +119,16 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $this->assertSame(StdSAT::class, get_class($tr));
 
         // extended class
-        $tr = StdSAT::addToWithCl($m, StdSAT2::class);
+        $tr = StdSAT::addToWithCl($m, [StdSAT2::class]);
         $this->assertSame(StdSAT2::class, get_class($tr));
 
         // not the same or extended class - unsafe enabled
-        $tr = StdSAT::addToWithClUnsafe($m, \stdClass::class);
+        $tr = StdSAT::addToWithClUnsafe($m, [\stdClass::class]);
         $this->assertSame(\stdClass::class, get_class($tr));
 
         // not the same or extended class - unsafe disabled
         $this->expectException(\atk4\core\Exception::class);
-        $tr = StdSAT::addToWithCl($m, \stdClass::class);
+        $tr = StdSAT::addToWithCl($m, [\stdClass::class]);
     }
 
     public function testUniqueNames()


### PR DESCRIPTION
fixes: https://github.com/atk4/core/issues/226

merge after: https://github.com/atk4/data/pull/639
merge after: https://github.com/atk4/ui/pull/1315

why? currently, there is a lot of code that "prenormalize seed" and process it differently, example:
https://github.com/atk4/data/blob/8748a634b3ab4f7b02b5a009eaf2c28f917f3cb9/tests/ContainsOneTest.php#L54
notice, that it looks like a regular seed, but in reality the 1st argument/value is not an class name seed for that seed, but instead of for completely diffent class (and it has nothing to to with `caption`)

- `null` should be not supported as well (use `[]` instead), but `DIContainerTrait::setDefaults()` is not ready for this change now
- this PR means you are not allowed to use string seeds like `Cl::class`, but you have to use `[Cl::class]` instead
- other inputs types (like `int`, ...) may be working now, but only because of non-strict checking

In other words - as of now, non-object seed must be of `array` type with the first argument (value with numerical key) is class name, object seed remains object like before

Regex to find old usage:
```
(seed|factory)[^\n]*::class(?!.*\])
```
or more aggressive:
```
[=(][^\n\[]*(?<!exception)::class(?! \.)
```

data/ui PRs above may help you to understand what changes needs to be done

to debug it may help you to:
a) uncomment https://github.com/atk4/core/blob/9b9aad0dfa3105eb551bd5a479fa41cf9c17fa38/src/Factory.php#L49
b) replace if to `(true)` https://github.com/atk4/core/blob/9b9aad0dfa3105eb551bd5a479fa41cf9c17fa38/src/ExceptionRenderer/HTML.php#L158