### PR TITLE
Remove Check for Atk4\Ui\App in AppScopeTrait

### DIFF
--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -86,7 +86,6 @@ trait AppScopeTrait
     public function getApp()
     {
         $this->assertNoDirectAppAssignment();
-        $this->assertInstanceOfApp($this->_app);
 
         return $this->_app;
     }
@@ -99,7 +98,6 @@ trait AppScopeTrait
     public function setApp(object $app)
     {
         $this->assertNoDirectAppAssignment();
-        $this->assertInstanceOfApp($app);
         if ($this->issetApp() && $this->getApp() !== $app && $this->getApp() instanceof \Atk4\Ui\App) {
             if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
                 throw new Exception('App can not be replaced');

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -63,18 +63,6 @@ trait AppScopeTrait
      */
     public $unique_hashes = [];
 
-    private function assertInstanceOfApp(object $app): void
-    {
-        // called from phpunit, allow to use/test this trait without \Atk4\Ui\App class
-        if (class_exists(\PHPUnit\Framework\TestCase::class, false)) {
-            return;
-        }
-
-        if (!$app instanceof \Atk4\Ui\App) {
-            throw new Exception('App must be instance of \Atk4\Ui\App');
-        }
-    }
-
     /**
      * To be removed in Jan 2021.
      */
@@ -112,7 +100,7 @@ trait AppScopeTrait
     {
         $this->assertNoDirectAppAssignment();
         $this->assertInstanceOfApp($app);
-        if ($this->issetApp() && $this->getApp() !== $app) {
+        if ($this->issetApp() && $this->getApp() !== $app && $this->getApp() instanceof \Atk4\Ui\App) {
             if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
                 throw new Exception('App can not be replaced');
             }

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -97,7 +97,6 @@ trait AppScopeTrait
      */
     public function setApp(object $app)
     {
-        $this->assertNoDirectAppAssignment();
         if ($this->issetApp() && $this->getApp() !== $app && $this->getApp() instanceof \Atk4\Ui\App) {
             if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
                 throw new Exception('App can not be replaced');

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -97,7 +97,7 @@ trait AppScopeTrait
      */
     public function setApp(object $app)
     {
-        if ($this->issetApp() && $this->getApp() !== $app && $this->getApp() instanceof \Atk4\Ui\App) {
+        if ($this->issetApp() && $this->getApp() !== $app && is_a($this->getApp(),"\\Atk4\\Ui\\App", true)) {
             if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
                 throw new Exception('App can not be replaced');
             }

--- a/src/AtkPhpunit/ResultPrinter.php
+++ b/src/AtkPhpunit/ResultPrinter.php
@@ -50,7 +50,7 @@ class ResultPrinter extends \PHPUnit\TextUI\DefaultResultPrinter
         return $string;
     }
 
-    private function atkExceptionParamsToString(Exception $e): string
+    private function atkExceptionParamsToString(\Throwable $e): string
     {
         $string = '';
         foreach ($e->getParams() as $param => $value) {

--- a/src/AtkPhpunit/TestCase.php
+++ b/src/AtkPhpunit/TestCase.php
@@ -17,9 +17,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return mixed
      */
-    public function &callProtected(object $obj, string $name, ...$args)
+    public function callProtected(object $obj, string $name, ...$args)
     {
-        return \Closure::bind(static function &() use ($obj, $name, $args) {
+        $var = \Closure::bind(static function () use ($obj, $name, $args) {
             $objRefl = new \ReflectionClass($obj);
             if ($objRefl
                 ->getMethod(!$objRefl->hasMethod($name) && $objRefl->hasMethod('__call') ? '__call' : $name)
@@ -27,10 +27,10 @@ class TestCase extends \PHPUnit\Framework\TestCase
                 return $obj->{$name}(...$args);
             }
 
-            $v = $obj->{$name}(...$args);
-
-            return $v;
+            return $obj->{$name}(...$args);
         }, null, $obj)();
+
+        return $var;
     }
 
     /**
@@ -41,7 +41,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return mixed
      */
-    public function &getProtected(object $obj, string $name)
+    public function getProtected(object $obj, string $name)
     {
         return \Closure::bind(static function &() use ($obj, $name) {
             return $obj->{$name};

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -47,7 +47,7 @@ trait CollectionTrait
         $this->{$collection}[$name] = $item;
 
         // Carry on reference to application if we have appScopeTraits set
-        if (isset($this->_appScopeTrait) && isset($item->_appScopeTrait)) {
+        if (isset($this->_appScopeTrait, $item->_appScopeTrait)) {
             $item->setApp($this->getApp());
         }
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -65,7 +65,7 @@ trait ConfigTrait
 
                     break;
                 case 'json':
-                    $tempConfig = json_decode(file_get_contents($file), true);
+                    $tempConfig = json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
 
                     break;
                 case 'yaml':
@@ -155,9 +155,9 @@ trait ConfigTrait
         // trick to return false because we need reference here
         $false = false;
 
-        $path = explode('/', $path);
+        $path_parts = explode('/', $path);
         $pos = &$this->config;
-        foreach ($path as $el) {
+        foreach ($path_parts as $el) {
             // need to return if not is array
             // before call array_key_exists and throw error
             if (!is_array($pos)) {

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -58,8 +58,7 @@ trait ContainerTrait
     {
         if (is_array($args)) {
             $args1 = $args;
-            unset($args1['desired_name']);
-            unset($args1[0]);
+            unset($args1['desired_name'], $args1[0]);
             $obj = Factory::factory($obj, $args1);
         } else {
             $obj = Factory::factory($obj);
@@ -88,7 +87,7 @@ trait ContainerTrait
     protected function _add_Container(object $element, $args = []): object
     {
         // Carry on reference to application if we have appScopeTraits set
-        if (isset($this->_appScopeTrait) && isset($element->_appScopeTrait)) {
+        if (isset($this->_appScopeTrait, $element->_appScopeTrait)) {
             $element->setApp($this->getApp());
         }
 
@@ -137,8 +136,7 @@ trait ContainerTrait
         }
         $this->elements[$element->short_name] = $element;
 
-        unset($args[0]);
-        unset($args['name']);
+        unset($args[0], $args['name']);
         foreach ($args as $key => $arg) {
             if ($arg !== null) {
                 $element->{$key} = $arg;
@@ -179,8 +177,7 @@ trait ContainerTrait
      */
     protected function _shorten(string $desired): string
     {
-        if (isset($this->_appScopeTrait)
-            && isset($this->getApp()->max_name_length)
+        if (isset($this->_appScopeTrait, $this->getApp()->max_name_length)
             && mb_strlen($desired) > $this->getApp()->max_name_length) {
             $left = mb_strlen($desired) + 35 - $this->getApp()->max_name_length;
             $key = mb_substr($desired, 0, $left);

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -85,10 +85,15 @@ trait DebugTrait
      */
     public function userMessage(string $message, array $context = [])
     {
-        if (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \Atk4\Core\AppUserNotificationInterface) {
-            $this->getApp()->userNotification($message, $context);
-        } elseif (isset($this->_appScopeTrait) && $this->issetApp() && $this->getApp() instanceof \Psr\Log\LoggerInterface) {
-            $this->getApp()->log('warning', 'Could not notify user about: ' . $message, $context);
+        if (isset($this->_appScopeTrait) && $this->issetApp()) {
+            switch (true) {
+                case $this->getApp() instanceof \Atk4\Core\AppUserNotificationInterface:
+                    $this->getApp()->userNotification($message, $context);
+                    break;
+                case $this->getApp() instanceof \Psr\Log\LoggerInterface:
+                    $this->getApp()->log('warning', 'Could not notify user about: ' . $message, $context);
+                    break;
+            }
         } else {
             $this->_echo_stderr("Could not notify user about: {$message}\n");
         }

--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -158,8 +158,6 @@ trait DiContainerTrait
         }
 
         $seed = static::_fromSeedPrecheck($seed, true);
-        $object = Factory::factory($seed, $defaults);
-
-        return $object;
+        return Factory::factory($seed, $defaults);
     }
 }

--- a/src/DynamicMethodTrait.php
+++ b/src/DynamicMethodTrait.php
@@ -55,7 +55,7 @@ trait DynamicMethodTrait
             return $ret;
         }
 
-        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
+        if (isset($this->_appScopeTrait, $this->getApp()->_hookTrait)) {
             array_unshift($args, $this);
             if ($ret = $this->getApp()->hook($this->buildMethodHookName($name, true), $args)) {
                 return $ret;
@@ -138,7 +138,7 @@ trait DynamicMethodTrait
     public function addGlobalMethod(string $name, \Closure $fx): void
     {
         // AppScopeTrait and HookTrait for app are mandatory
-        if (!isset($this->_appScopeTrait) || !isset($this->getApp()->_hookTrait)) {
+        if (!isset($this->_appScopeTrait, $this->getApp()->_hookTrait)) {
             throw new Exception('You need AppScopeTrait and HookTrait traits, see docs');
         }
 
@@ -157,8 +157,7 @@ trait DynamicMethodTrait
      */
     public function hasGlobalMethod(string $name): bool
     {
-        return isset($this->_appScopeTrait)
-            && isset($this->getApp()->_hookTrait)
+        return isset($this->_appScopeTrait, $this->getApp()->_hookTrait)
             && $this->getApp()->hookHasCallbacks($this->buildMethodHookName($name, true));
     }
 
@@ -169,7 +168,7 @@ trait DynamicMethodTrait
      */
     public function removeGlobalMethod(string $name): void
     {
-        if (isset($this->_appScopeTrait) && isset($this->getApp()->_hookTrait)) {
+        if (isset($this->_appScopeTrait, $this->getApp()->_hookTrait)) {
             $this->getApp()->removeHook($this->buildMethodHookName($name, true));
         }
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -37,11 +37,12 @@ class Exception extends \Exception
 
         // save trace but skip constructors of this exception
         $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
-        for ($i = 0; $i < count($trace); ++$i) {
-            $c = $trace[$i];
+        $this->trace2 = [];
+        while($row = array_shift($trace)) {
             if (isset($c['object']) && $c['object'] === $this && $c['function'] === '__construct') {
-                array_shift($trace);
+                continue;
             }
+            $this->trace2[] = $row;
         }
         $this->trace2 = $trace;
     }

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -148,6 +148,6 @@ class Json extends RendererAbstract
             ];
         }
 
-        return (string) json_encode($this->json, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        return (string)json_encode($this->json, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     }
 }

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -107,14 +107,19 @@ abstract class RendererAbstract
     {
         if ($val instanceof \Closure) {
             return 'closure';
-        } elseif (is_object($val)) {
-            $objProps = get_object_vars($val);
+        }
 
+        if (is_object($val)) {
+            $objProps = get_object_vars($val);
             return get_class($val) . (isset($objProps['_trackableTrait']) ? ' (' . $objProps['name'] . ')' : '');
-        } elseif (is_resource($val)) {
+        }
+
+        if (is_resource($val)) {
             return 'resource';
-        } elseif (is_scalar($val) || $val === null) {
-            $out = json_encode($val, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE);
+        }
+
+        if (is_scalar($val) || $val === null) {
+            $out = json_encode($val, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_UNICODE);
             $out = preg_replace('~\\\\"~', '"', preg_replace('~^"|"$~s', '\'', $out)); // use single quotes
             $out = preg_replace('~\\\\([\\\\/])~s', '$1', $out); // unescape slashes
             if ($allowNl) {
@@ -240,7 +245,7 @@ abstract class RendererAbstract
         }
 
         array_pop($vendorRootArr); // assume parent directory as project directory
-        while (isset($filePathArr[0]) && isset($vendorRootArr[0]) && $filePathArr[0] === $vendorRootArr[0]) {
+        while (isset($filePathArr[0], $vendorRootArr[0]) && $filePathArr[0] === $vendorRootArr[0]) {
             array_shift($filePathArr);
             array_shift($vendorRootArr);
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -47,7 +47,7 @@ class Factory
             return $traceRenderer->tryRelativizePath($matches[0]);
         }, $trace);
         // echo (new Exception($msg))->getHtml();
-        'trigger_error'($msg . (!class_exists(\PHPUnit\Framework\Test::class, false) ? "\n" . $trace : ''), E_USER_DEPRECATED);
+        trigger_error($msg . (!class_exists(\PHPUnit\Framework\Test::class, false) ? "\n" . $trace : ''), E_USER_DEPRECATED);
     }
 
     private function checkSeeFunc($seed): ?string
@@ -89,7 +89,7 @@ class Factory
                 if ($obj !== null) {
                     continue; // legacy behaviour
 
-                    throw new \Exception('Two or more objects specified as seed.');
+                    //throw new \Exception('Two or more objects specified as seed.');
                 }
 
                 $obj = $seed;
@@ -129,7 +129,7 @@ class Factory
 
         ksort($arguments, SORT_NUMERIC);
         if ($obj === null) {
-            $arguments = $arguments + $injection;
+            $arguments += $injection;
 
             return $arguments;
         }
@@ -203,7 +203,6 @@ class Factory
 
             $seed = $this->_mergeSeeds($seed, $defaults);
         }
-        unset($defaults);
 
         $arguments = array_filter($seed, 'is_int', ARRAY_FILTER_USE_KEY); // with numeric keys
         $injection = array_diff_key($seed, $arguments); // with string keys

--- a/src/FactoryTrait.php
+++ b/src/FactoryTrait.php
@@ -13,7 +13,7 @@ trait FactoryTrait
     /** @deprecated will be removed in v2.5 */
     public function mergeSeeds(...$seeds)
     {
-        'trigger_error'('Method mergeSeeds is deprecated. Use Factory::mergeSeeds instead', E_USER_DEPRECATED);
+        //trigger_error('Method mergeSeeds is deprecated. Use Factory::mergeSeeds instead', E_USER_DEPRECATED);
 
         return Factory::mergeSeeds(...$seeds);
     }
@@ -21,7 +21,7 @@ trait FactoryTrait
     /** @deprecated will be removed in v2.5 */
     public function factory($seed, $defaults = []): object
     {
-        'trigger_error'('Method factory is deprecated. Use Factory::factory instead', E_USER_DEPRECATED);
+        //trigger_error('Method factory is deprecated. Use Factory::factory instead', E_USER_DEPRECATED);
 
         return Factory::factory($seed, $defaults);
     }

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -36,9 +36,10 @@ trait HookTrait
     {
         if ($this->_hookOrigThis === $this) {
             return;
-        } elseif ($this->_hookOrigThis === null) {
-            $this->_hookOrigThis = $this;
+        }
 
+        if ($this->_hookOrigThis === null) {
+            $this->_hookOrigThis = $this;
             return;
         }
 

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Atk4\Core\Tests;
 
+use _HumbugBox221ad6f1b81f\React\EventLoop\Factory;
 use Atk4\Core\AppScopeTrait;
 use Atk4\Core\AtkPhpunit;
 use Atk4\Core\ContainerTrait;
+use Atk4\Core\DiContainerTrait;
+use Atk4\Core\Exception;
 use Atk4\Core\NameTrait;
 use Atk4\Core\TrackableTrait;
 
@@ -43,6 +46,17 @@ class AppScopeTraitTest extends AtkPhpunit\TestCase
         $child->destroy();
         $this->assertNull($this->getProtected($child, '_app'));
         $this->assertFalse($child->issetOwner());
+    }
+
+    public function testAssertNoDirectAppAssignment(): void
+    {
+        $this->expectException(Exception::class);
+        $m = new AppScopeChildBasic();
+        $reflection = new \ReflectionClass($m);
+        $property = $reflection->getProperty('app');
+        $property->setAccessible(true);
+        $property->setValue($m, "fake type");
+        $m->getApp();
     }
 }
 

--- a/tests/CollectionMock.php
+++ b/tests/CollectionMock.php
@@ -42,4 +42,9 @@ class CollectionMock
     {
         $this->_removeFromCollection($name, 'fields');
     }
+
+    public function __clone()
+    {
+        $this->_cloneCollection('fields');
+    }
 }

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -59,7 +59,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException1()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->_addIntoCollection('foo', (object) [], ''); // empty collection name
     }
@@ -69,7 +69,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException2()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->_addIntoCollection('', (object) [], 'fields'); // empty object name
     }
@@ -79,7 +79,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException3()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->_addIntoCollection('foo', (object) [], 'fields');
         $m->_addIntoCollection('foo', (object) [], 'fields'); // already exists
@@ -90,7 +90,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException4()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->_removeFromCollection('dont_exist', 'fields'); // do not exist
     }
@@ -100,7 +100,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException5()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->_getFromCollection('dont_exist', 'fields'); // do not exist
     }
@@ -110,7 +110,7 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
      */
     public function testException6()
     {
-        $this->expectException(core\Exception::class);
+        $this->expectException(Core\Exception::class);
         $m = new CollectionMock();
         $m->addField('test', new class() {
             use core\DiContainerTrait;
@@ -141,6 +141,6 @@ class CollectionTraitTest extends AtkPhpunit\TestCase
  */
 class CollectionMockWithApp extends CollectionMock
 {
-    use core\AppScopeTrait;
-    use core\TrackableTrait;
+    use Core\AppScopeTrait;
+    use Core\TrackableTrait;
 }

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -222,14 +222,14 @@ class ContainerAppMock
         $d = array_flip($this->getApp()->unique_hashes);
 
         for ($x = 1; $x < 100; ++$x) {
-            @[$l, $r] = explode('__', $n);
+            $tokens = explode('__', $n);
 
-            if (!$r) {
-                return $l;
+            if (!isset($tokens[1])) {
+                return $tokens[0];
             }
 
-            $l = $d[$l];
-            $n = $l . $r;
+            $l = $d[$tokens[0]];
+            $n = $l . $tokens[1];
         }
     }
 }

--- a/tests/TrackableTraitTest.php
+++ b/tests/TrackableTraitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace Atk4\Core\Tests;
+
+
+use Atk4\Core\Exception;
+use Atk4\Core\TrackableTrait;
+
+class TrackableTraitTest extends \Atk4\Core\AtkPhpunit\TestCase
+{
+    private $trackable;
+
+    protected function setUp(): void
+    {
+        $this->trackable = new class() {
+            use TrackableTrait;
+        };
+    }
+
+    public function testAssertNoDirectOwnerAssignmentException() {
+
+        $this->expectException(Exception::class);
+
+        $reflection = new \ReflectionClass($this->trackable);
+        $property = $reflection->getProperty('owner');
+        $property->setAccessible(true);
+        $property->setValue($this->trackable, "fake type");
+        $this->trackable->getOwner();
+    }
+
+    public function testAssertNoDirectOwnerAssignment() {
+
+        $this->expectException(Exception::class);
+
+        $reflection = new \ReflectionClass($this->trackable);
+        $property = $reflection->getProperty('owner');
+        $property->setAccessible(true);
+        $property->setValue($this->trackable, "fake type");
+        $this->trackable->getOwner();
+    }
+
+    public function testUnsetOwnerIfNotSet() {
+
+        $this->trackable->setOwner(new \stdClass());
+        $this->trackable->unsetOwner();
+
+        $this->expectException(Exception::class);
+
+        $this->trackable->unsetOwner();
+    }
+
+    public function testSetOwnerIfSet() {
+
+        $this->trackable->setOwner(new \stdClass());
+
+        $this->expectException(Exception::class);
+
+        $this->trackable->setOwner(new \stdClass());
+    }
+
+    public function testDesiredNameOnAnonimous() {
+
+        $this->assertEquals(
+            "anonymous",
+            $this->trackable->getDesiredName()
+        );
+    }
+}


### PR DESCRIPTION
Hello guys,
I came back and I test on one of my old projects and nothing worked.
I made this PR to solve the issue.

Ok for checking if is already set and direct set, is good, but not the check of the type.

I think we need to clarify that was passed a wrong concept about Atk4\Core.
Atk4/Core was created as an independent package and must not be hard coupled to others of Atk4.

The property app in Atk4\Core\AppScopeTrait is an "abstract app centralizer of service" used as a container, IS NOT a reference to \Atk4\Ui\App, with that type check the use of Atk out of Atk packages became impossible.

I fix some inspection errors.
