### PR TITLE
Drop PHP v7.3 support and upgrade CS Fixer to v3

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Check Coding Style (only for CodingStyle)
         if: matrix.type == 'CodingStyle'
-        run: vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots
+        run: vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --verbose
 
       - name: Run Static Analysis (only for StaticAnalysis)
         if: matrix.type == 'StaticAnalysis'
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', 'latest']
+        php: ['7.4', 'latest']
         type: ['Phpunit']
         include:
           - php: 'latest'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,13 +8,13 @@ $finder = PhpCsFixer\Finder::create()
         'vendor',
     ]);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true,
-        '@PhpCsFixer:risky' =>true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PhpCsFixer:risky' => true,
+        '@PHP74Migration:risky' => true,
+        '@PHP74Migration' => true,
 
         // required by PSR-12
         'concat_space' => [
@@ -33,9 +33,6 @@ return PhpCsFixer\Config::create()
         ],
         'native_constant_invocation' => true,
         'native_function_invocation' => false,
-        'non_printable_character' => [
-            'use_escape_sequences_in_strings' => true,
-        ],
         'void_return' => false,
         'blank_line_before_statement' => [
             'statements' => ['break', 'continue', 'declare', 'return', 'throw', 'exit'],
@@ -53,13 +50,16 @@ return PhpCsFixer\Config::create()
         'phpdoc_add_missing_param_annotation' => false,
         'return_assignment' => false,
         'comment_to_phpdoc' => false,
-        'list_syntax' => ['syntax' => 'short'],
         'general_phpdoc_annotation_remove' => [
             'annotations' => ['author', 'copyright', 'throws'],
         ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => false,
         ],
+
+        // fn => without curly brackets is less readable,
+        // also prevent bounding of unwanted variables for GC
+        'use_arrow_functions' => false,
     ])
     ->setFinder($finder)
-    ->setCacheFile(__DIR__ . '/.php_cs.cache');
+    ->setCacheFile(sys_get_temp_dir() . '/php-cs-fixer.' . md5(__DIR__) . '.cache');

--- a/composer.json
+++ b/composer.json
@@ -41,19 +41,19 @@
     "require-dev": {
         "atk4/data": "dev-develop",
         "ergebnis/composer-normalize": "^2.13",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "johnkary/phpunit-speedtrap": "^3.2",
         "phpstan/phpstan": "^0.12.58",
-        "phpunit/phpunit": ">=9.1",
+        "phpunit/phpunit": ">=9.3",
         "symfony/contracts": ">=1.1"
     },
     "require-dev-release": {
         "atk4/data": "~3.0.0",
         "ergebnis/composer-normalize": "^2.13",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "johnkary/phpunit-speedtrap": "^3.2",
         "phpstan/phpstan": "^0.12.58",
-        "phpunit/phpunit": ">=9.1",
+        "phpunit/phpunit": ">=9.3",
         "symfony/contracts": ">=1.1"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,9 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.4.0",
         "ext-json": "*",
         "psr/log": "~1.0",
-        "symfony/polyfill-php74": "^1.17",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-php81": "^1.22",
         "symfony/yaml": "^3.4 || ^4.4 || ^5.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
     <listeners>
         <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener" />
     </listeners>
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">src</directory>
         </include>

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,8 +6,7 @@ namespace Atk4\Core;
 
 class Factory
 {
-    /** @var Factory */
-    private static $_instance;
+    private static ?Factory $_instance = null;
 
     protected function __construct()
     {

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -11,7 +11,7 @@ namespace Atk4\Core;
  */
 trait StaticAddToTrait
 {
-    // use DiContainerTrait; // uncomment once PHP7.2 support is dropped
+    use DiContainerTrait;
 
     private static function _addTo_add(object $parent, object $object, array $addArgs, bool $skipAdd = false): void
     {

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -6,13 +6,11 @@ namespace Atk4\Core\Tests;
 
 use Atk4\Core\AtkPhpunit;
 use Atk4\Core\ContainerTrait;
-use Atk4\Core\DiContainerTrait;
 use Atk4\Core\StaticAddToTrait;
 use Atk4\Core\TrackableTrait;
 
 class StdSat extends \StdClass
 {
-    use DiContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
 }
 
@@ -27,13 +25,11 @@ class ContainerFactoryMockSat
 
 class TrackableMockSat
 {
-    use DiContainerTrait; // remove once PHP7.2 support is dropped
     use StaticAddToTrait;
     use TrackableTrait;
 }
 class DiMockSat
 {
-    use DiContainerTrait;
     use StaticAddToTrait;
 
     /** @var string */
@@ -46,7 +42,6 @@ class DiMockSat
 
 class DiConstructorMockSat
 {
-    use DiContainerTrait;
     use StaticAddToTrait;
 
     /** @var string */


### PR DESCRIPTION
to support using `WeakReference` and other new features like `fn`, typed properties