### PR TITLE
Remove NameTrait from TrackableTrait

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -19,8 +19,8 @@ elements inside container::
     $object->add(new AnoterObject(), 'test');
     $another_object = $object->getElement('test');
 
-If you additionally use :php:trait:`TrackableTrait` then your objects
-also receive unique "name". From example above:
+If you additionally use :php:trait:`TrackableTrait` together with :php:trait:`NameTrait`
+then your objects also receive unique "name". From example above:
 
 * $object->name == "app_object_4"
 * $another_object->name == "app_object_4_test"
@@ -155,6 +155,7 @@ Container Trait
 
         class MyItem  {
             use Atk4\Core\TrackableTrait;
+            use Atk4\Core\NameTrait;
         }
 
         Now the instances of MyItem can be added to instances of MyContainer
@@ -185,8 +186,8 @@ Properties
 
     Contains a list of objects that have been "added" into the current
     container. The key is a "shot_name" of the child. The actual link to
-    the element will be only present if child uses trait "TrackableTrait",
-    otherwise the value of array key will be "true".
+    the element will be only present if child uses both :php:trait:`TrackableTrait`
+    and :php:trait:`NameTrait` traits, otherwise the value of array key will be "true".
 
 Methods
 -------

--- a/docs/initializer.rst
+++ b/docs/initializer.rst
@@ -15,9 +15,9 @@ Declare a object class in your framework::
 
     class FormField {
         use AppScopeTrait;
-        use TrackableTrait;
         use InitializerTrait;
-
+        use NameTrait;
+        use TrackableTrait;
     }
 
     class FormField_Input extends FormField {
@@ -51,10 +51,11 @@ class::
 
     class FormField {
         use AppScopeTrait;
-        use TrackableTrait;
         use InitializerTrait {
             init as _init
         }
+        use TrackableTrait;
+        use NameTrait;
 
         public $value = null;
 

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -55,7 +55,7 @@ trait CollectionTrait
         if (TraitUtil::hasTrackableTrait($item)) {
             $item->short_name = $name;
             $item->setOwner($this);
-            if (TraitUtil::hasTrackableTrait($this)) {
+            if (TraitUtil::hasTrackableTrait($this) && TraitUtil::hasNameTrait($this) && TraitUtil::hasNameTrait($item)) {
                 $item->name = $this->_shorten_ml($this->name . '-' . $collection, $item->short_name, $item->name);
             }
         }

--- a/src/ContainerTrait.php
+++ b/src/ContainerTrait.php
@@ -119,7 +119,7 @@ trait ContainerTrait
 
         $element->setOwner($this);
         $element->short_name = $args[0];
-        if (TraitUtil::hasNameTrait($this)) {
+        if (TraitUtil::hasTrackableTrait($this) && TraitUtil::hasNameTrait($this) && TraitUtil::hasNameTrait($element)) {
             $element->name = $this->_shorten((string) $this->name, $element->short_name, $element->name);
         }
         $this->elements[$element->short_name] = $element;

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -11,8 +11,6 @@ namespace Atk4\Core;
  */
 trait TrackableTrait
 {
-    use NameTrait;
-
     /** @var object|null Link to (parent) object into which we added this object. */
     private $_owner;
 

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -142,11 +142,9 @@ class CollectionTraitTest extends TestCase
     }
 }
 
-/**
- * Adds support for apptrait and trackable.
- */
 class CollectionMockWithApp extends CollectionMock
 {
     use Core\AppScopeTrait;
+    use Core\NameTrait;
     use Core\TrackableTrait;
 }

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -117,6 +117,8 @@ class ContainerTraitTest extends TestCase
 
         $createTrackableMockFx = function (string $name, bool $isLongName = false) {
             return new class($name, $isLongName) extends TrackableMock {
+                use Core\NameTrait;
+
                 public function __construct(string $name, bool $isLongName)
                 {
                     if ($isLongName) {
@@ -155,6 +157,7 @@ class ContainerTraitTest extends TestCase
         $m = new ContainerMock();
         $m2 = $m->add(new class() extends TrackableMock {
             use Core\DiContainerTrait;
+            use Core\NameTrait;
         }, ['name' => 'foo']);
         $this->assertTrue($m->hasElement('foo'));
         $this->assertSame('foo', $m2->short_name);
@@ -233,6 +236,7 @@ class ContainerAppMock
 {
     use Core\AppScopeTrait;
     use Core\ContainerTrait;
+    use Core\NameTrait;
     use Core\TrackableTrait;
 
     public function getElementCount(): int

--- a/tests/FieldMockCustom.php
+++ b/tests/FieldMockCustom.php
@@ -6,6 +6,7 @@ namespace Atk4\Core\Tests;
 
 use Atk4\Core\AppScopeTrait;
 use Atk4\Core\InitializerTrait;
+use Atk4\Core\NameTrait;
 use Atk4\Core\TrackableTrait;
 
 class FieldMockCustom extends FieldMock
@@ -14,6 +15,7 @@ class FieldMockCustom extends FieldMock
     use InitializerTrait {
         init as private _init;
     }
+    use NameTrait;
     use TrackableTrait;
 
     /** @var bool verifying if init was called */


### PR DESCRIPTION
related to https://github.com/atk4/core/pull/342

and atk4/data, `obj->name` is set only if owner & child is trackable, but in atk4/data, Model is NOT trackable, thus `name` was never set in Field, Reference, ... but was declared

issues like https://github.com/atk4/data/pull/942 will be thus always detected by phpstan