### PR TITLE
Make hook check less strict - check only for the same class name

### DIFF
--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -55,6 +55,7 @@ trait HookTrait
                         // TODO we throw only if the class name is the same, otherwise the check is too strict
                         // and on a bad side - we should not throw when an object with a hook is cloned,
                         // but instead we should throw once the closure this object is cloned
+                        // example of legit use: https://github.com/atk4/audit/blob/eb9810e085a40caedb435044d7318f4d8dd93e11/src/Controller.php#L85
                         if (get_class($fxThis) === get_class($this->_hookOrigThis) || preg_match('~^atk4\\\\(?:core|dsql|data)~', get_class($fxThis))) {
                             throw (new Exception('Object can not be cloned with hook bound to a different object than this'))
                                 ->addMoreInfo('closure_file', $fxRefl->getFileName())

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -52,9 +52,16 @@ trait HookTrait
                     }
 
                     if ($fxThis !== $this->_hookOrigThis) {
-                        throw (new Exception('Object can not be cloned with hook bound to a different object than this'))
-                            ->addMoreInfo('closure_file', $fxRefl->getFileName())
-                            ->addMoreInfo('closure_start_line', $fxRefl->getStartLine());
+                        // TODO we throw only if the class name is the same, otherwise the check is too strict
+                        // and on a bad side - we should not throw when an object with a hook is cloned,
+                        // but instead we should throw once the closure this object is cloned
+                        if (get_class($fxThis) === get_class($this->_hookOrigThis) || preg_match('~^atk4\\\\(?:core|dsql|data)~', get_class($fxThis))) {
+                            throw (new Exception('Object can not be cloned with hook bound to a different object than this'))
+                                ->addMoreInfo('closure_file', $fxRefl->getFileName())
+                                ->addMoreInfo('closure_start_line', $fxRefl->getStartLine());
+                        }
+
+                        continue;
                     }
 
                     $hookData[0] = \Closure::bind($hookData[0], $this);


### PR DESCRIPTION
introduced in https://github.com/atk4/core/pull/272

for core/dsql/data repos, we can keep the check active as long as there is no strong usecase to disable it, this strick check can payoff with better cloning safety

only Dark can merge this one :)