### PR TITLE
Array seed requires valid (of omitted) class name

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -142,6 +142,10 @@ class Factory
 
     protected function _factory($seed, $defaults = []): object
     {
+        if (is_object($defaults)) {
+            throw new Exception('Factory $defaults can not be an object');
+        }
+
         if ($defaults === null) { // should be deprecated soon
             $defaults = [];
         }
@@ -163,7 +167,7 @@ class Factory
 
         if (is_array($defaults)) {
             array_unshift($defaults, null); // insert argument 0
-        } elseif (!is_object($defaults)) {
+        } else {
             $defaults = [null, $defaults];
         }
         $seed = $this->_mergeSeeds($seed, $defaults);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -172,12 +172,6 @@ class Factory
         }
         $seed = $this->_mergeSeeds($seed, $defaults);
 
-        if (is_object($seed)) {
-            // setDefaults() already called in _mergeSeeds()
-
-            return $seed;
-        }
-
         $arguments = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
         $injection = array_diff_key($seed, $arguments); // with string keys
         $object = array_shift($arguments); // first numeric key argument is object

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -78,6 +78,15 @@ class Factory
                 return null;
             }
 
+            // do not emit warnings for core tests:
+            // - some tests already tests for exception
+            // - we may later want to use this function for "mergeDefaults" (like _factory() below does)
+            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $cl) {
+                if (strpos($cl['class'] ?? '', 'atk4\core\tests\\') === 0) {
+                    return null;
+                }
+            }
+
             return 'non-existing/non-autoloadable (' . $seed[0] . ')';
         };
         if ($checkSeedClFunc($seed) !== null || $checkSeedClFunc($seed2) !== null) {

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -67,9 +67,6 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $m2 = $m->factory($m1);
         $this->assertSame(FactoryMock::class, get_class($m2));
 
-        $m2 = $m->factory([$m1]);
-        $this->assertSame(FactoryMock::class, get_class($m2));
-
         // as class name with parameters
         $m1 = $m->factory([FactoryDIMock::class], ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m1->a);
@@ -99,6 +96,11 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertSame('ZZZ', $m2->c);
+
+        // as object wrapped in array
+        // $this->expectException(Exception::class);
+        $this->expectDeprecation(); // replace with line above once support is removed (expected in 2020-dec)
+        $m->factory([$m1]);
     }
 
     /**

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -372,9 +372,8 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testGiveClassFirst()
     {
+        $this->expectException(Exception::class);
         $s1 = $this->factory(['foo' => 'bar'], new SeedDITestMock());
-        $this->assertTrue($s1 instanceof SeedDITestMock);
-        $this->assertSame('bar', $s1->foo);
     }
 
     public function testStringDefault()

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -77,14 +77,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $o = new SeedDITestMock();
         $this->assertSame(
             ['b1', 'a2', 'c3'],
-            $this->mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'], [$o])
-        );
-
-        // we will still return it
-        $o = new SeedDITestMock();
-        $this->assertSame(
-            $o,
-            $this->mergeSeeds([null, 'a2', null], [null, null, 'c3'], [$o])[0]
+            $this->mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'], [1 => $o])
         );
 
         // but constructor arguments (except silently ignored class name)
@@ -309,29 +302,18 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testDefaultsObject()
     {
+        // $this->expectException(Exception::class);
+        $this->expectDeprecation(); // replace with line above once support is removed (expected in 2020-dec)
         $s1 = $this->factory([new SeedDITestMock(), 'foo' => 'bar'], ['baz' => '', 'foo' => 'default']);
-        $this->assertSame('bar', $s1->foo);
-        $this->assertSame('', $s1->baz);
     }
 
     public function testMerge()
     {
-        $s1 = $this->factory([new SeedDITestMock(), 'foo' => ['red']], ['foo' => ['big'], 'foo' => 'default']);
-        $this->assertSame(['red'], $s1->foo);
-
-        $o = new ViewTestMock();
-        $o->foo = ['xx'];
-        $s1 = $this->factory([$o, 'foo' => ['red']], ['foo' => ['big'], 'foo' => 'default']);
-        $this->assertSame(['xx', 'red'], $s1->foo);
-
         $s1 = $this->factory([SeedDITestMock::class, 'hello', 'world'], ['more', 'more', 'args']);
         $this->assertSame(['hello', 'world', 'args'], $s1->args);
 
         $s1 = $this->factory([SeedDITestMock::class, null, 'world'], ['more', 'more', 'args']);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
-
-        $s1 = $this->factory([new SeedDITestMock('x', 'y'), null, 'bar'], ['foo', 'baz']);
-        $this->assertSame(['x', 'y'], $s1->args);
     }
 
     public function testMerge7()

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -76,10 +76,6 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $tr = StdSAT::addTo($m);
         $this->assertNotNull($tr);
 
-        // add object - for BC
-        $tr = StdSAT::addTo($m, $tr);
-        $this->assertSame(StdSAT::class, get_class($tr));
-
         // trackable object can be referenced by name
         $tr3 = TrackableMockSAT::addTo($m, [], ['foo']);
         $tr = $m->getElement('foo');


### PR DESCRIPTION
intended to be merged into develop

- dsql: unaffected
- data: 2 lines of bad ui usage
- ui: see related PR

merge after: https://github.com/atk4/data/pull/640
merge after: https://github.com/atk4/ui/pull/1330

**This PR is part of very strict definition/impl. of seeds. Seed is defined now strictly as:**
- object which may be updated using DI (dependency injection), but the same instance is always returned
- an array:
  - which has arguments (values with numerical keys) and injection (KV pairs with non-numerical keys)
  - 1st argument must be string class name (or `null` for merging seeds) @TODO I think this is wrong too, as in the code we should be able to find classes in seeds easily, this should be probably implemented with some special class

**For BC, this PR does not restrict this:**
- throw if 1st argument is not present
- throw if 1st argument is null (see comment above, it maybe never will)
- seed is null (instead of `[]` - but DIContainerTrait::setDefaults() is not ready for this change now)

Regexes to find old usage:
`\[\s*new` - do not instance object for seed
-`\[[^,]+(?<!::class)(\]| ,)` - all usages of seeds where the seed class is omitted (very few cases across whole `ui` repo)

ui PR above may help you to understand what changes needs to be done

to debug it may help you to:
a) uncomment https://github.com/atk4/core/blob/9b9aad0dfa3105eb551bd5a479fa41cf9c17fa38/src/Factory.php#L49
b) replace if to `(true)` https://github.com/atk4/core/blob/9b9aad0dfa3105eb551bd5a479fa41cf9c17fa38/src/ExceptionRenderer/HTML.php#L158