### PR TITLE
Fix Jonkary Speedtrap issue until merged II.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "symfony/yaml": ">=3.4"
   },
   "conflict": {
-    "remove_once_johnkary_phpunit_speedtrap_pr_73_is_merged": "1",
+    "atk4/remove_once_johnkary_phpunit_speedtrap_pr_73_is_merged": "1",
     "phpunit/phpunit": ">=9.5"
   },
   "require-dev": {


### PR DESCRIPTION
fixes:
```
Deprecation warning: conflict.remove_once_johnkary_phpunit_speedtrap_pr_73_is_merged is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$". Make sure you fix this as Composer 2.0 will error.
```