### PR TITLE
Fix escaped new lines in exception renderer when allowed

### DIFF
--- a/src/AtkPhpunit/ResultPrinter.php
+++ b/src/AtkPhpunit/ResultPrinter.php
@@ -55,7 +55,7 @@ class ResultPrinter extends \PHPUnit\TextUI\DefaultResultPrinter
         $string = '';
         foreach ($e->getParams() as $param => $value) {
             $valueStr = \atk4\core\ExceptionRenderer\RendererAbstract::toSafeString($value, true);
-            $string .= '  ' . $param . ': ' . str_replace("\n", "\n" . '  ', $valueStr) . "\n";
+            $string .= '  ' . $param . ': ' . str_replace("\n", "\n" . '    ', $valueStr) . "\n";
         }
 
         return $string;

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -112,6 +112,9 @@ abstract class RendererAbstract
             $out = json_encode($val, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE);
             $out = preg_replace('~\\\\"~', '"', preg_replace('~^"|"$~s', '\'', $out)); // use single quotes
             $out = preg_replace('~\\\\([\\\\/])~s', '$1', $out); // unescape slashes
+            if ($allowNl) {
+                $out = preg_replace('~(\\\\r)?\\\\n|\\\\r~s', "\n", $out); // unescape new lines
+            }
 
             return $out;
         }
@@ -126,7 +129,7 @@ abstract class RendererAbstract
             $vSafe = static::toSafeString($v, $allowNl, $maxDepth - 1);
 
             if ($allowNl) {
-                $out .= "\n" . '  ' . $kSafe . ': ' . preg_replace('~(?<=\n)~', '  ', $vSafe);
+                $out .= "\n" . '  ' . $kSafe . ': ' . preg_replace('~(?<=\n)~', '    ', $vSafe);
             } else {
                 $out .= $kSafe . ': ' . $vSafe;
             }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/2228672/88296637-41bf3c00-ccff-11ea-994c-78083667ca59.png)


after:
![image](https://user-images.githubusercontent.com/2228672/88296665-497ee080-ccff-11ea-82ef-e9edd534fb84.png)
