### PR TITLE
Move "app" and "owner" props to getter/setter

### DIFF
--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -40,7 +40,7 @@ DebugTrait::
     $this->debug('User {user} created', ['user'=>$user]);
 
 The Application itself can use DebugTrait too and normally should do, making it
-possible to use ``$this->app->debug()``.
+possible to use ``$this->getApp()->debug()``.
 
 Various objects may implement DebugTrait and also invoke $this->debug(), but in
 most cases this will simply be ignored right away unless you manually enable
@@ -53,15 +53,15 @@ debugging for the object::
     $obj1->debug('test1'); // will go to logger
     $obj2->debug('test2'); // will not go to logger because debug is not enabled for this object
 
-Executing debug will look for ``$this->app`` link and if the application
-implements ``Psr\Log\LoggerInterface``, then ``$this->app->log()`` will be
+Executing debug will look for ``$this->getApp()`` link and if the application
+implements ``Psr\Log\LoggerInterface``, then ``$this->getApp()->log()`` will be
 called using LogLevel DEBUG.
 
 Log
 ---
 
 Log method will log message every time. DebugTrait implements the ``log()``
-method which will either display information on the STDOUT (if ``$this->app``
+method which will either display information on the STDOUT (if ``$this->getApp()``
 does not exist or does not implement PSR-3)
 
 Message

--- a/docs/dynamicmethod.rst
+++ b/docs/dynamicmethod.rst
@@ -20,7 +20,7 @@ If object has application scope :php:trait:`AppScopeTrait` and the application
 implements :php:trait:`HookTrait` then executing $object->test() will also
 look for globally-registered method inside the application::
 
-    $object->app->addGlobalMethod('test', function($app, $o, $args){
+    $object->getApp()->addGlobalMethod('test', function($app, $o, $args){
         echo 'hello, '.$args[0];
     });
 

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -100,6 +100,7 @@ trait AppScopeTrait
     public function getApp()
     {
         $this->assertNoDirectAppAssignment();
+        $this->assertInstanceOfApp($this->_app);
 
         return $this->_app;
     }

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -115,7 +115,9 @@ trait AppScopeTrait
         $this->assertNoDirectAppAssignment();
         $this->assertInstanceOfApp($app);
         if ($this->issetApp() && $this->getApp() !== $app) {
-            throw new Exception('App can not be replaced');
+            if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
+                throw new Exception('App can not be replaced');
+            }
         }
 
         $this->_app = $app;

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -114,8 +114,8 @@ trait AppScopeTrait
     {
         $this->assertNoDirectAppAssignment();
         $this->assertInstanceOfApp($app);
-        if ($this->issetApp()) {
-            throw new Exception('App already set');
+        if ($this->issetApp() && $this->getApp() !== $app) {
+            throw new Exception('App can not be replaced');
         }
 
         $this->_app = $app;

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -22,11 +22,16 @@ trait AppScopeTrait
     public $_appScopeTrait = true;
 
     /**
-     * Always points to current Application.
-     *
-     * @var \atk4\ui\App
+     * @internal to be removed in Jan 2021, keep until then to prevent wrong assignments
      */
-    public $app;
+    private $app;
+
+    /**
+     * Always points to current application.
+     *
+     * @var App
+     */
+    private $_app;
 
     /**
      * When using mechanism for ContainerTrait, they inherit name of the
@@ -59,4 +64,61 @@ trait AppScopeTrait
      * @var array
      */
     public $unique_hashes = [];
+
+    private function assertInstanceOfApp(object $app): void
+    {
+        // called from phpunit, allow to use/test this trait without \atk4\ui\App class
+        if (class_exists(\PHPUnit\Framework\TestCase::class, false)) {
+            return;
+        }
+
+        if (!$app instanceof \atk4\ui\App) {
+            throw new Exception('App must be instance of \atk4\ui\App');
+        }
+    }
+
+    /**
+     * To be removed in Jan 2021.
+     */
+    private function assertNoDirectAppAssignment(): void
+    {
+        if ($this->app !== null) {
+            throw new Exception('App can not be assigned directly');
+        }
+    }
+
+    public function issetApp(): bool
+    {
+        $this->assertNoDirectAppAssignment();
+
+        return $this->_app !== null;
+    }
+
+    /**
+     * @return \atk4\ui\App
+     */
+    public function getApp()
+    {
+        $this->assertNoDirectAppAssignment();
+
+        return $this->_app;
+    }
+
+    /**
+     * @param \atk4\ui\App $app
+     *
+     * @return static
+     */
+    public function setApp(object $app)
+    {
+        $this->assertNoDirectAppAssignment();
+        $this->assertInstanceOfApp($app);
+        if ($this->issetApp()) {
+            throw new Exception('App already set');
+        }
+
+        $this->_app = $app;
+
+        return $this;
+    }
 }

--- a/src/AtkPhpunit/TestCase.php
+++ b/src/AtkPhpunit/TestCase.php
@@ -17,9 +17,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return mixed
      */
-    public function &callProtected(object $obj, string $name, ...$args)
+    public function &callProtected(object $obj, string $name, &...$args)
     {
-        return \Closure::bind(static function &() use ($obj, $name, $args) {
+        return \Closure::bind(static function &() use ($obj, $name, &$args) {
             $objRefl = new \ReflectionClass($obj);
             if ($objRefl
                 ->getMethod(!$objRefl->hasMethod($name) && $objRefl->hasMethod('__call') ? '__call' : $name)
@@ -49,7 +49,30 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Fake test. Otherwise Travis gives warning that there are no tests in here.
+     * Sets protected property value.
+     *
+     * NOTE: this method must only be used for low-level functionality, not
+     * for general test-scripts.
+     *
+     * @param mixed $value
+     *
+     * @return static
+     */
+    public function setProtected(object $obj, string $name, &$value, bool $byReference = false)
+    {
+        \Closure::bind(static function () use ($obj, &$value, $byReference) {
+            if ($byReference) {
+                $obj->{$name} = &$value;
+            } else {
+                $obj->{$name} = $value;
+            }
+        }, null, $obj)();
+
+        return $this;
+    }
+
+    /**
+     * Fake test. Otherwise phpunit gives warning that there are no tests in here.
      *
      * @doesNotPerformAssertions
      */

--- a/src/AtkPhpunit/TestCase.php
+++ b/src/AtkPhpunit/TestCase.php
@@ -17,9 +17,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return mixed
      */
-    public function &callProtected(object $obj, string $name, &...$args)
+    public function &callProtected(object $obj, string $name, ...$args)
     {
-        return \Closure::bind(static function &() use ($obj, $name, &$args) {
+        return \Closure::bind(static function &() use ($obj, $name, $args) {
             $objRefl = new \ReflectionClass($obj);
             if ($objRefl
                 ->getMethod(!$objRefl->hasMethod($name) && $objRefl->hasMethod('__call') ? '__call' : $name)

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -48,7 +48,7 @@ trait CollectionTrait
 
         // Carry on reference to application if we have appScopeTraits set
         if (isset($this->_appScopeTrait) && isset($item->_appScopeTrait)) {
-            $item->app = $this->app;
+            $item->setApp($this->getApp());
         }
 
         // Calculate long "name" but only if both are trackables
@@ -159,11 +159,11 @@ trait CollectionTrait
                         $this->_appScopeTrait = $app !== null;
 
                         try {
-                            $this->app = $app;
+                            $this->setApp($app);
 
                             return $this->_shorten($desired);
                         } finally {
-                            $this->app = null; // important for GC
+                            $this->_app = null; // important for GC
                         }
                     }
                 };
@@ -172,6 +172,6 @@ trait CollectionTrait
             return $factory->collectionTraitHelper;
         }, null, Factory::class)();
 
-        return $collectionTraitHelper->shorten($this->_appScopeTrait ? $this->app : null, $desired);
+        return $collectionTraitHelper->shorten($this->_appScopeTrait ? $this->getApp() : null, $desired);
     }
 }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -100,7 +100,7 @@ trait CollectionTrait
         $this->{$collectionName} = array_map(function ($item) {
             $item = clone $item;
             if (isset($item->_trackableTrait) && $item->issetOwner()) {
-                $item->setOwner($this);
+                $item->unsetOwner()->setOwner($this);
             }
 
             return $item;

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -54,10 +54,7 @@ trait CollectionTrait
         // Calculate long "name" but only if both are trackables
         if (isset($item->_trackableTrait)) {
             $item->short_name = $name;
-            if ($item->owner !== null) {
-                throw new Exception('Element owner is already set');
-            }
-            $item->owner = $this;
+            $item->setOwner($this);
             if (isset($this->_trackableTrait)) {
                 $item->name = $this->_shorten_ml($this->name . '-' . $collection . '_' . $name);
             }
@@ -102,8 +99,8 @@ trait CollectionTrait
     {
         $this->{$collectionName} = array_map(function ($item) {
             $item = clone $item;
-            if (isset($item->owner)) {
-                $item->owner = $this;
+            if (isset($item->_trackableTrait) && $item->issetOwner()) {
+                $item->setOwner($this);
             }
 
             return $item;

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -89,7 +89,7 @@ trait ContainerTrait
     {
         // Carry on reference to application if we have appScopeTraits set
         if (isset($this->_appScopeTrait) && isset($element->_appScopeTrait)) {
-            $element->app = $this->app;
+            $element->setApp($this->getApp());
         }
 
         // If element is not trackable, then we don't need to do anything with it
@@ -182,11 +182,9 @@ trait ContainerTrait
      */
     protected function _shorten(string $desired): string
     {
-        if (
-            isset($this->_appScopeTrait) &&
-            isset($this->app->max_name_length) &&
-            mb_strlen($desired) > $this->app->max_name_length
-        ) {
+        if (isset($this->_appScopeTrait)
+            && isset($this->getApp()->max_name_length)
+            && mb_strlen($desired) > $this->getApp()->max_name_length) {
             /*
              * Basic rules: hash is 10 character long (8+2 for separator)
              * We need at least 5 characters on the right side. Total must not exceed
@@ -194,15 +192,15 @@ trait ContainerTrait
              * max-15
              */
             $len = mb_strlen($desired);
-            $left = $len - ($len - 10) % ($this->app->max_name_length - 15) - 5;
+            $left = $len - ($len - 10) % ($this->getApp()->max_name_length - 15) - 5;
 
             $key = mb_substr($desired, 0, $left);
             $rest = mb_substr($desired, $left);
 
-            if (!isset($this->app->unique_hashes[$key])) {
-                $this->app->unique_hashes[$key] = '_' . dechex(crc32($key));
+            if (!isset($this->getApp()->unique_hashes[$key])) {
+                $this->getApp()->unique_hashes[$key] = '_' . dechex(crc32($key));
             }
-            $desired = $this->app->unique_hashes[$key] . '__' . $rest;
+            $desired = $this->getApp()->unique_hashes[$key] . '__' . $rest;
         }
 
         return $desired;

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -130,10 +130,7 @@ trait ContainerTrait
                 ->addMoreInfo('arg2', $args);
         }
 
-        if ($element->owner !== null) {
-            throw new Exception('Element owner is already set');
-        }
-        $element->owner = $this;
+        $element->setOwner($this);
         $element->short_name = $args[0];
         if (isset($this->_nameTrait)) {
             $element->name = $this->_shorten($this->name . '_' . $element->short_name);

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -49,7 +49,7 @@ trait DebugTrait
 
         // if debug is enabled, then log it
         if ($this->debug) {
-            if (!isset($this->app) || !isset($this->app->logger) || !$this->app->logger instanceof \Psr\Log\LoggerInterface) {
+            if (!isset($this->_appScopeTrait) || !$this->issetApp() || !$this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
                 $message = '[' . static::class . ']: ' . $message;
             }
             $this->log(LogLevel::DEBUG, $message, $context);
@@ -68,8 +68,8 @@ trait DebugTrait
      */
     public function log($level, $message, array $context = [])
     {
-        if (isset($this->app) && isset($this->app->logger) && $this->app->logger instanceof \Psr\Log\LoggerInterface) {
-            $this->app->logger->log($level, $message, $context);
+        if (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
+            $this->getApp()->logger->log($level, $message, $context);
         } else {
             $this->_echo_stderr($message . "\n");
         }
@@ -85,10 +85,10 @@ trait DebugTrait
      */
     public function userMessage(string $message, array $context = [])
     {
-        if (isset($this->app) && $this->app instanceof \atk4\core\AppUserNotificationInterface) {
-            $this->app->userNotification($message, $context);
-        } elseif (isset($this->app) && $this->app instanceof \Psr\Log\LoggerInterface) {
-            $this->app->log('warning', 'Could not notify user about: ' . $message, $context);
+        if (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \atk4\core\AppUserNotificationInterface) {
+            $this->getApp()->userNotification($message, $context);
+        } elseif (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \Psr\Log\LoggerInterface) {
+            $this->getApp()->log('warning', 'Could not notify user about: ' . $message, $context);
         } else {
             $this->_echo_stderr("Could not notify user about: {$message}\n");
         }

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -55,9 +55,9 @@ trait DynamicMethodTrait
             return $ret;
         }
 
-        if (isset($this->_appScopeTrait) && isset($this->app->_hookTrait)) {
+        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
             array_unshift($args, $this);
-            if ($ret = $this->app->hook($this->buildMethodHookName($name, true), $args)) {
+            if ($ret = $this->getApp()->hook($this->buildMethodHookName($name, true), $args)) {
                 return $ret;
             }
         }
@@ -136,7 +136,7 @@ trait DynamicMethodTrait
     public function addGlobalMethod(string $name, \Closure $fx): void
     {
         // AppScopeTrait and HookTrait for app are mandatory
-        if (!isset($this->_appScopeTrait) || !isset($this->app->_hookTrait)) {
+        if (!isset($this->_appScopeTrait) || !isset($this->getApp()->_hookTrait)) {
             throw new Exception('You need AppScopeTrait and HookTrait traits, see docs');
         }
 
@@ -145,7 +145,7 @@ trait DynamicMethodTrait
                 ->addMoreInfo('name', $name);
         }
 
-        $this->app->onHook($this->buildMethodHookName($name, true), $fx);
+        $this->getApp()->onHook($this->buildMethodHookName($name, true), $fx);
     }
 
     /**
@@ -155,10 +155,9 @@ trait DynamicMethodTrait
      */
     public function hasGlobalMethod(string $name): bool
     {
-        return
-            isset($this->_appScopeTrait) &&
-            isset($this->app->_hookTrait) &&
-            $this->app->hookHasCallbacks($this->buildMethodHookName($name, true));
+        return isset($this->_appScopeTrait)
+            && isset($this->getApp()->_hookTrait)
+            && $this->getApp()->hookHasCallbacks($this->buildMethodHookName($name, true));
     }
 
     /**
@@ -168,8 +167,8 @@ trait DynamicMethodTrait
      */
     public function removeGlobalMethod(string $name): void
     {
-        if (isset($this->_appScopeTrait) && isset($this->app->_hookTrait)) {
-            $this->app->removeHook($this->buildMethodHookName($name, true));
+        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
+            $this->getApp()->removeHook($this->buildMethodHookName($name, true));
         }
     }
 }

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -81,6 +81,23 @@ trait TrackableTrait
     }
 
     /**
+     * Should be used only when object is cloned.
+     *
+     * @return static
+     */
+    public function unsetOwner()
+    {
+        $this->assertNoDirectOwnerAssignment();
+        if (!$this->issetOwner()) {
+            throw new Exception('Owner not set');
+        }
+
+        $this->_owner = null;
+
+        return $this;
+    }
+
+    /**
      * If name of the object is omitted then it's naturally to name them
      * after the class. You can specify a different naming pattern though.
      */

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -21,11 +21,18 @@ trait TrackableTrait
     public $_trackableTrait = true;
 
     /**
+     * @internal to be removed in Jan 2021, keep until then to prevent wrong assignments
+     *
+     * @var object
+     */
+    private $owner;
+
+    /**
      * Link to (parent) object into which we added this object.
      *
      * @var object
      */
-    public $owner;
+    private $_owner;
 
     /**
      * Name of the object in owner's element array.
@@ -33,6 +40,45 @@ trait TrackableTrait
      * @var string
      */
     public $short_name;
+
+    /**
+     * To be removed in Jan 2021.
+     */
+    private function assertNoDirectOwnerAssignment(): void
+    {
+        if ($this->owner !== null) {
+            throw new Exception('Owner can not be assigned directly');
+        }
+    }
+
+    public function issetOwner(): bool
+    {
+        $this->assertNoDirectOwnerAssignment();
+
+        return $this->_owner !== null;
+    }
+
+    public function getOwner(): object
+    {
+        $this->assertNoDirectOwnerAssignment();
+
+        return $this->_owner;
+    }
+
+    /**
+     * @return static
+     */
+    public function setOwner(object $owner)
+    {
+        $this->assertNoDirectOwnerAssignment();
+        if ($this->issetOwner()) {
+            throw new Exception('Owner already set');
+        }
+
+        $this->_owner = $owner;
+
+        return $this;
+    }
 
     /**
      * If name of the object is omitted then it's naturally to name them
@@ -63,16 +109,16 @@ trait TrackableTrait
      */
     public function destroy(): void
     {
-        if ($this->owner !== null && isset($this->owner->_containerTrait)) {
-            $this->owner->removeElement($this->short_name);
+        if ($this->_owner !== null && isset($this->_owner->_containerTrait)) {
+            $this->_owner->removeElement($this->short_name);
 
             // GC remove reference to app is AppScope in use
-            if (isset($this->_appScopeTrait) && $this->issetApp() && isset($this->owner->_appScopeTrait)) {
+            if (isset($this->_appScopeTrait) && $this->issetApp()) {
                 $this->_app = null;
             }
 
             // GC : remove reference to owner
-            $this->owner = null;
+            $this->_owner = null;
         }
     }
 }

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -63,19 +63,12 @@ trait TrackableTrait
      */
     public function destroy(): void
     {
-        if (
-            isset($this->owner) &&
-            $this->owner->_containerTrait
-        ) {
+        if ($this->owner !== null && isset($this->owner->_containerTrait)) {
             $this->owner->removeElement($this->short_name);
 
             // GC remove reference to app is AppScope in use
-            if (
-                isset($this->app) &&
-                ($this->_appScopeTrait ?? false) &&
-                ($this->owner->_appScopeTrait ?? false)
-            ) {
-                $this->app = null;
+            if (isset($this->_appScopeTrait) && $this->issetApp() && isset($this->owner->_appScopeTrait)) {
+                $this->_app = null;
             }
 
             // GC : remove reference to owner

--- a/src/TranslatableTrait.php
+++ b/src/TranslatableTrait.php
@@ -23,16 +23,15 @@ trait TranslatableTrait
      *
      * @param string      $message    The message to be translated
      * @param array       $parameters Array of parameters used to translate message
-     * @param string|null $context    The domain for the message or null to use the default
+     * @param string|null $domain     The domain for the message or null to use the default
      * @param string|null $locale     The locale or null to use the default
      *
      * @return string The translated string
      */
     public function _($message, array $parameters = [], string $domain = null, string $locale = null): string
     {
-        // if App is present
-        if (isset($this->app) && method_exists($this->app, '_')) {
-            return $this->app->_($message, $parameters, $domain, $locale);
+        if (isset($this->_appScopeTrait) && $this->issetApp() && method_exists($this->getApp(), '_')) {
+            return $this->getApp()->_($message, $parameters, $domain, $locale);
         }
 
         return Translator::instance()->_($message, $parameters, $domain, $locale);

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -21,25 +21,27 @@ class AppScopeTraitTest extends AtkPhpunit\TestCase
     public function testConstruct()
     {
         $m = new AppScopeMock();
-        $m->app = 'myapp';
+        $fakeApp = new \stdClass();
+        $m->setApp($fakeApp);
 
-        $c = $m->add(new Child1());
-        $this->assertSame('myapp', $c->app);
+        $c = $m->add(new AppScopeChildBasic());
+        $this->assertSame($fakeApp, $c->getApp());
 
-        $c = $m->add(new Child2());
-        $this->assertFalse(isset($c->app));
+        $c = $m->add(new AppScopeChildWithoutAppScope());
+        $this->assertFalse(property_exists($c, 'app'));
+        $this->assertFalse(property_exists($c, '_app'));
 
         $m = new AppScopeMock2();
 
-        $c = $m->add(new Child1());
-        $this->assertFalse(isset($c->app));
+        $c = $m->add(new AppScopeChildBasic());
+        $this->assertFalse($c->issetApp());
 
         // test for GC
         $m = new AppScopeMock();
-        $m->app = $m;
-        $m->add($child = new Child3());
+        $m->setApp($m);
+        $m->add($child = new AppScopeChildTrackable());
         $child->destroy();
-        $this->assertNull($child->app);
+        $this->assertNull($this->getProtected($child, '_app'));
         $this->assertNull($child->owner);
     }
 }
@@ -67,17 +69,17 @@ class AppScopeMock2
     }
 }
 
-class Child1
+class AppScopeChildBasic
 {
     use AppScopeTrait;
 }
 
-class Child2
+class AppScopeChildWithoutAppScope
 {
     use TrackableTrait;
 }
 
-class Child3
+class AppScopeChildTrackable
 {
     use AppScopeTrait;
     use TrackableTrait;

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -42,7 +42,7 @@ class AppScopeTraitTest extends AtkPhpunit\TestCase
         $m->add($child = new AppScopeChildTrackable());
         $child->destroy();
         $this->assertNull($this->getProtected($child, '_app'));
-        $this->assertNull($child->owner);
+        $this->assertFalse($child->issetOwner());
     }
 }
 

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -55,7 +55,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
             $this->assertSame('app', $surname->getApp()->name);
 
             $this->assertSame('form-fields_surname', $surname->name);
-            $this->assertSame($surname->owner, $m);
+            $this->assertSame($surname->getOwner(), $m);
 
             $long = $m->addField('very-long-and-annoying-name-which-will-be-shortened', [CustomFieldMock::class]);
             $this->assertLessThan(21, strlen($long->name));

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -44,15 +44,15 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
     {
         try {
             $m = new CollectionMockWithApp();
-            $m->app = new class() {
+            $m->setApp(new class() {
                 public $name = 'app';
                 public $max_name_length = 20;
-            };
+            });
             $m->name = 'form';
 
             $surname = $m->addField('surname', [CustomFieldMock::class]);
 
-            $this->assertSame('app', $surname->app->name);
+            $this->assertSame('app', $surname->getApp()->name);
 
             $this->assertSame('form-fields_surname', $surname->name);
             $this->assertSame($surname->owner, $m);

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -55,7 +55,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
     public function testLongNames()
     {
         $app = new ContainerAppMock();
-        $app->app = $app;
+        $app->setApp($app);
         $app->max_name_length = 30;
         $m = $app->add(new ContainerAppMock(), 'quick-brown-fox');
         $m = $m->add(new ContainerAppMock(), 'jumps-over-a-lazy-dog');
@@ -84,7 +84,7 @@ class ContainerTraitTest extends AtkPhpunit\TestCase
     public function testLongNames2()
     {
         $app = new ContainerAppMock();
-        $app->app = $app;
+        $app->setApp($app);
         $app->max_name_length = 30;
         $app->name = 'my-app-name-is-pretty-long';
 
@@ -220,7 +220,7 @@ class ContainerAppMock
     {
         $n = $this->name;
 
-        $d = array_flip($this->app->unique_hashes);
+        $d = array_flip($this->getApp()->unique_hashes);
 
         for ($x = 1; $x < 100; ++$x) {
             @[$l, $r] = explode('__', $n);

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -59,7 +59,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
         $app->logger = $app;
 
         $m = new DebugMock();
-        $m->app = $app;
+        $m->setApp($app);
         $m->debug();
 
         $m->debug('debug test2');
@@ -83,7 +83,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
         $app->logger = $app;
 
         $m = new DebugMock();
-        $m->app = $app;
+        $m->setApp($app);
         $m->log('warning', 'debug test3');
 
         $this->assertSame(['warning', 'debug test3', []], $app->log);
@@ -103,7 +103,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
         $app = new DebugAppMock();
 
         $m = new DebugMock();
-        $m->app = $app;
+        $m->setApp($app);
         $m->userMessage('hello user');
 
         $this->assertSame(['warning', 'Could not notify user about: hello user', []], $app->log);
@@ -115,7 +115,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
         $app = new DebugAppMock2();
 
         $m = new DebugMock();
-        $m->app = $app;
+        $m->setApp($app);
         $m->userMessage('hello user');
 
         $this->assertSame(['hello user', []], $app->message);
@@ -132,7 +132,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
 
         $m = new DebugMock();
         $app->logger = $app;
-        $m->app = $app;
+        $m->setApp($app);
 
         $this->triggerDebugTraceChange($m, 'test1'); // difference is 1 line between calls
         $this->triggerDebugTraceChange($m, 'test1');
@@ -163,7 +163,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
 
         $m = new PsrMock();
         $app->logger = $app;
-        $m->app = $app;
+        $m->setApp($app);
 
         $m->info('i', ['x']);
         $this->assertSame(['info', 'i', ['x']], $app->log);
@@ -191,6 +191,7 @@ class DebugTraitTest extends AtkPhpunit\TestCase
 // @codingStandardsIgnoreStart
 class DebugMock
 {
+    use AppScopeTrait;
     use DebugTrait {
         _echo_stderr as __echo_stderr;
     }

--- a/tests/DynamicMethodTraitTest.php
+++ b/tests/DynamicMethodTraitTest.php
@@ -62,7 +62,7 @@ class DynamicMethodTraitTest extends AtkPhpunit\TestCase
         // can't call method without HookTrait or AppScope+Hook traits
         $this->expectException(Exception::class);
         $m = new GlobalMethodObjectMock();
-        $m->app = new GlobalMethodAppMock();
+        $m->setApp(new GlobalMethodAppMock());
         $m->unknownMethod();
     }
 
@@ -141,10 +141,10 @@ class DynamicMethodTraitTest extends AtkPhpunit\TestCase
         $app = new GlobalMethodAppMock();
 
         $m = new GlobalMethodObjectMock();
-        $m->app = $app;
+        $m->setApp($app);
 
         $m2 = new GlobalMethodObjectMock();
-        $m2->app = $app;
+        $m2->setApp($app);
 
         $m->addGlobalMethod('sum', function ($m, $obj, $a, $b) {
             return $a + $b;
@@ -163,7 +163,7 @@ class DynamicMethodTraitTest extends AtkPhpunit\TestCase
         $this->expectException(Exception::class);
 
         $m = new GlobalMethodObjectMock();
-        $m->app = new GlobalMethodAppMock();
+        $m->setApp(new GlobalMethodAppMock());
 
         $m->addGlobalMethod('sum', function ($m, $obj, $a, $b) {
             return $a + $b;

--- a/tests/TranslatorAdapterAppTest.php
+++ b/tests/TranslatorAdapterAppTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace atk4\core\tests;
 
+use atk4\core\AppScopeTrait;
 use atk4\core\TranslatableTrait;
 
 class TranslatorAdapterAppTest extends TranslatorAdapterBase
@@ -15,10 +16,11 @@ class TranslatorAdapterAppTest extends TranslatorAdapterBase
         };
 
         $mock = new class() {
+            use AppScopeTrait;
             use TranslatableTrait;
         };
 
-        $mock->app = $app;
+        $mock->setApp($app);
 
         return $mock;
     }


### PR DESCRIPTION
there are at least 3 reasons why:
- have more control (type check, reassign, enforce presence in some situations like after init, ...)
- allow to use WeakReference (for owner to allow to release child object based on ref counting not requiring expensive/slow GC)
- make sure we do not get/set properties on object not "implementing" given traits

if AppScopeTrait trait is present, we may even want to assert if App is set in any init

### How to update your code?
1. replace `->owner->` with `->getOwner()->`
2. search for `->owner(?!\w)` and adjust to `getOwner()`, `setOwner()`, `issetOwner()` manually
3. do the same with app property