### PR TITLE
Revert "Drop PHP 7.2 support"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', 'latest', '8.0']
+        php: ['7.2', '7.3', 'latest', '8.0']
         type: ['Phpunit']
         include:
           - php: 'latest'

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.3.0",
+    "php": ">=7.2.0",
     "ext-json": "*",
     "psr/log": "~1.0",
     "symfony/polyfill-php73": "^1.15",


### PR DESCRIPTION
revert until one stable releases for php 7.2 are made, otherwise if the broken releases will be used by everyone still on php 7.2 and we do not want these complains...

after release, drop support forever