### PR TITLE
remove duplicate func_num_args == 2 check

### DIFF
--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -33,10 +33,6 @@ trait FactoryTrait
      */
     public function factory($seed, $defaults = []): object
     {
-        if (func_num_args() > 2) { // prevent bad usage
-            throw new \Error('Too many method arguments, factory does no longer support prefix');
-        }
-
         return Factory::factory($seed, $defaults);
     }
 }


### PR DESCRIPTION
Remove this check as called function checks exactly the same:
```
//check in Factory.php

 final public static function factory($seed, $defaults = []): object
    {
        if (func_num_args() > 2) { // prevent bad usage
            throw new \Error('Too many method arguments');
        }

        return self::getInstance()->_factory($seed, $defaults);
    }
```