### PR TITLE
Warn if property does not exist and add it to DiContainerTrait

### DIFF
--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -32,6 +32,8 @@ namespace Atk4\Core;
  */
 trait DiContainerTrait
 {
+    use WarnDynamicPropertyTrait;
+
     /**
      * Call from __construct() to initialize the properties allowing
      * developer to pass Dependency Injector Container.

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -11,6 +11,8 @@ use Atk4\Core\Translator\ITranslatorAdapter;
  */
 class Exception extends \Exception
 {
+    use WarnDynamicPropertyTrait;
+
     /** @var array */
     public $params = [];
 

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -14,14 +14,14 @@ namespace Atk4\Core;
  */
 trait WarnDynamicPropertyTrait
 {
-    protected function warnIfPropertyDoesNotExist(string $name): void
+    protected function warnPropertyDoesNotExist(string $name): void
     {
         'trigger_error'('Property ' . static::class . '::$' . $name . ' does not exist', \E_USER_DEPRECATED);
     }
 
     public function __isset(string $name): bool
     {
-        $this->warnIfPropertyDoesNotExist($name);
+        $this->warnPropertyDoesNotExist($name);
 
         return isset($this->{$name});
     }
@@ -31,7 +31,7 @@ trait WarnDynamicPropertyTrait
      */
     public function &__get(string $name)
     {
-        $this->warnIfPropertyDoesNotExist($name);
+        $this->warnPropertyDoesNotExist($name);
 
         return $this->{$name};
     }
@@ -41,14 +41,14 @@ trait WarnDynamicPropertyTrait
      */
     public function __set(string $name, $value): void
     {
-        $this->warnIfPropertyDoesNotExist($name);
+        $this->warnPropertyDoesNotExist($name);
 
         $this->{$name} = $value;
     }
 
     public function __unset(string $name): void
     {
-        $this->warnIfPropertyDoesNotExist($name);
+        $this->warnPropertyDoesNotExist($name);
 
         unset($this->{$name});
     }

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -16,7 +16,8 @@ trait WarnDynamicPropertyTrait
 {
     protected function warnIfPropertyDoesNotExist(string $name): void
     {
-        if (!property_exists($this, $name)) {
+        // if (!property_exists($this, $name)) { //  does not work with unset properties
+        if (!array_key_exists($name, (array) $this)) {
             'trigger_error'('Property ' . static::class . '::$' . $name . ' does not exist', \E_USER_DEPRECATED);
         }
     }

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -29,7 +29,7 @@ trait WarnDynamicPropertyTrait
     /**
      * @return mixed
      */
-    public function __get(string $name)
+    public function &__get(string $name)
     {
         $this->warnIfPropertyDoesNotExist($name);
 

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core;
+
+/**
+ * This trait implements https://github.com/php/php-src/pull/7390 .
+ *
+ * We also add this trait to the most commonly used DiContainerTrait trait to help the developer
+ * to discover removed/renamed properties and/or general typos.
+ *
+ * Remove once PHP 8.1 is no longer supported (the PR above is expected to be merged into PHP 8.2).
+ */
+trait WarnDynamicPropertyTrait
+{
+    protected function warnIfPropertyDoesNotExist(string $name): void
+    {
+        if (!property_exists($this, $name)) {
+            'trigger_error'('Property ' . static::class . '::$' . $name . ' does not exist', \E_USER_DEPRECATED);
+        }
+    }
+
+    public function __isset(string $name): bool
+    {
+        $this->warnIfPropertyDoesNotExist($name);
+
+        return isset($this->{$name});
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        $this->warnIfPropertyDoesNotExist($name);
+
+        return $this->{$name};
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        $this->warnIfPropertyDoesNotExist($name);
+
+        $this->{$name} = $value;
+    }
+
+    public function __unset(string $name): void
+    {
+        $this->warnIfPropertyDoesNotExist($name);
+
+        unset($this->{$name});
+    }
+}

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -5,12 +5,8 @@ declare(strict_types=1);
 namespace Atk4\Core;
 
 /**
- * This trait implements https://github.com/php/php-src/pull/7390 .
- *
- * We also add this trait to the most commonly used DiContainerTrait trait to help the developer
- * to discover removed/renamed properties and/or general typos.
- *
- * Remove once PHP 8.1 is no longer supported (the PR above is expected to be merged into PHP 8.2).
+ * This trait implements https://github.com/php/php-src/pull/7390 for lower PHP versions
+ * and also emit a warning when isset() is called on undefined variable.
  */
 trait WarnDynamicPropertyTrait
 {

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -16,10 +16,7 @@ trait WarnDynamicPropertyTrait
 {
     protected function warnIfPropertyDoesNotExist(string $name): void
     {
-        // if (!property_exists($this, $name)) { //  does not work with unset properties
-        if (!array_key_exists($name, (array) $this)) {
-            'trigger_error'('Property ' . static::class . '::$' . $name . ' does not exist', \E_USER_DEPRECATED);
-        }
+        'trigger_error'('Property ' . static::class . '::$' . $name . ' does not exist', \E_USER_DEPRECATED);
     }
 
     public function __isset(string $name): bool


### PR DESCRIPTION
This highly improves code quality as something like:

```
$m->noLongerSupportedProperty = 'x';
```
or
```
$m->eckbox= 'x'; // notice the typo
```

will warn if the new trait is added. To add it to the most of the code, we add it to `DiContainerTrait` by default.

The deprecation warnings can be supressed by a custom error handler or by overriding the `warnIfPropertyDoesNotExist` method.