### PR TITLE
Fix PSR class/trait/method naming

### DIFF
--- a/docs/di.rst
+++ b/docs/di.rst
@@ -2,7 +2,7 @@
 Dependency Injection Container
 ==============================
 
-.. php:trait:: DIContainerTrait
+.. php:trait:: DiContainerTrait
 
 Agile Core implements basic support for Dependency Injection Container.
 
@@ -40,10 +40,10 @@ This improves testability of objects, for instance. Typically constructor can
 be good for 1 or 2 arguments.
 
 However in Agile UI there are components that are designed specifically to
-encapsulate many various objects. CRUD for example is a fully-functioning
+encapsulate many various objects. Crud for example is a fully-functioning
 editing solution, but suppose you want to use custom form object::
 
-    $crud = new CRUD([
+    $crud = new Crud([
         'formEdit' => new MyForm(),
         'formAdd'  => new MyForm()
     ]);
@@ -54,14 +54,14 @@ Dependency Injection Container. Theory states that developers who use IDEs
 extensively would prefer to pass "object" and not "array", however we typically
 offer a better option::
 
-    $crud = new CRUD();
+    $crud = new Crud();
     $crud->formEdit = new MyForm();
     $crud->formAdd  = new MyForm();
 
-How to use DIContainerTrait
+How to use DiContainerTrait
 ---------------------------
 
-.. php:trait: DIContainerTrait
+.. php:trait: DiContainerTrait
 
 .. php:method: setDefaults($properties, $passively = false)
 
@@ -71,7 +71,7 @@ Calling this method will set object's properties. If any specified property
 is undefined then it will be skipped. Here is how you should use trait::
 
     class MyObj {
-        use DIContainerTrait;
+        use DiContainerTrait;
 
         function __construct($defaults = []) {
             $this->setDefaults($defaults, true);
@@ -87,7 +87,7 @@ like this::
 This is done by overriding setMissingProperty method::
 
     class MyObj {
-        use DIContainerTrait {
+        use DiContainerTrait {
             setMissingProperty as _setMissingProperty;
         }
 

--- a/docs/exception.rst
+++ b/docs/exception.rst
@@ -73,7 +73,7 @@ user to see. This will include the error, parameters and backtrace. The code
 will also make an attempt to locate and highlight the code that have caused the
 problem.
 
-.. php:method:: getHTML()
+.. php:method:: getHtml()
 
 Will return nice HTML-formatted exception that will rely on a presence of
 Semantic UI. This will include the error, parameters and backtrace. The code
@@ -108,7 +108,7 @@ If you do not instantiate App, or set it up without automatic exception catching
 
 then you might want to output message details yourself.
 
-Use :php:meth:`Exception::getColorfulText` or :php:meth:`Exception::getHTML`::
+Use :php:meth:`Exception::getColorfulText` or :php:meth:`Exception::getHtml`::
 
     try {
         // some code..

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -139,7 +139,7 @@ is done by executing factory method.
 .. php:method:: factory($seed, $defaults = [])
 
 Creates and returns new object. If is_object($seed), then it will be returned and
-$defaults will only be sed if object implement DIContainerTrait.
+$defaults will only be sed if object implement DiContainerTrait.
 
 
 In a conventional PHP, you can create and configure object before passing
@@ -200,7 +200,7 @@ Any other numeric arguments will be passed as constructor arguments::
     new Button('My Label', 'red', 'big');
 
 Finally any named values inside seed array will be assigned to class properties
-by using :php:meth:`DIContainerTrait::setDefaults`.
+by using :php:meth:`DiContainerTrait::setDefaults`.
 
 Factory uses `array_shift` to separate class definition from other components.
 
@@ -284,7 +284,7 @@ specified in the seed and is also mentioned in the second argument - $defaults.
 The seed takes precedence, so icon='cake'.
 
 Factory will then create instance of RedButton with a default icon 'book'.
-It will then execute :php:meth:`DIContainerTrait::setDefaults` with the
+It will then execute :php:meth:`DiContainerTrait::setDefaults` with the
 `['icon'=>'cake']` which will change value of $icon to `cake`.
 
 The `cake` will be the final value of the example above. Even though `init()`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,7 @@ ChildClass can extend the basic functionality.
    child.
  - :php:trait:`TrackableTrait` will let you assign unique names to object
  - :php:trait:`FactoryTrait` will let you specify object class by Seed
- - :php:trait:`DIContainerTrait` will let you with dependency injection
+ - :php:trait:`DiContainerTrait` will let you with dependency injection
 
 Just to clarify what Seed is::
 

--- a/examples/test5.php
+++ b/examples/test5.php
@@ -21,5 +21,5 @@ function loopToCreateStack($test)
 try {
     loopToCreateStack(1);
 } catch (Exception $e) {
-    echo $e->getJSON();
+    echo $e->getJson();
 }

--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -30,14 +30,14 @@ namespace atk4\core;
  * Relying on this trait excessively may cause anger management issues to
  * some code reviewers.
  */
-trait DIContainerTrait
+trait DiContainerTrait
 {
     /**
      * Check this property to see if trait is present in the object.
      *
      * @var bool
      */
-    public $_DIContainerTrait = true;
+    public $_DiContainerTrait = true;
 
     /**
      * Call from __construct() to initialize the properties allowing

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace atk4\core;
 
-use atk4\core\ExceptionRenderer\Console;
-use atk4\core\ExceptionRenderer\HTML;
-use atk4\core\ExceptionRenderer\JSON;
-use atk4\core\ExceptionRenderer\RendererAbstract;
 use atk4\core\Translator\ITranslatorAdapter;
 
 /**
@@ -84,7 +80,7 @@ class Exception extends \Exception
      */
     public function getColorfulText(): string
     {
-        return (string) new Console($this, $this->adapter);
+        return (string) new ExceptionRenderer\Console($this, $this->adapter);
     }
 
     /**
@@ -93,21 +89,21 @@ class Exception extends \Exception
      *
      *   $l = new \atk4\ui\App();
      *   $l->initLayout(\atk4\ui\Layout\Centered::class);
-     *   $l->layout->template->setHTML('Content', $e->getHTML());
+     *   $l->layout->template->setHtml('Content', $e->getHtml());
      *   $l->run();
      *   exit;
      */
-    public function getHTML(): string
+    public function getHtml(): string
     {
-        return (string) new HTML($this, $this->adapter);
+        return (string) new ExceptionRenderer\Html($this, $this->adapter);
     }
 
     /**
      * Return exception in JSON Format.
      */
-    public function getJSON(): string
+    public function getJson(): string
     {
-        return (string) new JSON($this, $this->adapter);
+        return (string) new ExceptionRenderer\Json($this, $this->adapter);
     }
 
     /**
@@ -117,7 +113,7 @@ class Exception extends \Exception
      */
     public function toString($val): string
     {
-        return RendererAbstract::toSafeString($val);
+        return ExceptionRenderer\RendererAbstract::toSafeString($val);
     }
 
     /**

--- a/src/ExceptionRenderer/Html.php
+++ b/src/ExceptionRenderer/Html.php
@@ -6,7 +6,7 @@ namespace atk4\core\ExceptionRenderer;
 
 use atk4\core\Exception;
 
-class HTML extends RendererAbstract
+class Html extends RendererAbstract
 {
     protected function processHeader(): void
     {

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -6,7 +6,7 @@ namespace atk4\core\ExceptionRenderer;
 
 use atk4\core\Exception;
 
-class JSON extends RendererAbstract
+class Json extends RendererAbstract
 {
     /** @var array */
     protected $json = [
@@ -131,7 +131,7 @@ HTML;
             $this->json = [
                 'success' => false,
                 'code' => $this->exception->getCode(),
-                'message' => 'Error during JSON renderer: ' . $this->exception->getMessage(),
+                'message' => 'Error during json renderer: ' . $this->exception->getMessage(),
                 // avoid translation
                 //'message'  => $this->_($this->exception->getMessage()),
                 'title' => get_class($this->exception),

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,7 +27,7 @@ class Factory
     {
         static $traceRenderer = null;
         if ($traceRenderer === null) {
-            $traceRenderer = new class(new Exception()) extends ExceptionRenderer\HTML {
+            $traceRenderer = new class(new Exception()) extends ExceptionRenderer\Html {
                 public function tryRelativizePath(string $path): string
                 {
                     try {
@@ -46,7 +46,7 @@ class Factory
         $trace = preg_replace_callback('~[^\n\[\]<>]+\.php~', function ($matches) use ($traceRenderer) {
             return $traceRenderer->tryRelativizePath($matches[0]);
         }, $trace);
-        // echo (new Exception($msg))->getHTML();
+        // echo (new Exception($msg))->getHtml();
         'trigger_error'($msg . (!class_exists(\PHPUnit\Framework\Test::class, false) ? "\n" . $trace : ''), E_USER_DEPRECATED);
     }
 
@@ -117,10 +117,10 @@ class Factory
                 }
 
                 if (count($injection) > 0) {
-                    if (isset($seed->_DIContainerTrait)) {
+                    if (isset($seed->_DiContainerTrait)) {
                         $seed->setDefaults($injection, $passively);
                     } else {
-                        throw (new Exception('Property injection is possible only to objects that use \atk4\core\DIContainerTrait trait'))
+                        throw (new Exception('Property injection is possible only to objects that use \atk4\core\DiContainerTrait trait'))
                             ->addMoreInfo('object', $seed)
                             ->addMoreInfo('injection', $injection)
                             ->addMoreInfo('passively', $passively);

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -7,11 +7,11 @@ namespace atk4\core;
 /**
  * Trait StaticAddToTrait.
  *
- * Intended to be always used with DIContainerTrait trait.
+ * Intended to be always used with DiContainerTrait trait.
  */
 trait StaticAddToTrait
 {
-    // use DIContainerTrait; // uncomment once PHP7.2 support is dropped
+    // use DiContainerTrait; // uncomment once PHP7.2 support is dropped
 
     /**
      * Check this property to see if trait is present in the object.
@@ -33,9 +33,9 @@ trait StaticAddToTrait
      * The best, typehinting-friendly, way to create an object if it should be immediately
      * added to a parent (otherwise use fromSeed() method).
      *
-     * $crud = CRUD::addTo($app, ['displayFields' => ['name']]);
+     * $crud = Crud::addTo($app, ['displayFields' => ['name']]);
      *   is equivalent to
-     * $crud = $app->add(['CRUD', 'displayFields' => ['name']]);
+     * $crud = $app->add(['Crud', 'displayFields' => ['name']]);
      *   but the first one design pattern is strongly recommended as it supports refactoring.
      *
      * @param array|string $seed

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -83,12 +83,12 @@ class Generic implements ITranslatorAdapter
      */
     protected function getDefinition(string $message, $domain, ?string $locale)
     {
-        $this->loadDefinitionATK($locale); // need to be called before manual add
+        $this->loadDefinitionAtk($locale); // need to be called before manual add
 
         return $this->definitions[$locale][$domain][$message] ?? null;
     }
 
-    protected function loadDefinitionATK(string $locale): void
+    protected function loadDefinitionAtk(string $locale): void
     {
         if (isset($this->definitions[$locale]['atk'])) {
             return;
@@ -107,7 +107,7 @@ class Generic implements ITranslatorAdapter
      */
     public function addDefinitionFromFile(string $file, string $locale, string $domain, string $format): void
     {
-        $this->loadDefinitionATK($locale); // need to be called before manual add
+        $this->loadDefinitionAtk($locale); // need to be called before manual add
 
         $this->readConfig($file, $format);
 
@@ -132,7 +132,7 @@ class Generic implements ITranslatorAdapter
      */
     public function setDefinitionSingle(string $key, $definition, string $locale = 'en', string $domain = 'atk')
     {
-        $this->loadDefinitionATK($locale); // need to be called before manual add
+        $this->loadDefinitionAtk($locale); // need to be called before manual add
 
         if (is_string($definition)) {
             $definition = [$definition];

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace atk4\core\Translator;
 
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 use atk4\core\Exception;
 use atk4\core\Translator\Adapter\Generic;
 
@@ -14,7 +14,7 @@ use atk4\core\Translator\Adapter\Generic;
  */
 class Translator
 {
-    use DIContainerTrait {
+    use DiContainerTrait {
         setDefaults as protected _setDefaults;
     }
 

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -125,7 +125,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
         $this->expectException(core\Exception::class);
         $m = new CollectionMock();
         $m->addField('test', new class() {
-            use core\DIContainerTrait;
+            use core\DiContainerTrait;
             use core\InitializerTrait;
             public $name;
 

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -128,7 +128,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
         // passing name with array key 'name'
         $m = new ContainerMock();
         $m2 = $m->add(new class() extends TrackableMock {
-            use core\DIContainerTrait;
+            use core\DiContainerTrait;
         }, ['name' => 'foo']);
         $this->assertTrue($m->hasElement('foo'));
         $this->assertSame('foo', $m2->short_name);

--- a/tests/DIContainerTraitTest.php
+++ b/tests/DIContainerTraitTest.php
@@ -5,62 +5,62 @@ declare(strict_types=1);
 namespace atk4\core\tests;
 
 use atk4\core\AtkPhpunit;
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 use atk4\core\Exception;
 use atk4\core\FactoryTrait;
 
 /**
- * @coversDefaultClass \atk4\core\DIContainerTrait
+ * @coversDefaultClass \atk4\core\DiContainerTrait
  */
-class DIContainerTraitTest extends AtkPhpunit\TestCase
+class DiContainerTraitTest extends AtkPhpunit\TestCase
 {
     public function testFromSeed()
     {
-        $this->assertSame(StdSAT::class, get_class(StdSAT::fromSeed([StdSAT::class])));
-        $this->assertSame(StdSAT2::class, get_class(StdSAT::fromSeed([StdSAT2::class])));
+        $this->assertSame(StdSat::class, get_class(StdSat::fromSeed([StdSat::class])));
+        $this->assertSame(StdSat2::class, get_class(StdSat::fromSeed([StdSat2::class])));
 
         $this->expectException(Exception::class);
-        StdSAT2::fromSeed([StdSAT::class]);
+        StdSat2::fromSeed([StdSat::class]);
     }
 
     public function testNoPropExNumeric()
     {
         $this->expectException(\Error::class);
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->setDefaults([5 => 'qwerty']);
     }
 
     public function testNoPropExStandard()
     {
         $this->expectException(Exception::class);
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->setDefaults(['not_exist' => 'qwerty']);
     }
 
     public function testProperties()
     {
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar']);
         $this->assertSame([$m->a, $m->b, $m->c], ['foo', 'BBB', 'bar']);
 
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->setDefaults(['a' => null, 'c' => false]);
         $this->assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
     }
 
     public function testPropertiesPassively()
     {
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar'], true);
         $this->assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', 'bar']);
 
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->setDefaults(['a' => null, 'c' => false], true);
         $this->assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
 
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->a = ['foo'];
         $m->setDefaults(['a' => ['bar']], true);
         $this->assertSame([$m->a, $m->b, $m->c], [['foo'], 'BBB', null]);
@@ -71,16 +71,16 @@ class DIContainerTraitTest extends AtkPhpunit\TestCase
      */
     public function testPassively()
     {
-        $m = new FactoryDIMock2();
+        $m = new FactoryDiMock2();
         $m->setDefaults([], true);
     }
 }
 
 // @codingStandardsIgnoreStart
-class FactoryDIMock2
+class FactoryDiMock2
 {
     use FactoryTrait;
-    use DIContainerTrait;
+    use DiContainerTrait;
 
     public $a = 'AAA';
     public $b = 'BBB';

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -157,11 +157,11 @@ class DebugTraitTest extends AtkPhpunit\TestCase
         $this->assertNull($app->log);
     }
 
-    public function testPSR()
+    public function testPsr()
     {
         $app = new DebugAppMock();
 
-        $m = new PSRMock();
+        $m = new PsrMock();
         $app->logger = $app;
         $m->app = $app;
 
@@ -224,7 +224,7 @@ class DebugAppMock2 implements \atk4\core\AppUserNotificationInterface
     }
 }
 
-class PSRmock implements \Psr\Log\LoggerInterface
+class PsrMock implements \Psr\Log\LoggerInterface
 {
     use DebugTrait;
     use AppScopeTrait;

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -31,7 +31,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $this->assertSame(['a1' => 222, 'a2' => 333], $m->getParams());
 
         // get HTML
-        $ret = $m->getHTML();
+        $ret = $m->getHtml();
         $this->assertMatchesRegularExpression('/TestIt/', $ret);
         $this->assertMatchesRegularExpression('/PrevError/', $ret);
         $this->assertMatchesRegularExpression('/333/', $ret);
@@ -43,7 +43,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $this->assertMatchesRegularExpression('/333/', $ret);
 
         // get JSON
-        $ret = $m->getJSON();
+        $ret = $m->getJson();
         $this->assertMatchesRegularExpression('/TestIt/', $ret);
         $this->assertMatchesRegularExpression('/PrevError/', $ret);
         $this->assertMatchesRegularExpression('/333/', $ret);
@@ -71,7 +71,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $m = new Exception('atk4 exception', 0, $m);
         $m->setMessage('bumbum');
 
-        $ret = $m->getHTML();
+        $ret = $m->getHtml();
         $this->assertMatchesRegularExpression('/Classic/', $ret);
         $this->assertMatchesRegularExpression('/bumbum/', $ret);
 
@@ -79,7 +79,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $this->assertMatchesRegularExpression('/Classic/', $ret);
         $this->assertMatchesRegularExpression('/bumbum/', $ret);
 
-        $ret = $m->getJSON();
+        $ret = $m->getJson();
         $this->assertMatchesRegularExpression('/Classic/', $ret);
         $this->assertMatchesRegularExpression('/bumbum/', $ret);
     }
@@ -89,13 +89,13 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $m = new Exception('Exception with solution');
         $m->addSolution('One Solution');
 
-        $ret = $m->getHTML();
+        $ret = $m->getHtml();
         $this->assertMatchesRegularExpression('/One Solution/', $ret);
 
         $ret = $m->getColorfulText();
         $this->assertMatchesRegularExpression('/One Solution/', $ret);
 
-        $ret = $m->getJSON();
+        $ret = $m->getJson();
         $this->assertMatchesRegularExpression('/One Solution/', $ret);
     }
 
@@ -121,14 +121,14 @@ class ExceptionTest extends AtkPhpunit\TestCase
         $m = new ExceptionTestThrowError('test', 2);
         $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
             . ExceptionTestThrowError::class . '(2): test !!';
-        $this->assertSame($expectedFallbackText, $m->getHTML());
+        $this->assertSame($expectedFallbackText, $m->getHtml());
         $this->assertSame($expectedFallbackText, $m->getColorfulText());
         $this->assertSame(
             json_encode(
                 [
                     'success' => false,
                     'code' => 2,
-                    'message' => 'Error during JSON renderer: test',
+                    'message' => 'Error during json renderer: test',
                     'title' => ExceptionTestThrowError::class,
                     'class' => ExceptionTestThrowError::class,
                     'params' => [],
@@ -143,7 +143,7 @@ class ExceptionTest extends AtkPhpunit\TestCase
                 ],
                 JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
             ),
-            $m->getJSON()
+            $m->getJson()
         );
     }
 }

--- a/tests/FactoryTraitTest.php
+++ b/tests/FactoryTraitTest.php
@@ -6,7 +6,7 @@ namespace atk4\core\tests;
 
 use atk4\core\AppScopeTrait;
 use atk4\core\AtkPhpunit;
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 use atk4\core\Exception;
 use atk4\core\FactoryTrait;
 use atk4\core\HookBreaker as HB;
@@ -54,7 +54,7 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
      */
     public function testParameters()
     {
-        $m = new FactoryDIMock();
+        $m = new FactoryDiMock();
 
         // as class name
         $m1 = $m->factory([FactoryMock::class]);
@@ -68,30 +68,30 @@ class FactoryTraitTest extends AtkPhpunit\TestCase
         $this->assertSame(FactoryMock::class, get_class($m2));
 
         // as class name with parameters
-        $m1 = $m->factory([FactoryDIMock::class], ['a' => 'XXX', 'b' => 'YYY']);
+        $m1 = $m->factory([FactoryDiMock::class], ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m1->a);
         $this->assertSame('YYY', $m1->b);
         $this->assertNull($m1->c);
 
-        $m1 = $m->factory([FactoryDIMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
+        $m1 = $m->factory([FactoryDiMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
         $this->assertSame('AAA', $m1->a);
         $this->assertSame('YYY', $m1->b);
         $this->assertSame('ZZZ', $m1->c);
 
         // as object with parameters
-        $m1 = $m->factory([FactoryDIMock::class]);
+        $m1 = $m->factory([FactoryDiMock::class]);
         $m2 = $m->factory($m1, ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertNull($m2->c);
 
-        $m1 = $m->factory([FactoryDIMock::class]);
+        $m1 = $m->factory([FactoryDiMock::class]);
         $m2 = $m->factory($m1, ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
         $this->assertSame('AAA', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertSame('ZZZ', $m2->c);
 
-        $m1 = $m->factory([FactoryDIMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'SSS']);
+        $m1 = $m->factory([FactoryDiMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'SSS']);
         $m2 = $m->factory($m1, ['a' => 'XXX', 'b' => null, 'c' => 'ZZZ']);
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
@@ -138,10 +138,10 @@ class FactoryMock
     public $b = 'BBB';
     public $c;
 }
-class FactoryDIMock
+class FactoryDiMock
 {
     use FactoryTrait;
-    use DIContainerTrait;
+    use DiContainerTrait;
 
     public $a = 'AAA';
     public $b = 'BBB';

--- a/tests/FieldMock.php
+++ b/tests/FieldMock.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace atk4\core\tests;
 
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 
 class FieldMock
 {
-    use DIContainerTrait;
+    use DiContainerTrait;
 
     public $name;
 }

--- a/tests/LocalizationTest.php
+++ b/tests/LocalizationTest.php
@@ -21,9 +21,9 @@ class LocalizationTest extends AtkPhpunit\TestCase
         try {
             Persistence::connect('error:error');
         } catch (Exception $e) {
-            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getHtml());
             $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getColorfulText());
-            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/Невозможно определить постоянство драйвера из DSN/', $e->getJson());
         }
     }
 
@@ -36,9 +36,9 @@ class LocalizationTest extends AtkPhpunit\TestCase
             Persistence::connect('error:error');
         } catch (Exception $e) {
             $e->setTranslatorAdapter($adapter);
-            $this->assertMatchesRegularExpression('/message is translated/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getHtml());
             $this->assertMatchesRegularExpression('/message is translated/', $e->getColorfulText());
-            $this->assertMatchesRegularExpression('/message is translated/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/message is translated/', $e->getJson());
         }
     }
 
@@ -61,9 +61,9 @@ class LocalizationTest extends AtkPhpunit\TestCase
                     return 'external translator';
                 }
             });
-            $this->assertMatchesRegularExpression('/external translator/', $e->getHTML());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getHtml());
             $this->assertMatchesRegularExpression('/external translator/', $e->getColorfulText());
-            $this->assertMatchesRegularExpression('/external translator/', $e->getJSON());
+            $this->assertMatchesRegularExpression('/external translator/', $e->getJson());
         }
     }
 }

--- a/tests/SeedTest.php
+++ b/tests/SeedTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace atk4\core\tests;
 
 use atk4\core\AtkPhpunit;
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 use atk4\core\Exception;
 use atk4\core\FactoryTrait;
 
@@ -37,15 +37,15 @@ class SeedTest extends AtkPhpunit\TestCase
         );
 
         // object takes precedence
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $this->assertSame(
             $o,
             $this->mergeSeeds(null, ['two'], $o, ['four'])
         );
 
         // if more than one object, leftmost is returned
-        $o1 = new SeedDITestMock();
-        $o2 = new SeedDITestMock();
+        $o1 = new SeedDiTestMock();
+        $o2 = new SeedDiTestMock();
         $this->assertSame(
             $o2,
             $this->mergeSeeds(null, ['two'], $o2, $o1, ['four'])
@@ -67,14 +67,14 @@ class SeedTest extends AtkPhpunit\TestCase
         );
 
         // object takes precedence
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $this->assertSame(
             $o,
             $this->mergeSeeds(['a1'], $o)
         );
 
         // is object is wrapped in array - we dont care
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $this->assertSame(
             ['b1', 'a2', 'c3'],
             $this->mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'], [1 => $o])
@@ -82,7 +82,7 @@ class SeedTest extends AtkPhpunit\TestCase
 
         // but constructor arguments (except silently ignored class name)
         // for already instanced object are not valid
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $this->expectException(Exception::class);
         $this->mergeSeeds(['a1', 'a2'], $o);
     }
@@ -102,14 +102,14 @@ class SeedTest extends AtkPhpunit\TestCase
         );
 
         // object is injected with values
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $oo = $this->mergeSeeds(['foo' => 1], $o);
 
         $this->assertSame($o, $oo);
         $this->assertSame(1, $oo->foo);
 
         // even it already has value
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $o->foo = 5;
         $oo = $this->mergeSeeds(['foo' => 1], $o);
 
@@ -117,7 +117,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $this->assertSame(1, $oo->foo);
 
         // but this way existing value is respected
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $o->foo = 5;
         $oo = $this->mergeSeeds($o, ['foo' => 1]);
 
@@ -136,7 +136,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $this->assertSame(['red', 'green'], $oo->foo);
 
         // still we don't care if they are to the right of the object
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $o->foo = ['red'];
         $oo = $this->mergeSeeds($o, ['foo' => ['green']]);
 
@@ -155,7 +155,7 @@ class SeedTest extends AtkPhpunit\TestCase
         $this->assertSame(['red', 'green', 'xx'], $oo->foo);
 
         // also without arrays
-        $o = new SeedDITestMock();
+        $o = new SeedDiTestMock();
         $o->foo = 'red';
         $oo = $this->mergeSeeds(['foo' => 'xx'], ['foo' => 'green'], $o, ['foo' => 5]);
 
@@ -238,10 +238,10 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testInjection()
     {
-        $s1 = $this->factory(new SeedDITestMock(), null);
+        $s1 = $this->factory(new SeedDiTestMock(), null);
         $this->assertNotSame('bar', $s1->foo);
 
-        $s1 = $this->factory(new SeedDITestMock(), ['foo' => 'bar']);
+        $s1 = $this->factory(new SeedDiTestMock(), ['foo' => 'bar']);
         $this->assertSame('bar', $s1->foo);
     }
 
@@ -258,15 +258,15 @@ class SeedTest extends AtkPhpunit\TestCase
         $s1 = $this->factory([SeedTestMock::class, null, 'world']);
         $this->assertSame([null, 'world'], $s1->args);
 
-        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'foo' => 'bar', 'world']);
+        $s1 = $this->factory([SeedDiTestMock::class, 'hello', 'foo' => 'bar', 'world']);
         $this->assertSame(['hello', 'world'], $s1->args);
         $this->assertSame('bar', $s1->foo);
     }
 
     public function testDefaults()
     {
-        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'foo' => 'bar', 'world'], ['more', 'baz' => '', 'more', 'args']);
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory([SeedDiTestMock::class, 'hello', 'foo' => 'bar', 'world'], ['more', 'baz' => '', 'more', 'args']);
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['hello', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
         $this->assertSame('', $s1->baz);
@@ -276,27 +276,27 @@ class SeedTest extends AtkPhpunit\TestCase
 
     public function testNull()
     {
-        $s1 = $this->factory([SeedDITestMock::class, 'foo' => null, null, 'world'], ['more', 'foo' => 'bar', 'more', 'args']);
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory([SeedDiTestMock::class, 'foo' => null, null, 'world'], ['more', 'foo' => 'bar', 'more', 'args']);
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds([SeedDITestMock::class, 'foo' => null, null, 'world'], [SeedTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory($this->mergeSeeds([SeedDiTestMock::class, 'foo' => null, null, 'world'], [SeedTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds([null, 'foo' => null, null, 'world'], [SeedDITestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory($this->mergeSeeds([null, 'foo' => null, null, 'world'], [SeedDiTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds(null, [SeedDITestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory($this->mergeSeeds(null, [SeedDiTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['more', 'more', 'args'], $s1->args);
         $this->assertSame('bar', $s1->foo);
 
-        $s1 = $this->factory($this->mergeSeeds([], [SeedDITestMock::class, 'test']));
+        $s1 = $this->factory($this->mergeSeeds([], [SeedDiTestMock::class, 'test']));
         $this->assertSame(['test'], $s1->args);
     }
 
@@ -304,15 +304,15 @@ class SeedTest extends AtkPhpunit\TestCase
     {
         // $this->expectException(Exception::class);
         $this->expectDeprecation(); // replace with line above once support is removed (expected in 2020-dec)
-        $s1 = $this->factory([new SeedDITestMock(), 'foo' => 'bar'], ['baz' => '', 'foo' => 'default']);
+        $s1 = $this->factory([new SeedDiTestMock(), 'foo' => 'bar'], ['baz' => '', 'foo' => 'default']);
     }
 
     public function testMerge()
     {
-        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'world'], ['more', 'more', 'args']);
+        $s1 = $this->factory([SeedDiTestMock::class, 'hello', 'world'], ['more', 'more', 'args']);
         $this->assertSame(['hello', 'world', 'args'], $s1->args);
 
-        $s1 = $this->factory([SeedDITestMock::class, null, 'world'], ['more', 'more', 'args']);
+        $s1 = $this->factory([SeedDiTestMock::class, null, 'world'], ['more', 'more', 'args']);
         $this->assertSame(['more', 'world', 'args'], $s1->args);
     }
 
@@ -337,10 +337,10 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testClassMayNotBeEmpty()
     {
         $this->expectException(\Error::class);
-        $s1 = $this->factory([''], [SeedDITestMock::class, 'test']);
+        $s1 = $this->factory([''], [SeedDiTestMock::class, 'test']);
     }
 
-    public function testMystBeDI()
+    public function testMystBeDi()
     {
         $this->expectException(Exception::class);
         $s1 = $this->factory([SeedTestMock::class, 'hello', 'foo' => 'bar', 'world']);
@@ -349,19 +349,19 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testMustHaveProperty()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory([SeedDITestMock::class, 'hello', 'xxx' => 'bar', 'world']);
+        $s1 = $this->factory([SeedDiTestMock::class, 'hello', 'xxx' => 'bar', 'world']);
     }
 
     public function testGiveClassFirst()
     {
         $this->expectException(Exception::class);
-        $s1 = $this->factory(['foo' => 'bar'], new SeedDITestMock());
+        $s1 = $this->factory(['foo' => 'bar'], new SeedDiTestMock());
     }
 
     public function testStringDefault()
     {
-        $s1 = $this->factory([SeedDITestMock::class], ['hello']);
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $s1 = $this->factory([SeedDiTestMock::class], ['hello']);
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['hello'], $s1->args);
 
         // also OK if it's not a DIContainer object
@@ -373,11 +373,11 @@ class SeedTest extends AtkPhpunit\TestCase
     /**
      * Cannot inject in non-DI.
      */
-    public function testNonDIInject()
+    public function testNonDiInject()
     {
         $this->expectException(Exception::class);
         $s1 = $this->factory([SeedTestMock::class], ['foo' => 'hello']);
-        $this->assertTrue($s1 instanceof SeedDITestMock);
+        $this->assertTrue($s1 instanceof SeedDiTestMock);
         $this->assertSame(['hello'], $s1->args);
     }
 
@@ -387,7 +387,7 @@ class SeedTest extends AtkPhpunit\TestCase
     public function testPropertyMerging()
     {
         $s1 = $this->factory(
-            [SeedDITestMock::class, 'foo' => ['Button', 'icon' => 'red']],
+            [SeedDiTestMock::class, 'foo' => ['Button', 'icon' => 'red']],
             ['foo' => ['Label', 'red']]
         );
 
@@ -411,14 +411,14 @@ class SeedTestMock
     }
 }
 
-class SeedDITestMock extends SeedTestMock
+class SeedDiTestMock extends SeedTestMock
 {
-    use DIContainerTrait;
+    use DiContainerTrait;
 }
 
 class ViewTestMock extends SeedTestMock
 {
-    use DIContainerTrait {
+    use DiContainerTrait {
         setDefaults as _setDefaults;
     }
     public $def;
@@ -440,7 +440,7 @@ class ViewTestMock extends SeedTestMock
 
 class SeedDefTestMock extends SeedTestMock
 {
-    use DIContainerTrait {
+    use DiContainerTrait {
         setDefaults as _setDefaults;
     }
     public $def;

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -6,38 +6,38 @@ namespace atk4\core\tests;
 
 use atk4\core\AtkPhpunit;
 use atk4\core\ContainerTrait;
-use atk4\core\DIContainerTrait;
+use atk4\core\DiContainerTrait;
 use atk4\core\FactoryTrait;
 use atk4\core\StaticAddToTrait;
 use atk4\core\TrackableTrait;
 
 // @codingStandardsIgnoreStart
-class StdSAT extends \StdClass
+class StdSat extends \StdClass
 {
-    use DIContainerTrait; // remove once PHP7.2 support is dropped
+    use DiContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
 }
 
-class StdSAT2 extends StdSAT
+class StdSat2 extends StdSat
 {
 }
 
-class ContainerFactoryMockSAT
+class ContainerFactoryMockSat
 {
     use ContainerTrait;
     use FactoryTrait;
 }
 
-class TrackableMockSAT
+class TrackableMockSat
 {
     use TrackableTrait;
-    use DIContainerTrait; // remove once PHP7.2 support is dropped
+    use DiContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
 }
-class DIMockSAT
+class DiMockSat
 {
     use FactoryTrait;
-    use DIContainerTrait;
+    use DiContainerTrait;
     use StaticAddToTrait;
 
     public $a = 'AAA';
@@ -45,10 +45,10 @@ class DIMockSAT
     public $c;
 }
 
-class DIConstructorMockSAT
+class DiConstructorMockSat
 {
     use FactoryTrait;
-    use DIContainerTrait;
+    use DiContainerTrait;
     use StaticAddToTrait;
 
     public $a = 'AAA';
@@ -73,32 +73,32 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $this->assertTrue(isset($m->_containerTrait));
 
         // add to return object
-        $tr = StdSAT::addTo($m);
+        $tr = StdSat::addTo($m);
         $this->assertNotNull($tr);
 
         // trackable object can be referenced by name
-        $tr3 = TrackableMockSAT::addTo($m, [], ['foo']);
+        $tr3 = TrackableMockSat::addTo($m, [], ['foo']);
         $tr = $m->getElement('foo');
         $this->assertSame($tr, $tr3);
 
         // not the same or extended class
         $this->expectException(\atk4\core\Exception::class);
-        $tr = StdSAT::addTo($m, $tr);
+        $tr = StdSat::addTo($m, $tr);
     }
 
     public function testAssertInstanceOf()
     {
         // object is of the same class
-        StdSAT::assertInstanceOf(new StdSAT());
-        $o = new StdSAT();
-        $this->assertSame($o, StdSAT::assertInstanceOf($o));
+        StdSat::assertInstanceOf(new StdSat());
+        $o = new StdSat();
+        $this->assertSame($o, StdSat::assertInstanceOf($o));
 
         // object is a subtype
-        StdSAT::assertInstanceOf(new StdSAT2());
+        StdSat::assertInstanceOf(new StdSat2());
 
         // object is not a subtype
         $this->expectException(\atk4\core\Exception::class);
-        StdSAT2::assertInstanceOf(new StdSAT());
+        StdSat2::assertInstanceOf(new StdSat());
     }
 
     public function testWithClassName()
@@ -107,24 +107,24 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $this->assertTrue(isset($m->_containerTrait));
 
         // the same class
-        $tr = StdSAT::addToWithCl($m, [StdSAT::class]);
-        $this->assertSame(StdSAT::class, get_class($tr));
+        $tr = StdSat::addToWithCl($m, [StdSat::class]);
+        $this->assertSame(StdSat::class, get_class($tr));
 
         // add object - for BC
-        $tr = StdSAT::addToWithCl($m, $tr);
-        $this->assertSame(StdSAT::class, get_class($tr));
+        $tr = StdSat::addToWithCl($m, $tr);
+        $this->assertSame(StdSat::class, get_class($tr));
 
         // extended class
-        $tr = StdSAT::addToWithCl($m, [StdSAT2::class]);
-        $this->assertSame(StdSAT2::class, get_class($tr));
+        $tr = StdSat::addToWithCl($m, [StdSat2::class]);
+        $this->assertSame(StdSat2::class, get_class($tr));
 
         // not the same or extended class - unsafe enabled
-        $tr = StdSAT::addToWithClUnsafe($m, [\stdClass::class]);
+        $tr = StdSat::addToWithClUnsafe($m, [\stdClass::class]);
         $this->assertSame(\stdClass::class, get_class($tr));
 
         // not the same or extended class - unsafe disabled
         $this->expectException(\atk4\core\Exception::class);
-        $tr = StdSAT::addToWithCl($m, [\stdClass::class]);
+        $tr = StdSat::addToWithCl($m, [\stdClass::class]);
     }
 
     public function testUniqueNames()
@@ -132,11 +132,11 @@ class StaticAddToTest extends AtkPhpunit\TestCase
         $m = new ContainerMock();
 
         // two anonymous children should get unique names asigned.
-        TrackableMockSAT::addTo($m);
-        $anon = TrackableMockSAT::addTo($m);
-        TrackableMockSAT::addTo($m, [], ['foo bar']);
-        TrackableMockSAT::addTo($m, [], ['123']);
-        TrackableMockSAT::addTo($m, [], ['false']);
+        TrackableMockSat::addTo($m);
+        $anon = TrackableMockSat::addTo($m);
+        TrackableMockSat::addTo($m, [], ['foo bar']);
+        TrackableMockSat::addTo($m, [], ['123']);
+        TrackableMockSat::addTo($m, [], ['false']);
 
         $this->assertTrue($m->hasElement('foo bar'));
         $this->assertTrue($m->hasElement('123'));
@@ -151,13 +151,13 @@ class StaticAddToTest extends AtkPhpunit\TestCase
 
     public function testFactoryMock()
     {
-        $m = new ContainerFactoryMockSAT();
-        $m1 = DIMockSAT::addTo($m, ['a' => 'XXX', 'b' => 'YYY']);
+        $m = new ContainerFactoryMockSat();
+        $m1 = DiMockSat::addTo($m, ['a' => 'XXX', 'b' => 'YYY']);
         $this->assertSame('XXX', $m1->a);
         $this->assertSame('YYY', $m1->b);
         $this->assertNull($m1->c);
 
-        $m2 = DIConstructorMockSAT::addTo($m, ['a' => 'XXX', 'John', 'b' => 'YYY']);
+        $m2 = DiConstructorMockSat::addTo($m, ['a' => 'XXX', 'John', 'b' => 'YYY']);
         $this->assertSame('XXX', $m2->a);
         $this->assertSame('YYY', $m2->b);
         $this->assertSame('John', $m2->c);

--- a/tests/TranslatorAdapterGenericTest.php
+++ b/tests/TranslatorAdapterGenericTest.php
@@ -19,12 +19,12 @@ class TranslatorAdapterGenericTest extends TranslatorAdapterBase
         };
     }
 
-    public function testExceptionDINotFound(): void
+    public function testExceptionDiNotFound(): void
     {
         $this->assertSame('no key return self', Translator::instance()->_('no key return self'));
     }
 
-    public function testExceptionDIInstance(): void
+    public function testExceptionDiInstance(): void
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([
@@ -32,7 +32,7 @@ class TranslatorAdapterGenericTest extends TranslatorAdapterBase
         ]);
     }
 
-    public function testExceptionDIAdapter(): void
+    public function testExceptionDiAdapter(): void
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([
@@ -40,7 +40,7 @@ class TranslatorAdapterGenericTest extends TranslatorAdapterBase
         ]);
     }
 
-    public function testExceptionDIDefaultDomain(): void
+    public function testExceptionDiDefaultDomain(): void
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([
@@ -48,7 +48,7 @@ class TranslatorAdapterGenericTest extends TranslatorAdapterBase
         ]);
     }
 
-    public function testExceptionDIDefaultLocale(): void
+    public function testExceptionDiDefaultLocale(): void
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([


### PR DESCRIPTION
pure case refactor only, class/trait/method names are CI

renamed to pure PascalCase (camelCase for methods) with snake case reasoning (like you will never write `h_t_m_l`)

based on `(?<!::)(trait|interface|function|class) ((?!(Expression|Connection|Query)_).)*[A-Z][A-Z]`

the only breaking change is that these files will not load using autoloaded if not optimized and not using CI FS

updated names:
```
DIContainerTrait
atk4\core\ExceptionRenderer\HTML
atk4\core\ExceptionRenderer\JSON
Exception::getHTML()
Exception::getJSON()
```

for 100% BC you can require the renamed classes manually (but if some other updated code required them before use is enough)