### PR TITLE
Add PHPStan to CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Configure PHP
         run: |
-          if [ -z "$LOG_COVERAGE" ]; then rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; fi
+          if [ -n "$LOG_COVERAGE" ]; then echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; else rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; fi
           php --version
 
       # trick composer that this is a "atk4/core:develop" dependency to install atk4/data
@@ -104,7 +104,7 @@ jobs:
 
       - name: Configure PHP
         run: |
-          if [ -z "$LOG_COVERAGE" ]; then rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; fi
+          if [ -n "$LOG_COVERAGE" ]; then echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; else rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; fi
           php --version
 
       # trick composer that this is a "atk4/core:develop" dependency to install atk4/data

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,8 @@ jobs:
         include:
           - php: 'latest'
             type: 'CodingStyle'
+          - php: 'latest'
+            type: 'StaticAnalysis'
     env:
       LOG_COVERAGE: ""
     steps:
@@ -52,8 +54,9 @@ jobs:
 
       - name: Install PHP dependencies
         run: |
-          if [ "${{ matrix.type }}" != "Phpunit" ]; then composer remove --no-interaction --no-update phpunit/phpunit johnkary/phpunit-speedtrap --dev ; fi
+          if [ "${{ matrix.type }}" != "Phpunit" ] && [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpunit/phpunit johnkary/phpunit-speedtrap --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
+          if [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpstan/phpstan --dev ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
 
       - name: Init
@@ -71,6 +74,12 @@ jobs:
       - name: Check Coding Style (only for CodingStyle)
         if: matrix.type == 'CodingStyle'
         run: vendor/bin/php-cs-fixer fix --dry-run --using-cache=no --diff --diff-format=udiff --verbose --show-progress=dots
+
+      - name: Run Static Analysis (only for StaticAnalysis)
+        if: matrix.type == 'StaticAnalysis'
+        run: |
+          echo "memory_limit = 1G" > /usr/local/etc/php/conf.d/custom-memory-limit.ini
+          vendor/bin/phpstan analyse
 
   unit-test:
     name: Unit
@@ -119,6 +128,7 @@ jobs:
         run: |
           if [ "${{ matrix.type }}" != "Phpunit" ] && [ "${{ matrix.type }}" != "Phpunit Lowest" ] && [ "${{ matrix.type }}" != "Phpunit Burn" ]; then composer remove --no-interaction --no-update phpunit/phpunit --no-update phpunit/phpunit johnkary/phpunit-speedtrap --dev ; fi
           if [ "${{ matrix.type }}" != "CodingStyle" ]; then composer remove --no-interaction --no-update friendsofphp/php-cs-fixer --dev ; fi
+          if [ "${{ matrix.type }}" != "StaticAnalysis" ]; then composer remove --no-interaction --no-update phpstan/phpstan --dev ; fi
           if [ "${{ matrix.php }}" == "8.0" ]; then composer config platform.php 7.4.5 ; fi
           composer install --no-suggest --ansi --prefer-dist --no-interaction --no-progress --optimize-autoloader
           if [ "${{ matrix.type }}" == "Phpunit Lowest" ]; then composer update  --ansi --prefer-dist --prefer-lowest --prefer-stable --no-interaction --no-progress --optimize-autoloader ; fi

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "atk4/data": "dev-develop",
     "friendsofphp/php-cs-fixer": "^2.16",
     "johnkary/phpunit-speedtrap": "^3.2",
+    "phpstan/phpstan": "^0.12.58",
     "phpunit/phpunit": ">=9.1",
     "symfony/contracts": ">=1.1"
   },
@@ -54,6 +55,7 @@
     "atk4/data": "~2.3.0",
     "friendsofphp/php-cs-fixer": "^2.16",
     "johnkary/phpunit-speedtrap": "^3.2",
+    "phpstan/phpstan": "^0.12.58",
     "phpunit/phpunit": ">=9.1",
     "symfony/contracts": ">=1.1"
   },

--- a/examples/test3.php
+++ b/examples/test3.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 require '../vendor/autoload.php';
 
-class MyClass
+class MyClass2
 {
     use \atk4\core\DynamicMethodTrait;
     use \atk4\core\HookTrait;
 }
 
-$c = new MyClass();
+$c = new MyClass2();
 
 $c->addMethod('mymethod', function ($c, $a, $b) {
     return $a + $b;
 });
 
+// @phpstan-ignore-next-line
 echo $c->mymethod(2, 3) . "\n";

--- a/examples/test5.php
+++ b/examples/test5.php
@@ -7,9 +7,9 @@ require '../vendor/autoload.php';
 function loopToCreateStack($test)
 {
     if ($test > 5) {
-        $exc_prev = new \Exception('Previous Exception');
+        $excPrev = new \Exception('Previous Exception');
 
-        $exc = (new atk4\core\Exception('Test value is too high', 200, $exc_prev))
+        $exc = (new \atk4\core\Exception('Test value is too high', 200, $excPrev))
             ->addMoreInfo('test', $test);
 
         throw $exc->addSolution('Suggested solution test');
@@ -20,6 +20,6 @@ function loopToCreateStack($test)
 
 try {
     loopToCreateStack(1);
-} catch (Exception $e) {
+} catch (\atk4\core\Exception $e) {
     echo $e->getJson();
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,7 @@ parameters:
 
     ignoreErrors:
         - '~^Unsafe usage of new static\(\)\.$~'
-        
+
         # fix unresolved \atk4\ui\App class
         - '~^(.+(?<!\w)atk4\\ui\\App.+|Call to an undefined method .+::(issetApp|getApp)\(\)\.)$~'
 
@@ -44,13 +44,10 @@ parameters:
 
         - '~^Cannot access property \$(foo|def) on array\|object\.$~'
         - '~^Call to an undefined method atk4\\core\\tests\\(DynamicMethodMock|DynamicMethodWithoutHookMock|GlobalMethodObjectMock)::\w+\(\)\.$~'
-        
+
         # PHPStan issue https://github.com/phpstan/phpstan/issues/4167
         - '~^Variable \$brokenBy in PHPDoc tag @var does not match assigned variable \$ret\.$~'
-        
-        # PHPStan issue https://github.com/phpstan/phpstan/issues/4168
-        - '~^Method .+::tryCall\(\) should return mixed but return statement is missing\.$~'
-    
+
     # some extra rules
     checkAlwaysTrueCheckTypeFunctionCall: true
     checkAlwaysTrueInstanceof: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,19 @@
+parameters:
+    level: 1
+    paths:
+        - ./
+    excludes_analyse:
+        - cache/
+        - build/
+        - vendor/
+
+    # TODO review once we drop PHP 7.x support
+    treatPhpDocTypesAsCertain: false
+
+    ignoreErrors:
+        - '~^Unsafe usage of new static\(\)\.$~'
+        
+        # TODO use interfaces for traits
+        - '~^(Class atk4\\ui\\App not found|Call to an undefined method .+::(issetApp|getApp)\(\))\.$~'
+        - '~^Call to an undefined method .+::(hook|onHook|hookHasCallbacks|removeHook)\(\)\.$~'
+        - '~^Access to an undefined property .+::\$(name|_appScopeTrait|_app)\.$~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,8 +13,8 @@ parameters:
     ignoreErrors:
         - '~^Unsafe usage of new static\(\)\.$~'
         
-        # TODO use interfaces for traits
-        - '~^(Class atk4\\ui\\App not found|Call to an undefined method .+::(issetApp|getApp)\(\))\.$~'
+        # fix unresolved \atk4\ui\App class
+        - '~^(.+(?<!\w)atk4\\ui\\App.+|Call to an undefined method .+::(issetApp|getApp)\(\)\.)$~'
 
         # for AppScopeTrait.php
         - '~^Call to an undefined method .+::setApp\(\)\.$~'
@@ -41,3 +41,24 @@ parameters:
         - '~^Call to an undefined method .+::unsetOwner\(\)\.$~'
         - '~^Call to an undefined method .+::getDesiredName\(\)\.$~'
         - '~^Access to an undefined property .+::\$short_name\.$~'
+
+        - '~^Cannot access property \$(foo|def) on array\|object\.$~'
+        - '~^Call to an undefined method atk4\\core\\tests\\(DynamicMethodMock|DynamicMethodWithoutHookMock|GlobalMethodObjectMock)::\w+\(\)\.$~'
+        
+        # PHPStan issue https://github.com/phpstan/phpstan/issues/4167
+        - '~^Variable \$brokenBy in PHPDoc tag @var does not match assigned variable \$ret\.$~'
+        
+        # PHPStan issue https://github.com/phpstan/phpstan/issues/4168
+        - '~^Method .+::tryCall\(\) should return mixed but return statement is missing\.$~'
+    
+    # some extra rules
+    checkAlwaysTrueCheckTypeFunctionCall: true
+    checkAlwaysTrueInstanceof: true
+    checkAlwaysTrueStrictComparison: true
+    checkExplicitMixedMissingReturn: true
+    checkFunctionNameCase: true
+# TODO    checkMissingClosureNativeReturnTypehintRule: true
+    reportMaybesInMethodSignatures: true
+    reportStaticMethodSignatures: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    checkMissingIterableValueType: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
     paths:
         - ./
     excludes_analyse:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,5 +15,29 @@ parameters:
         
         # TODO use interfaces for traits
         - '~^(Class atk4\\ui\\App not found|Call to an undefined method .+::(issetApp|getApp)\(\))\.$~'
-        - '~^Call to an undefined method .+::(hook|onHook|hookHasCallbacks|removeHook)\(\)\.$~'
-        - '~^Access to an undefined property .+::\$(name|_appScopeTrait|_app)\.$~'
+
+        # for AppScopeTrait.php
+        - '~^Call to an undefined method .+::setApp\(\)\.$~'
+        - '~^Access to an undefined property .+::\$_appScopeTrait\.$~'
+        - '~^Access to an undefined property .+::\$_app\.$~'
+        - '~^Access to an undefined property .+::\$unique_hashes\.$~'
+        # for ContainerTrait.php
+        - '~^Call to an undefined method .+::removeElement\(\)\.$~'
+        # for DiContainerTrait.php
+        - '~^Call to an undefined method .+::setDefaults\(\)\.$~'
+        # for HookTrait.php
+        - '~^Call to an undefined method .+::onHook\(\)\.$~'
+        - '~^Call to an undefined method .+::removeHook\(\)\.$~'
+        - '~^Call to an undefined method .+::hookHasCallbacks\(\)\.$~'
+        - '~^Call to an undefined method .+::hook\(\)\.$~'
+        # for InitializerTrait.php
+        - '~^Call to an undefined method .+::invokeInit\(\)\.$~'
+        - '~^Access to an undefined property .+::\$_initialized\.$~'
+        # for NameTrait.php
+        - '~^Access to an undefined property .+::\$name\.$~'
+        # for TrackableTrait.php
+        - '~^Call to an undefined method .+::issetOwner\(\)\.$~'
+        - '~^Call to an undefined method .+::setOwner\(\)\.$~'
+        - '~^Call to an undefined method .+::unsetOwner\(\)\.$~'
+        - '~^Call to an undefined method .+::getDesiredName\(\)\.$~'
+        - '~^Access to an undefined property .+::\$short_name\.$~'

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -29,7 +29,7 @@ trait AppScopeTrait
     /**
      * Always points to current application.
      *
-     * @var App
+     * @var \atk4\ui\App
      */
     private $_app;
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -147,6 +147,7 @@ trait CollectionTrait
         $collectionTraitHelper = \Closure::bind(function () {
             $factory = Factory::getInstance();
             if (!property_exists($factory, 'collectionTraitHelper')) {
+                // @phpstan-ignore-next-line
                 $factory->collectionTraitHelper = new class() {
                     use AppScopeTrait;
                     use ContainerTrait;
@@ -166,6 +167,7 @@ trait CollectionTrait
                 };
             }
 
+            // @phpstan-ignore-next-line
             return $factory->collectionTraitHelper;
         }, null, Factory::class)();
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -147,8 +147,8 @@ trait ConfigTrait
      * @param string $path            Path to navigate to
      * @param bool   $create_elements Should we create elements it they don't exist
      *
-     * @return &pos|false Pointer to element in $this->config or false is element don't exist and $create_elements===false
-     *                    Returns false if element don't exist and $create_elements===false
+     * @return array|false Pointer to element in $this->config or false is element don't exist and $create_elements===false
+     *                     Returns false if element don't exist and $create_elements===false
      */
     private function &_lookupConfigElement(string $path, bool $create_elements = false)
     {

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -151,7 +151,7 @@ trait ContainerTrait
     /**
      * Remove child element if it exists.
      *
-     * @param string|TrackableTrait $short_name short name of the element
+     * @param string|object $short_name short name of the element
      */
     public function removeElement($short_name)
     {
@@ -222,8 +222,6 @@ trait ContainerTrait
 
     /**
      * @param string $short_name Short name of the child element
-     *
-     * @return object|bool
      */
     public function hasElement($short_name): bool
     {

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -47,7 +47,7 @@ trait DynamicMethodTrait
      * @param string $name Name of the method
      * @param array  $args Array of arguments to pass to this method
      *
-     * @return mixed|null
+     * @return mixed
      */
     public function tryCall($name, $args)
     {
@@ -61,6 +61,8 @@ trait DynamicMethodTrait
                 return $ret;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -165,7 +165,7 @@ trait HookTrait
      * Delete all hooks for specified spot, priority and index.
      *
      * @param int|null $priority        filter specific priority, null for all
-     * @param int      $priorityIsIndex filter by index instead of priority
+     * @param bool     $priorityIsIndex filter by index instead of priority
      *
      * @return static
      */
@@ -191,7 +191,7 @@ trait HookTrait
      * Returns true if at least one callback is defined for this hook.
      *
      * @param int|null $priority        filter specific priority, null for all
-     * @param int      $priorityIsIndex filter by index instead of priority
+     * @param bool     $priorityIsIndex filter by index instead of priority
      */
     public function hookHasCallbacks(string $spot, int $priority = null, bool $priorityIsIndex = false): bool
     {


### PR DESCRIPTION
exclude rules for traits generated by:
```
foreach (scandir(__DIR__) as $fname) {
    if (!preg_match('~.*Trait\.php$~', $fname)) {
        continue;
    }

    $d = file_get_contents($fname);
    preg_match_all('~(?:private|protected|public)[^\n()]+(?:function[^\n()]+?(\w+)\(|\$(\w+))~', $d, $matchesAll, \PREG_SET_ORDER);
    $methods = [];
    $props = [];
    foreach ($matchesAll as $matches) {
        //print_r($matches);
        if ($matches[1] !== '') {
            $methods[] = $matches[1];
        } else {
            $props[] = $matches[2];
        }
    }

    echo '        # for ' . $fname . "\n";
    foreach ($methods as $n) {
        echo '        - \'~^Call to an undefined method .+::' . preg_quote($n, '~') . '\(\)\.$~\'' . "\n";
    }
    foreach ($props as $n) {
        echo '        - \'~^Access to an undefined property .+::\$' . preg_quote($n, '~') . '\.$~\'' . "\n";
    }
}
```