### PR TITLE
Factory $defaults can not be an object

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -142,6 +142,10 @@ class Factory
 
     protected function _factory($seed, $defaults = []): object
     {
+        if (is_object($defaults)) {
+            throw new Exception('Factory $defaults can not be an object');
+        }
+
         if ($defaults === null) { // should be deprecated soon
             $defaults = [];
         }
@@ -163,7 +167,7 @@ class Factory
 
         if (is_array($defaults)) {
             array_unshift($defaults, null); // insert argument 0
-        } elseif (!is_object($defaults)) {
+        } else {
             $defaults = [null, $defaults];
         }
         $seed = $this->_mergeSeeds($seed, $defaults);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -172,12 +172,6 @@ class Factory
         }
         $seed = $this->_mergeSeeds($seed, $defaults);
 
-        if (is_object($seed)) {
-            // setDefaults() already called in _mergeSeeds()
-
-            return $seed;
-        }
-
         $arguments = array_filter($seed, 'is_numeric', ARRAY_FILTER_USE_KEY); // with numeric keys
         $injection = array_diff_key($seed, $arguments); // with string keys
         $object = array_shift($arguments); // first numeric key argument is object

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -372,9 +372,8 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testGiveClassFirst()
     {
+        $this->expectException(Exception::class);
         $s1 = $this->factory(['foo' => 'bar'], new SeedDITestMock());
-        $this->assertTrue($s1 instanceof SeedDITestMock);
-        $this->assertSame('bar', $s1->foo);
     }
 
     public function testStringDefault()

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -76,10 +76,6 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $tr = StdSAT::addTo($m);
         $this->assertNotNull($tr);
 
-        // add object - for BC
-        $tr = StdSAT::addTo($m, $tr);
-        $this->assertSame(StdSAT::class, get_class($tr));
-
         // trackable object can be referenced by name
         $tr3 = TrackableMockSAT::addTo($m, [], ['foo']);
         $tr = $m->getElement('foo');


### PR DESCRIPTION
expect two change in `core` tests, no changes needed for `data`, `dsql`, `ui`

marking as a bug, `addTo` does not accept object/class name by defintion (seed class name is defined with class before `::AddTo(`)