### PR TITLE
Hook closure must be unbound or bound to the this when cloning

### DIFF
--- a/docs/hook.rst
+++ b/docs/hook.rst
@@ -30,7 +30,7 @@ The framework or application would typically execute hooks like this::
 
 You can register multiple call-backs to be executed for the requested `spot`::
 
-    $obj->onHook('spot', function($obj){ echo "Hook 'spot' is called!"; });
+    $obj->onHook('spot', function($obj) { echo "Hook 'spot' is called!"; });
 
 Adding callbacks
 ================
@@ -48,13 +48,15 @@ In case $fx is omitted then $this object is used as $fx.
 
 In this case a method with same name as $spot will be used as callback::
 
-    protected function init(): void {
+    protected function init(): void
+    {
         parent::init();
 
-        $this->onHook('beforeUpdate');
+        $this->onHookMethod($spot, 'beforeUpdate');
     }
 
-    function beforeUpdate($obj){
+    function beforeUpdate()
+    {
         // will be called from the hook
     }
 

--- a/docs/hook.rst
+++ b/docs/hook.rst
@@ -52,7 +52,9 @@ In this case a method with same name as $spot will be used as callback::
     {
         parent::init();
 
-        $this->onHookMethod($spot, 'beforeUpdate');
+        $this->onHookShort($spot, function(...$args) {
+            $this->beforeUpdate(...$args);
+        });
     }
 
     function beforeUpdate()

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -144,6 +144,7 @@ trait DynamicMethodTrait
             throw (new Exception('Registering global method twice'))
                 ->addMoreInfo('name', $name);
         }
+
         $this->app->onHook($this->buildMethodHookName($name, true), $fx);
     }
 

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -69,7 +69,7 @@ trait HookTrait
      * Lower priority is called sooner. If priority is negative,
      * then hooks will be executed in reverse order.
      *
-     * @return int Index under which the hook was added
+     * @return int index under which the hook was added
      */
     public function onHook(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
@@ -93,7 +93,7 @@ trait HookTrait
     /**
      * Same as onHook() except no $this is passed to the callback as the 1st argument.
      *
-     * @return int Index under which the hook was added
+     * @return int index under which the hook was added
      */
     public function onHookShort(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -45,15 +45,16 @@ trait HookTrait
         foreach ($this->hooks as &$hooksByPriority) {
             foreach ($hooksByPriority as &$hooksByIndex) {
                 foreach ($hooksByIndex as &$hookData) {
-                    $fxThis = (new \ReflectionFunction($hookData[0]))->getClosureThis();
+                    $fxRefl = new \ReflectionFunction($hookData[0]);
+                    $fxThis = $fxRefl->getClosureThis();
                     if ($fxThis === null) {
                         continue;
                     }
 
                     if ($fxThis !== $this->_hookOrigThis) {
                         throw (new Exception('Object can not be cloned with hook bound to a different object than this'))
-                            ->addMoreInfo('closure_class', get_class($fxThis))
-                            ->addMoreInfo('closure_start_line', (new \ReflectionFunction($hookData[0]))->getStartLine());
+                            ->addMoreInfo('closure_file', $fxRefl->getFileName())
+                            ->addMoreInfo('closure_start_line', $fxRefl->getStartLine());
                     }
 
                     $hookData[0] = \Closure::bind($hookData[0], $this);

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -127,7 +127,7 @@ trait HookTrait
      */
     public function onHookDynamic(string $spot, \Closure $getFxThisFx, \Closure $fx, array $args = [], int $priority = 5): int
     {
-        $fxLong = function (&...$args) use ($getFxThisFx, $fx) {
+        $fxLong = function ($ignore, &...$args) use ($getFxThisFx, $fx) {
             $fxThis = $getFxThisFx($this);
             if ($fxThis === null) {
                 throw new Exception('New $this can not be null');
@@ -136,7 +136,7 @@ trait HookTrait
             return \Closure::bind($fx, $fxThis)($this, ...$args);
         };
 
-        return $this->onHookShort($spot, $fxLong, $args, $priority);
+        return $this->onHook($spot, $fxLong, $args, $priority);
     }
 
     /**

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -119,18 +119,6 @@ trait HookTrait
     }
 
     /**
-     * Same as onHookShort() except callback is specified by a target object method.
-     *
-     * @return int index under which the hook was added
-     */
-    public function onHookMethod(string $spot, string $methodName, array $args = [], int $priority = 5): int
-    {
-        return $this->onHookShort($spot, function (...$args) use ($methodName) {
-            return $this->{$methodName}(...$args);
-        }, $args, $priority);
-    }
-
-    /**
      * Delete all hooks for specified spot, priority and index.
      *
      * @param int|null $priority        filter specific priority, null for all

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -63,6 +63,53 @@ trait HookTrait
         $this->_hookOrigThis = $this;
     }
 
+    private function _unbindThisFromHookIfNotUsed(\Closure $fx): \Closure
+    {
+        $fxThis = (new \ReflectionFunction($fx))->getClosureThis();
+        if ($fxThis === null) {
+            return $fx;
+        }
+
+        // detect if $this is unused, there is not better detection than php warning
+        // see https://stackoverflow.com/questions/63692512/how-to-detect-if-this-is-used-in-closure
+        $hasThis = false;
+        set_error_handler(function ($errNo, $errStr) use (&$hasThis) {
+            if (preg_match(
+                \PHP_MAJOR_VERSION === 7
+                    ? '~^Unbinding \$this of (?:a )?(?:method|closure) is deprecated$~s'
+                    : '~^Cannot unbind \$this of (?:method|closure using \$this)$~s',
+                $errStr
+            )) {
+                $hasThis = true;
+            } else {
+                throw (new Exception('Unexpected error'))
+                    ->addMoreInfo('error', $errStr);
+            }
+        });
+        $fxUnbound = \Closure::bind($fx, null);
+        restore_error_handler();
+
+        // there is no warning in PHP 7.3, so detect $this from code, remove once PHP 7.3 support is dropped
+        if (\PHP_MAJOR_VERSION <= 7 && \PHP_MINOR_VERSION <= 3) {
+            $funcRefl = new \ReflectionFunction($fx);
+            if ($funcRefl->getEndLine() === $funcRefl->getStartLine()) {
+                throw new \atk4\ui\Exception('Closure body to extract must be on separate lines');
+            }
+
+            $funcCode = implode("\n", array_slice(
+                explode("\n", file_get_contents($funcRefl->getFileName())),
+                $funcRefl->getStartLine(),
+                $funcRefl->getEndLine() - $funcRefl->getStartLine() - 1
+            ));
+
+            if (str_contains($funcCode, '$this')) {
+                $hasThis = true;
+            }
+        }
+
+        return $hasThis ? $fx : $fxUnbound;
+    }
+
     /**
      * Add another callback to be executed during hook($hook_spot);.
      *
@@ -78,6 +125,8 @@ trait HookTrait
     public function onHook(string $spot, \Closure $fx = null, array $args = [], int $priority = 5)
     {
         $this->_rebindHooksIfCloned();
+
+        $fx = $this->_unbindThisFromHookIfNotUsed($fx);
 
         if (!isset($this->hooks[$spot][$priority])) {
             $this->hooks[$spot][$priority] = [];

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -104,15 +104,15 @@ trait HookTrait
         $fxScopeClassRefl = $fxRefl->getClosureScopeClass();
         $fxThis = $fxRefl->getClosureThis();
         if ($fxScopeClassRefl === null) {
-            $fxLong = static function ($ignore, ...$args) use ($fx) {
+            $fxLong = static function ($ignore, &...$args) use ($fx) {
                 return $fx(...$args);
             };
         } elseif ($fxThis === null) {
-            $fxLong = \Closure::bind(function ($ignore, ...$args) use ($fx) {
+            $fxLong = \Closure::bind(function ($ignore, &...$args) use ($fx) {
                 return $fx(...$args);
             }, null, $fxScopeClassRefl->getName());
         } else {
-            $fxLong = \Closure::bind(function ($ignore, ...$args) use ($fx) {
+            $fxLong = \Closure::bind(function ($ignore, &...$args) use ($fx) {
                 return \Closure::bind($fx, $this)(...$args);
             }, $fxThis, $fxScopeClassRefl->getName());
         }
@@ -127,7 +127,7 @@ trait HookTrait
      */
     public function onHookDynamic(string $spot, \Closure $getFxThisFx, \Closure $fx, array $args = [], int $priority = 5): int
     {
-        $fxLong = function (...$args) use ($getFxThisFx, $fx) {
+        $fxLong = function (&...$args) use ($getFxThisFx, $fx) {
             $fxThis = $getFxThisFx($this);
             if ($fxThis === null) {
                 throw new Exception('New $this can not be null');

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -66,16 +66,12 @@ trait HookTrait
     /**
      * Add another callback to be executed during hook($hook_spot);.
      *
-     * If priority is negative, then hooks will be executed in reverse order.
-     *
-     * @param string   $spot     Hook identifier to bind on
-     * @param \Closure $fx       Will be called on hook()
-     * @param array    $args     Arguments are passed to $fx
-     * @param int      $priority Lower priority is called sooner
+     * Lower priority is called sooner. If priority is negative,
+     * then hooks will be executed in reverse order.
      *
      * @return int Index under which the hook was added
      */
-    public function onHook(string $spot, \Closure $fx = null, array $args = [], int $priority = 5)
+    public function onHook(string $spot, \Closure $fx, array $args = [], int $priority = 5): int
     {
         $this->_rebindHooksIfCloned();
 
@@ -97,9 +93,8 @@ trait HookTrait
     /**
      * Delete all hooks for specified spot, priority and index.
      *
-     * @param string   $spot            Hook identifier
-     * @param int|null $priority        Filter specific priority, null for all
-     * @param int      $priorityIsIndex Filter by index instead of priority
+     * @param int|null $priority        filter specific priority, null for all
+     * @param int      $priorityIsIndex filter by index instead of priority
      *
      * @return static
      */
@@ -124,9 +119,8 @@ trait HookTrait
     /**
      * Returns true if at least one callback is defined for this hook.
      *
-     * @param string   $spot            Hook identifier
-     * @param int|null $priority        Filter specific priority, null for all
-     * @param int      $priorityIsIndex Filter by index instead of priority
+     * @param int|null $priority        filter specific priority, null for all
+     * @param int      $priorityIsIndex filter by index instead of priority
      */
     public function hookHasCallbacks(string $spot, int $priority = null, bool $priorityIsIndex = false): bool
     {
@@ -152,9 +146,6 @@ trait HookTrait
 
     /**
      * Execute all closures assigned to $hook_spot.
-     *
-     * @param string $spot Hook identifier
-     * @param array  $args Additional arguments to closures
      *
      * @return mixed Array of responses indexed by hook indexes or value specified to breakHook
      */

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -119,6 +119,18 @@ trait HookTrait
     }
 
     /**
+     * Same as onHookShort() except callback is specified by a target object method.
+     *
+     * @return int index under which the hook was added
+     */
+    public function onHookMethod(string $spot, string $methodName, array $args = [], int $priority = 5): int
+    {
+        return $this->onHookShort($spot, function (...$args) use ($methodName) {
+            return $this->{$methodName}(...$args);
+        }, $args, $priority);
+    }
+
+    /**
      * Delete all hooks for specified spot, priority and index.
      *
      * @param int|null $priority        filter specific priority, null for all

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -301,6 +301,7 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m = $makeMock();
         $m->onHook('inc', static function () {});
         $m->onHookShort('inc', static function () {});
+        $m->onHookShort('null_scope_class', \Closure::fromCallable('trim'), ['x']);
         $m = clone $m;
         foreach ($m->hook('inc') as $hookRes) {
             $this->assertNull($hookRes);
@@ -337,6 +338,7 @@ class HookMock
         ++$this->result;
     }
 }
+
 class HookWithDynamicMethodMock extends HookMock
 {
     use \atk4\core\DynamicMethodTrait;

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -382,6 +382,41 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $this->assertSame(5, $m->result);
         $this->assertSame(3, $mCloned->result);
     }
+
+    public function testPassByReference()
+    {
+        $value = 0;
+        $m = new HookMock();
+        $m->onHook('inc', function ($ignoreObject, $ignore1st, int &$value) {
+            ++$value;
+        });
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(1, $value);
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(2, $value);
+
+        $value = 0;
+        $m = new HookMock();
+        $m->onHookShort('inc', function ($ignore1st, int &$value) {
+            ++$value;
+        });
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(1, $value);
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(2, $value);
+
+        $value = 0;
+        $m = new HookMock();
+        $m->onHookDynamic('inc', function () use ($m) {
+            return clone $m;
+        }, function ($ignoreObject, $ignore1st, int &$value) {
+            ++$value;
+        });
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(1, $value);
+        $m->hook('inc', ['x', &$value]);
+        $this->assertSame(2, $value);
+    }
 }
 
 // @codingStandardsIgnoreStart

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -302,10 +302,9 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m->hook('inc');
 
         // callback bound to a different object - without $this used
-        // not supported yet
-        //$m->onHook('inc', (clone $m)->makeCallbackWithoutThisUsed());
-        //$m = clone $m;
-        //$m->hook('inc');
+        $m->onHook('inc', (clone $m)->makeCallbackWithoutThisUsed());
+        $m = clone $m;
+        $m->hook('inc');
 
         // callback bound to a different object - with $this used
         $m->onHook('inc', (clone $m)->makeCallbackWithThisUsed());

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -269,19 +269,10 @@ class HookTraitTest extends AtkPhpunit\TestCase
     public function testCloningSafety()
     {
         $m = new class() extends HookMock {
-            public function makeCallbackWithoutThisUsed(): \Closure
+            public function makeCallback(): \Closure
             {
                 return function () {
                     return 'test';
-                };
-            }
-
-            public function makeCallbackWithThisUsed(): \Closure
-            {
-                return function () {
-                    $this->test = 'test';
-
-                    return $this->test;
                 };
             }
         };
@@ -291,23 +282,13 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m = clone $m;
         $m->hook('inc');
 
-        // callback bound to the same object - without $this used
-        $m->onHook('inc', $m->makeCallbackWithoutThisUsed());
+        // callback bound to the same object
+        $m->onHook('inc', $m->makeCallback());
         $m = clone $m;
         $m->hook('inc');
 
-        // callback bound to the same object - with $this used
-        $m->onHook('inc', $m->makeCallbackWithThisUsed());
-        $m = clone $m;
-        $m->hook('inc');
-
-        // callback bound to a different object - without $this used
-        $m->onHook('inc', (clone $m)->makeCallbackWithoutThisUsed());
-        $m = clone $m;
-        $m->hook('inc');
-
-        // callback bound to a different object - with $this used
-        $m->onHook('inc', (clone $m)->makeCallbackWithThisUsed());
+        // callback bound to a different object
+        $m->onHook('inc', (clone $m)->makeCallback());
         $m = clone $m;
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Object can not be cloned with hook bound to a different object than this');

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -315,6 +315,10 @@ class HookTraitTest extends AtkPhpunit\TestCase
         foreach ($m->hook('inc') as $hookRes) {
             $this->assertSame($m, $hookRes);
         }
+        $m = clone $m; // clone twice
+        foreach ($m->hook('inc') as $hookRes) {
+            $this->assertSame($m, $hookRes);
+        }
 
         // callback bound to a different object
         $m = $makeMock();

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -323,8 +323,8 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m->onHookShort('inc', static function () {});
         $m->onHookShort('null_scope_class', \Closure::fromCallable('trim'), ['x']);
         $m = clone $m;
-        foreach ($m->hook('inc') as $hookRes) {
-            $this->assertNull($hookRes);
+        foreach ($m->hook('inc') as $v) {
+            $this->assertNull($v);
         }
 
         // callback bound to the same object
@@ -333,14 +333,19 @@ class HookTraitTest extends AtkPhpunit\TestCase
         $m->onHookShort('inc', $m->makeCallback());
         $m->onHookMethod('inc', 'incMethod');
         $m = clone $m;
-        foreach ($m->hook('inc') as $hookRes) {
-            $this->assertSame($m, $hookRes);
+        foreach ($m->hook('inc') as $v) {
+            $this->assertSame($m, $v);
         }
-        $m = clone $m; // clone twice
-        foreach ($m->hook('inc') as $hookRes) {
-            $this->assertSame($m, $hookRes);
+        $this->assertSame(1, $m->result);
+        foreach ($m->hook('inc') as $v) { // 2nd dispatch
+            $this->assertSame($m, $v);
         }
         $this->assertSame(2, $m->result);
+        $m = clone $m; // 2nd clone
+        foreach ($m->hook('inc') as $v) {
+            $this->assertSame($m, $v);
+        }
+        $this->assertSame(3, $m->result);
 
         // callback bound to a different object
         $m = $makeMock();


### PR DESCRIPTION
fixes https://github.com/atk4/core/issues/212

merge once https://github.com/atk4/data/pull/711 is finished

(not a direct bug, but it leads to bugs when target object is cloned)

no BC break - because later https://github.com/atk4/core/pull/275 PR

this PR solves a cloning issue when `onHook` is called with bounded Closured to other object than `$this`, like in:
https://github.com/atk4/data/blob/9ef78eab556930994b388270cb01703674c08217/src/Reference/HasOne.php#L213