### PR TITLE
Fix spaces before/after "=>" in comments

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -77,7 +77,7 @@ Example::
         {
             $seed = Factory::mergeSeeds($seed, [FieldMock::class]);
 
-            $field = Factory::factory($seed, ['name'=>$name]);
+            $field = Factory::factory($seed, ['name' => $name]);
 
             return $this->_addIntoCollection($name, $field, 'fields');
         }
@@ -215,8 +215,8 @@ Methods
 
         $args = ['child_name'];
         $args = 'child_name';
-        $args = ['child_name', 'db'=>$mydb];
-        $args = ['name'=>'child_name'];  // obsolete, backward-compatible
+        $args = ['child_name', 'db' => $mydb];
+        $args = ['name' => 'child_name'];  // obsolete, backward-compatible
 
     Method will return the object. Will throw exception if child with same
     name already exist.
@@ -290,8 +290,8 @@ Methods
     Normally object will try to be named after it's class, if the name is omitted.
     You can override this method to implement a different mechanics.
 
-    If you pass 'desired_name'=>'heh' to a constructor, then it will affect the
-    preferred name returned by this method. Unlike 'name'=>'heh' it won't fail
+    If you pass 'desired_name' => 'heh' to a constructor, then it will affect the
+    preferred name returned by this method. Unlike 'name' => 'heh' it won't fail
     if another element with this name exists, but will add '_2' postfix.
 
 .. php:method:: destroy

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -37,7 +37,7 @@ Information logged through debug like this on any object that implements
 DebugTrait::
 
     $this->debug('Things are bad');
-    $this->debug('User {user} created', ['user'=>$user]);
+    $this->debug('User {user} created', ['user' => $user]);
 
 The Application itself can use DebugTrait too and normally should do, making it
 possible to use ``$this->getApp()->debug()``.

--- a/docs/di.rst
+++ b/docs/di.rst
@@ -45,7 +45,7 @@ editing solution, but suppose you want to use custom form object::
 
     $crud = new Crud([
         'formEdit' => new MyForm(),
-        'formAdd'  => new MyForm()
+        'formAdd' => new MyForm()
     ]);
 
 In this scenario you can't pass all of the properties to the constructor, and

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -16,7 +16,7 @@ things like:
 
 Thanks to Factory trait, the following code::
 
-   $button = $app->add(['Button', 'A Label', 'icon'=>'book', 'action'=>My\Action::class]);
+   $button = $app->add(['Button', 'A Label', 'icon' => 'book', 'action' => My\Action::class]);
 
 can replace this::
 
@@ -32,7 +32,7 @@ Agile Toolkit 2.1 introduces support for a new syntax. It is functionally
 identical to a short-hand code, but your IDE will properly set type for
 a `$button` to be `class Button` instead of `class View`::
 
-    $button = Button::addTo($view, ['A Label', 'icon'=>'book', 'action'=>My\Action::class]);
+    $button = Button::addTo($view, ['A Label', 'icon' => 'book', 'action' => My\Action::class]);
 
 The traditional `$view->add` will remain available, there are no plans to
 remove that syntax.
@@ -77,7 +77,7 @@ This problem is solved in ATK with "Seeds".
 
 A Seed is an array consisting of class name/object, named and numeric arguments::
 
-   $seed = [Button::class, 'My Label', 'icon'=>'book'];
+   $seed = [Button::class, 'My Label', 'icon' => 'book'];
 
 Seed with and without class
 ---------------------------
@@ -85,7 +85,7 @@ Seed with and without class
 There are two types of seeds - with class name and without. The one above contains
 the class and is used when user needs a flexibility to specify a class::
 
-   $app->add(['Button', 'My Label', 'icon'=>'book']);
+   $app->add(['Button', 'My Label', 'icon' => 'book']);
 
 The other seed type is class-less and can be used in situations where there are no
 ambiguity about which class is used::
@@ -161,7 +161,7 @@ method and specifying a seed argument::
 
    $button = Factory::factory([Button::Class, 'A Label', 'icon' => ['book'], 'action' => new Action(..)]);
 
-Note that passing 'icon'=>['book'] will also use factory to initialize icon object.
+Note that passing 'icon' => ['book'] will also use factory to initialize icon object.
 
 Finally, if you are using IDE and type hinting, a preferred code would be::
 
@@ -173,7 +173,7 @@ commonly, however, you would use this through the add() method::
 
    use Atk4\Ui\Button;
 
-   $view->add([$button = new Button('A Label'), 'icon'=>['book'], 'action'=>new Action('..')]);
+   $view->add([$button = new Button('A Label'), 'icon' => ['book'], 'action' => new Action('..')]);
 
 Seed Components
 ---------------
@@ -216,7 +216,7 @@ array, then it's wrapped into [].
 
 Array that lacks class is called defaults, e.g.::
 
-    $defaults = ['Label', 'My Label', 'big red', 'icon'=>'book'];
+    $defaults = ['Label', 'My Label', 'big red', 'icon' => 'book'];
 
 You can pass defaults as second argument to :php:meth:`Factory::factory()`::
 
@@ -233,12 +233,12 @@ if you wish to change the label, but keep the class, use this::
 Finally, if you pass key/value pair inside seed with a value of ``null`` then
 default value will still be used::
 
-    $label = Factory::factory(['icon'=>null], $defaults);
+    $label = Factory::factory(['icon' => null], $defaults);
 
 This will result icon=book. If you wish to disable icon, you should use ``false``
 value::
 
-    $label = Factory::factory(['icon'=>false], $defaults);
+    $label = Factory::factory(['icon' => false], $defaults);
 
 With this it's handy to pass icon as an argument and don't worry if the null is
 used.
@@ -267,7 +267,7 @@ values. See my description below the example::
         }
     }
 
-    $button = Factory::factory([RedButton::class, 'icon'=>'cake'], ['icon'=>'thumbs up']);
+    $button = Factory::factory([RedButton::class, 'icon' => 'cake'], ['icon' => 'thumbs up']);
     // Question: what would be $button->icon value here?
 
 
@@ -277,7 +277,7 @@ The seed takes precedence, so icon='cake'.
 
 Factory will then create instance of RedButton with a default icon 'book'.
 It will then execute :php:meth:`DiContainerTrait::setDefaults` with the
-`['icon'=>'cake']` which will change value of $icon to `cake`.
+`['icon' => 'cake']` which will change value of $icon to `cake`.
 
 The `cake` will be the final value of the example above. Even though `init()`
 method is set to change the value of icon, the `init()` method is only executed
@@ -308,25 +308,25 @@ Some examples::
     Factory::mergeSeeds([null, 'Button Label'], ['Message', 'Message Label']);
     // Results in ['Message', 'Button Label']);
 
-    Factory::mergeSeeds(['null, 'Label1', 'icon'=>'book'], ['icon'=>'coin', 'Button'], ['class'=>['red']]);
-    // Results in ['Button', 'Label1', 'icon'=>'book', 'class'=>['red']]
+    Factory::mergeSeeds(['null, 'Label1', 'icon' => 'book'], ['icon' => 'coin', 'Button'], ['class' => ['red']]);
+    // Results in ['Button', 'Label1', 'icon' => 'book', 'class' => ['red']]
 
 Seed merging can also be used to merge defaults::
 
-    Factory::mergeSeeds(['label 1'], ['icon'=>'book']);
-    // results in ['label 1', 'icon'=>'book']
+    Factory::mergeSeeds(['label 1'], ['icon' => 'book']);
+    // results in ['label 1', 'icon' => 'book']
 
 When object is passed, it will take precedence and absorb all named arguments::
 
     Factory::mergeSeeds(
-        ['null, 'Label1', 'icon'=>'book'],
-        ['icon'=>'coin', 'Button'],
+        ['null, 'Label1', 'icon' => 'book'],
+        ['icon' => 'coin', 'Button'],
         new Message('foobar'),
-        ['class'=>['red']]
+        ['class' => ['red']]
     );
     // result is
     // $obj = new Message('foobar');
-    // $obj->setDefaults(['icon'=>'book', 'class'=>['red']);
+    // $obj->setDefaults(['icon' => 'book', 'class' => ['red']);
 
 If multiple objects are specified then early ones take precedence while still
 absorbing all named arguments.
@@ -360,7 +360,7 @@ Specify Icon for a Button
 As you may know, Button class has icon property, which may be specified as a
 string, seed or object::
 
-    $button = $app->add(['Button', 'icon'=>'book']);
+    $button = $app->add(['Button', 'icon' => 'book']);
 
 Well, to implement the button internally, render method uses this::
 
@@ -432,7 +432,7 @@ ways to use addButton()::
     $form->addButton('click me');
     // Adds a regular button with specified label, as expected
 
-    $form->addButton(['click me', 'red', 'icon'=>'book']);
+    $form->addButton(['click me', 'red', 'icon' => 'book']);
     // Specify class of a button and also icon
 
     $form->addButton(new MyButton('click me'));
@@ -440,7 +440,7 @@ ways to use addButton()::
 
 A same logic can be applied to addField::
 
-    $model->addField('is_vip', ['type'=>'boolean']);
+    $model->addField('is_vip', ['type' => 'boolean']);
     // class = Field, type = boolean
 
     $model->addField('is_vip', ['boolean'])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,7 +91,7 @@ In this scenario, even though a new object is added, we don't do it ourselves.
 We simply specify some information on how to create and what properties to
 inject into the object::
 
-    $field = $form->add([\Atk4\Ui\FormField\Password::class, 'icon'=>['lock', 'circular inverted'], 'width'=>4);
+    $field = $form->add([\Atk4\Ui\FormField\Password::class, 'icon' => ['lock', 'circular inverted'], 'width' => 4);
 
 The above code will determine the correct object to implement Password inside
 Form, instantiate it and then even add Icon object which is also defined through
@@ -196,7 +196,7 @@ class to define a business object, such as - ShoppingBag::
 
             $this->hasOne('user_id', new User());
             $this->hasMany('Items', new Item())
-                ->addField('total_price', ['aggregate'=>'sum', 'field'=>'price']);
+                ->addField('total_price', ['aggregate' => 'sum', 'field' => 'price']);
         }
     }
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -88,7 +88,7 @@ trait ConfigTrait
     /**
      * Manually set configuration option.
      *
-     * @param string|array $paths Path to configuration element to set or array of [path=>value]
+     * @param string|array $paths Path to configuration element to set or array of [path => value]
      * @param mixed        $value Value to set
      *
      * @return $this

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -98,11 +98,11 @@ trait ContainerTrait
             throw (new Exception('Second argument must be array'))
                 ->addMoreInfo('arg2', $args);
         } elseif (isset($args['desired_name'])) {
-            // passed as ['desired_name'=>'foo'];
+            // passed as ['desired_name' => 'foo'];
             $args[0] = $this->_unique_element($args['desired_name']);
             unset($args['desired_name']);
         } elseif (isset($args['name'])) {
-            // passed as ['name'=>'foo'];
+            // passed as ['name' => 'foo'];
             $args[0] = $args['name'];
             unset($args['name']);
         } elseif (isset($element->short_name)) {

--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -21,7 +21,7 @@ namespace Atk4\Core;
  * Several classes may opt to extend setDefaults, for example in Agile UI
  * setDefaults is extended to support classes and content:
  *
- * $segment->setDefaults(['Hello There', 'red', 'ui'=>'segment']);
+ * $segment->setDefaults(['Hello There', 'red', 'ui' => 'segment']);
  *
  * WARNING: Do not use this trait unless you have a lot of properties
  * to inject. Also follow the guidelines on

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -133,7 +133,7 @@ class Json extends RendererAbstract
                 'code' => $this->exception->getCode(),
                 'message' => 'Error during json renderer: ' . $this->exception->getMessage(),
                 // avoid translation
-                //'message'  => $this->_($this->exception->getMessage()),
+                //'message' => $this->_($this->exception->getMessage()),
                 'title' => get_class($this->exception),
                 'class' => get_class($this->exception),
                 'params' => [],

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -418,7 +418,7 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * Object factory definition must use ["class name", "x"=>"y"] form.
+     * Object factory definition must use ["class name", "x" => "y"] form.
      */
     public function testFactoryException1(): void
     {

--- a/tests/TranslatorAdapterBase.php
+++ b/tests/TranslatorAdapterBase.php
@@ -19,22 +19,22 @@ abstract class TranslatorAdapterBase extends TestCase
 
     /* DEFINITIONS
     [
-        'Field requires array for defaults'                                      => 'Field requires array for defaults',
+        'Field requires array for defaults' => 'Field requires array for defaults',
         'Field value can not be base64 encoded because it is not of string type' => 'Field value can not be base64 encoded because it is not of string type ({{field}})',
-        'Mandatory field value cannot be null'                                   => 'Mandatory field value cannot be null ({{field}})',
-        'Model is already related to another persistence'                        => 'Model is already related to another persistence',
-        'Must not be null'                                                       => 'Must not be null',
-        'Test with plural'                                                       => [
-            'zero'  => 'Test zero',
-            'one'   => 'Test is one',
+        'Mandatory field value cannot be null' => 'Mandatory field value cannot be null ({{field}})',
+        'Model is already related to another persistence' => 'Model is already related to another persistence',
+        'Must not be null' => 'Must not be null',
+        'Test with plural' => [
+            'zero' => 'Test zero',
+            'one' => 'Test is one',
             'other' => 'Test are {{count}}',
         ],
-        'There was error while decoding JSON'                                    => 'There was error while decoding JSON',
-        'Unable to determine persistence driver type from DSN'                   => 'Unable to determine persistence driver type from DSN',
-        'Unable to serialize field value on load'                                => 'Unable to serialize field value on load ({{field}})',
-        'Unable to serialize field value on save'                                => 'Unable to serialize field value on save ({{field}})',
-        'Unable to typecast field value on load'                                 => 'Unable to typecast field value on load ({{field}})',
-        'Unable to typecast field value on save'                                 => 'Unable to typecast field value on save ({{field}})',
+        'There was error while decoding JSON' => 'There was error while decoding JSON',
+        'Unable to determine persistence driver type from DSN' => 'Unable to determine persistence driver type from DSN',
+        'Unable to serialize field value on load' => 'Unable to serialize field value on load ({{field}})',
+        'Unable to serialize field value on save' => 'Unable to serialize field value on save ({{field}})',
+        'Unable to typecast field value on load' => 'Unable to typecast field value on load ({{field}})',
+        'Unable to typecast field value on save' => 'Unable to typecast field value on save ({{field}})',
     ];
     */
 


### PR DESCRIPTION
created usign these regexes:

```
=>(?!\s)
(?<!\s)=>
( {2,})=>
=>( {2,})
```

CI issues are unrelated, see https://github.com/sebastianbergmann/phpunit/issues/4788