### PR TITLE
Rename variables and properties to camelCase

### DIFF
--- a/docs/appscope.rst
+++ b/docs/appscope.rst
@@ -21,7 +21,7 @@ Properties
 
     Always points to current Application object
 
-.. php:attr:: max_name_length
+.. php:attr:: maxNameLength
 
     When using mechanism for ContainerTrait, they inherit name of the parent to
     generate unique name for a child. In a framework it makes sense if you have
@@ -30,11 +30,11 @@ Properties
 
     Unfortunately if those keys become too long it may be a problem, so
     ContainerTrait contains a mechanism for auto-shortening the name based
-    around max_name_length. The mechanism does only work if AppScopeTrait is
-    used, $app property is set and has a max_name_length defined.
+    around maxNameLength. The mechanism does only work if AppScopeTrait is
+    used, $app property is set and has a maxNameLength defined.
     Minimum value is 40.
 
-.. php:attr:: unique_hashes
+.. php:attr:: uniqueNameHashes
 
     As more names are shortened, the substituted part is being placed into
     this hash and the value contains the new key. This helps to avoid creating

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -65,7 +65,7 @@ Methods
 
     Manually set configuration option
 
-.. php:method:: getConfig($path, $default_value = null)
+.. php:method:: getConfig($path, $defaultValue = null)
 
     Get configuration element
 

--- a/docs/container.rst
+++ b/docs/container.rst
@@ -17,13 +17,13 @@ You will be able to use :php:meth:`ContainerTrait::getElement()` to access
 elements inside container::
 
     $object->add(new AnoterObject(), 'test');
-    $another_object = $object->getElement('test');
+    $anotherObject = $object->getElement('test');
 
 If you additionally use :php:trait:`TrackableTrait` together with :php:trait:`NameTrait`
 then your objects also receive unique "name". From example above:
 
 * $object->name == "app_object_4"
-* $another_object->name == "app_object_4_test"
+* $anotherObject->name == "app_object_4_test"
 
 
 
@@ -125,7 +125,7 @@ Methods
 
     Same as _hasInCollection but throws exception if element is not found
 
-.. php:method:: _shorten_ml($string $ownerName, string $itemShortName)
+.. php:method:: _shortenMl($string $ownerName, string $itemShortName)
 
     Implements name shortening
 
@@ -149,7 +149,7 @@ Container Trait
             use Atk4\Core\ContainerTrait;
 
             function add($obq, $args = []) {
-                return $this->_add_Container($obj, $args);
+                return $this->_addContainer($obj, $args);
             }
         }
 
@@ -196,7 +196,7 @@ Methods
 
     If you are using ContainerTrait only, then you can safely use this add()
     method. If you are also using factory, or initializer then redefine add()
-    and call _add_Container, _add_Factory,.
+    and call _addContainer, _addFactory,.
 
 .. php:method:: _addContainer($element, $args)
 
@@ -209,7 +209,7 @@ Methods
 
         function add($obj, $args = [])
         {
-            return $this->_add_Container($obj, $args);
+            return $this->_addContainer($obj, $args);
         }
 
     $args be in few forms::
@@ -222,9 +222,9 @@ Methods
     Method will return the object. Will throw exception if child with same
     name already exist.
 
-.. php:method:: removeElement($short_name)
+.. php:method:: removeElement($shortName)
 
-    Will remove element from $elements. You can pass either short_name
+    Will remove element from $elements. You can pass either shortName
     or the object itself. This will be called if :php:meth:`TrackableTrait::destroy`
     is called.
 
@@ -238,17 +238,17 @@ Methods
     This method will only be used if current object has :php:trait:`AppScope`,
     since the application is responsible for keeping shortenings.
 
-.. php:method:: getElement($short_name)
+.. php:method:: getElement($shortName)
 
     Given a short-name of the element, will return the object. Throws exception
-    if object with such short_name does not exist.
+    if object with such shortName does not exist.
 
-.. php:method:: hasElement($short_name)
+.. php:method:: hasElement($shortName)
 
     Given a short-name of the element, will return true if object with
-    such short_name exists, otherwise false.
+    such shortName exists, otherwise false.
 
-.. php:method:: _unique_element
+.. php:method:: _uniqueElementName
 
     Internal method to create unique name for an element.
 
@@ -278,9 +278,9 @@ Properties
     Will point to object which has add()ed this object. If multiple objects
     have added this object, then this will point to the most recent one.
 
-.. php:attr:: short_name
+.. php:attr:: shortName
 
-    When you add item into the owner, the "short_name" will contain short name
+    When you add item into the owner, the "shortName" will contain short name
     of this item.
 
 Methods

--- a/docs/exception.rst
+++ b/docs/exception.rst
@@ -99,7 +99,7 @@ If you want, you can wrap your code inside try / catch block::
         // handle exception
     }
 
-The other option is to use automatic exception catching, (:php:attr:`\Atk4\Ui\App::catch_exceptions`)
+The other option is to use automatic exception catching, (:php:attr:`\Atk4\Ui\App::catchExceptions`)
 which will automatically catch any unhandled exception then pass it to :php:meth:`\Atk4\Ui\App::caughtException()`.
 
 If you do not instantiate App, or set it up without automatic exception catching::

--- a/docs/factory.rst
+++ b/docs/factory.rst
@@ -451,7 +451,7 @@ A same logic can be applied to addField::
 
 and the implementation uses factory's default::
 
-    $field = Factory::factory($this->_field_class);
+    $field = Factory::factory($this->fieldSeed);
 
 Normally the field class property is a string, which will be used, but it can
 also be array.

--- a/src/AppScopeTrait.php
+++ b/src/AppScopeTrait.php
@@ -25,15 +25,15 @@ trait AppScopeTrait
      *
      * Unfortunately if those keys become too long it may be a problem,
      * so ContainerTrait contains a mechanism for auto-shortening the
-     * name based around max_name_length. The mechanism does only work
+     * name based around maxNameLength. The mechanism does only work
      * if AppScopeTrait is used, $app property is set and has a
-     * max_name_length defined.
+     * maxNameLength defined.
      *
      * Minimum is 40
      *
      * @var int
      */
-    public $max_name_length = 60;
+    public $maxNameLength = 60;
 
     /**
      * As more names are shortened, the substituted part is being placed into
@@ -45,7 +45,7 @@ trait AppScopeTrait
      *
      * @var array
      */
-    public $unique_hashes = [];
+    public $uniqueNameHashes = [];
 
     protected function assertInstanceOfApp(object $app): void
     {
@@ -87,7 +87,7 @@ trait AppScopeTrait
     {
         $this->assertInstanceOfApp($app);
         if ($this->issetApp() && $this->getApp() !== $app) {
-            if ($this->getApp()->catch_exceptions || $this->getApp()->always_run) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
+            if ($this->getApp()->catchExceptions || $this->getApp()->alwaysRun) { // allow to replace App created by AbstractView::initDefaultApp() - TODO fix
                 throw new Exception('App cannot be replaced');
             }
         }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -53,10 +53,10 @@ trait CollectionTrait
 
         // Calculate long "name" but only if both are trackables
         if (TraitUtil::hasTrackableTrait($item)) {
-            $item->short_name = $name;
+            $item->shortName = $name;
             $item->setOwner($this);
             if (TraitUtil::hasTrackableTrait($this) && TraitUtil::hasNameTrait($this) && TraitUtil::hasNameTrait($item)) {
-                $item->name = $this->_shorten_ml($this->name . '-' . $collection, $item->short_name, $item->name);
+                $item->name = $this->_shortenMl($this->name . '-' . $collection, $item->shortName, $item->name);
             }
         }
 
@@ -133,7 +133,7 @@ trait CollectionTrait
      *
      * Identical implementation to ContainerTrait::_shorten.
      */
-    protected function _shorten_ml(string $ownerName, string $itemShortName, ?string $origItemName): string
+    protected function _shortenMl(string $ownerName, string $itemShortName, ?string $origItemName): string
     {
         // ugly hack to deduplicate code
         $collectionTraitHelper = \Closure::bind(function () {

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -113,18 +113,18 @@ trait ConfigTrait
     /**
      * Get configuration element.
      *
-     * @param string $path          path to configuration element
-     * @param mixed  $default_value Default value returned if element don't exist
+     * @param string $path         path to configuration element
+     * @param mixed  $defaultValue Default value returned if element don't exist
      *
      * @return mixed
      */
-    public function getConfig(string $path, $default_value = null)
+    public function getConfig(string $path, $defaultValue = null)
     {
         $pos = &$this->_lookupConfigElement($path, false);
 
         // path element don't exist - return default value
         if ($pos === false) {
-            return $default_value;
+            return $defaultValue;
         }
 
         return $pos;
@@ -133,13 +133,13 @@ trait ConfigTrait
     /**
      * Internal method to lookup config element by given path.
      *
-     * @param string $path            Path to navigate to
-     * @param bool   $create_elements Should we create elements it they don't exist
+     * @param string $path           Path to navigate to
+     * @param bool   $createElements Should we create elements it they don't exist
      *
-     * @return array|false Pointer to element in $this->config or false is element don't exist and $create_elements===false
-     *                     Returns false if element don't exist and $create_elements===false
+     * @return array|false Pointer to element in $this->config or false is element don't exist and $createElements === false
+     *                     Returns false if element don't exist and $createElements === false
      */
-    private function &_lookupConfigElement(string $path, bool $create_elements = false)
+    private function &_lookupConfigElement(string $path, bool $createElements = false)
     {
         // trick to return false because we need reference here
         $false = false;
@@ -154,11 +154,11 @@ trait ConfigTrait
             }
 
             // create empty element if it doesn't exist
-            if (!array_key_exists($el, $pos) && $create_elements) {
+            if (!array_key_exists($el, $pos) && $createElements) {
                 $pos[$el] = [];
             }
             // if it still doesn't exist, then just return false (no error)
-            if (!array_key_exists($el, $pos) && !$create_elements) {
+            if (!array_key_exists($el, $pos) && !$createElements) {
                 return $false;
             }
 

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -12,16 +12,16 @@ trait DebugTrait
     public $debug = false;
 
     /** @var array Helps debugTraceChange. */
-    protected $_prev_bt = [];
+    protected $_prevTrace = [];
 
     /**
      * Outputs message to STDERR.
      *
      * @codeCoverageIgnore - replaced with "echo" which can be intercepted by test-suite
      */
-    protected function _echo_stderr(string $message): void
+    protected function _echoStderr(string $message): void
     {
-        file_put_contents('php://stderr', $message);
+        file_put_contents('php://stderr', $message, \FILE_APPEND);
     }
 
     /**
@@ -64,7 +64,7 @@ trait DebugTrait
         if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
             $this->getApp()->logger->log($level, $message, $context);
         } else {
-            $this->_echo_stderr($message . "\n");
+            $this->_echoStderr($message . "\n");
         }
 
         return $this;
@@ -90,14 +90,14 @@ trait DebugTrait
             }
         }
 
-        if (isset($this->_prev_bt[$trace]) && array_diff($this->_prev_bt[$trace], $bt)) {
-            $d1 = array_diff($this->_prev_bt[$trace], $bt);
-            $d2 = array_diff($bt, $this->_prev_bt[$trace]);
+        if (isset($this->_prevTrace[$trace]) && array_diff($this->_prevTrace[$trace], $bt)) {
+            $d1 = array_diff($this->_prevTrace[$trace], $bt);
+            $d2 = array_diff($bt, $this->_prevTrace[$trace]);
 
             $this->log('debug', 'Call path for ' . $trace . ' has diverged (was ' . implode(', ', $d1) . ', now ' . implode(', ', $d2) . ")\n");
         }
 
-        $this->_prev_bt[$trace] = $bt;
+        $this->_prevTrace[$trace] = $bt;
     }
 
     /**

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -17,7 +17,7 @@ class Exception extends \Exception
     public $params = [];
 
     /** @var string */
-    protected $custom_exception_title = 'Critical Error';
+    protected $customExceptionTitle = 'Critical Error';
 
     /**
      * Most exceptions would be a cause by some other exception, Agile
@@ -163,11 +163,11 @@ class Exception extends \Exception
     }
 
     /**
-     * Get the custom Exception title, if defined in $custom_exception_title.
+     * Get the custom Exception title, if defined in $customExceptionTitle.
      */
     public function getCustomExceptionTitle(): string
     {
-        return $this->custom_exception_title;
+        return $this->customExceptionTitle;
     }
 
     /**

--- a/src/ExceptionRenderer/Html.php
+++ b/src/ExceptionRenderer/Html.php
@@ -53,7 +53,7 @@ class Html extends RendererAbstract
         $tokens = [
             '{PARAMS}' => '',
         ];
-        $text_inner = '
+        $textInner = '
                     <tr><td><b>{KEY}</b></td><td style="width: 100%;">{VAL}</td></tr>';
         foreach ($this->exception->getParams() as $key => $val) {
             $key = htmlentities($key);
@@ -64,7 +64,7 @@ class Html extends RendererAbstract
                     '{KEY}' => $key,
                     '{VAL}' => $val,
                 ],
-                $text_inner
+                $textInner
             );
         }
 
@@ -95,10 +95,10 @@ class Html extends RendererAbstract
         $tokens = [
             '{SOLUTIONS}' => '',
         ];
-        $text_inner = '
+        $textInner = '
                     <tr><td>{VAL}</td></tr>';
         foreach ($exception->getSolutions() as $key => $val) {
-            $tokens['{SOLUTIONS}'] .= $this->replaceTokens(['{VAL}' => htmlentities($val)], $text_inner);
+            $tokens['{SOLUTIONS}'] .= $this->replaceTokens(['{VAL}' => htmlentities($val)], $textInner);
         }
 
         $this->output .= $this->replaceTokens($tokens, $text);

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -18,7 +18,7 @@ abstract class RendererAbstract
     public $exception;
 
     /** @var \Throwable|Exception|null */
-    public $parent_exception;
+    public $parentException;
 
     /** @var string */
     public $output = '';
@@ -26,11 +26,11 @@ abstract class RendererAbstract
     /** @var ITranslatorAdapter|null */
     public $adapter;
 
-    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null, \Throwable $parent_exception = null)
+    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null, \Throwable $parentException = null)
     {
         $this->adapter = $adapter;
         $this->exception = $exception;
-        $this->parent_exception = $parent_exception;
+        $this->parentException = $parentException;
     }
 
     abstract protected function processHeader(): void;
@@ -114,7 +114,7 @@ abstract class RendererAbstract
         if ($val instanceof \Closure) {
             return 'closure';
         } elseif (is_object($val)) {
-            return get_class($val) . (\Atk4\Core\TraitUtil::hasTrackableTrait($val) ? ' (' . (get_object_vars($val)['name'] ?? get_object_vars($val)['short_name']) . ')' : '');
+            return get_class($val) . (\Atk4\Core\TraitUtil::hasTrackableTrait($val) ? ' (' . (get_object_vars($val)['name'] ?? get_object_vars($val)['shortName']) . ')' : '');
         } elseif (is_resource($val)) {
             return 'resource';
         } elseif (is_scalar($val) || $val === null) {
@@ -184,20 +184,20 @@ abstract class RendererAbstract
         };
 
         $trace = $custTraceFunc($this->exception);
-        $parent_trace = $shorten && $this->parent_exception !== null ? $custTraceFunc($this->parent_exception) : [];
+        $parentTrace = $shorten && $this->parentException !== null ? $custTraceFunc($this->parentException) : [];
 
-        $both_atk = $this->exception instanceof Exception && $this->parent_exception instanceof Exception;
-        $c = min(count($trace), count($parent_trace));
+        $bothAtk = $this->exception instanceof Exception && $this->parentException instanceof Exception;
+        $c = min(count($trace), count($parentTrace));
         for ($i = 0; $i < $c; ++$i) {
             $cv = $this->parseStackTraceCall($trace[$i]);
-            $pv = $this->parseStackTraceCall($parent_trace[$i]);
+            $pv = $this->parseStackTraceCall($parentTrace[$i]);
 
             if ($cv['line'] === $pv['line']
                     && $cv['file'] === $pv['file']
                     && $cv['class'] === $pv['class']
-                    && (!$both_atk || $cv['object'] === $pv['object'])
+                    && (!$bothAtk || $cv['object'] === $pv['object'])
                     && $cv['function'] === $pv['function']
-                    && (!$both_atk || $cv['args'] === $pv['args'])) {
+                    && (!$bothAtk || $cv['args'] === $pv['args'])) {
                 unset($trace[$i]);
             } else {
                 break;

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -62,7 +62,7 @@ trait HookTrait
     }
 
     /**
-     * Add another callback to be executed during hook($hook_spot);.
+     * Add another callback to be executed during hook($spot);.
      *
      * Lower priority is called sooner. If priority is negative,
      * then hooks will be executed in reverse order.
@@ -214,7 +214,7 @@ trait HookTrait
     }
 
     /**
-     * Execute all closures assigned to $hook_spot.
+     * Execute all closures assigned to $spot.
      *
      * @param array<int, mixed> $args
      *

--- a/src/StaticAddToTrait.php
+++ b/src/StaticAddToTrait.php
@@ -13,7 +13,7 @@ trait StaticAddToTrait
 {
     use DiContainerTrait;
 
-    private static function _addTo_add(object $parent, object $object, array $addArgs, bool $skipAdd = false): void
+    private static function _addToAdd(object $parent, object $object, array $addArgs, bool $skipAdd = false): void
     {
         if (!$skipAdd) {
             $parent->add($object, ...$addArgs);
@@ -37,7 +37,7 @@ trait StaticAddToTrait
     {
         $object = static::fromSeed([static::class], $seed);
 
-        self::_addTo_add($parent, $object, $addArgs, $skipAdd);
+        self::_addToAdd($parent, $object, $addArgs, $skipAdd);
 
         return $object;
     }
@@ -53,7 +53,7 @@ trait StaticAddToTrait
     {
         $object = static::fromSeed($seed);
 
-        self::_addTo_add($parent, $object, $addArgs, $skipAdd);
+        self::_addToAdd($parent, $object, $addArgs, $skipAdd);
 
         return $object;
     }
@@ -69,7 +69,7 @@ trait StaticAddToTrait
     {
         $object = static::fromSeedUnsafe($seed);
 
-        self::_addTo_add($parent, $object, $addArgs, $skipAdd);
+        self::_addToAdd($parent, $object, $addArgs, $skipAdd);
 
         return $object;
     }

--- a/src/TrackableTrait.php
+++ b/src/TrackableTrait.php
@@ -15,7 +15,7 @@ trait TrackableTrait
     private $_owner;
 
     /** @var string Name of the object in owner's element array. */
-    public $short_name;
+    public $shortName;
 
     public function issetOwner(): bool
     {
@@ -87,7 +87,7 @@ trait TrackableTrait
     public function destroy(): void
     {
         if ($this->_owner !== null && TraitUtil::hasContainerTrait($this->_owner)) {
-            $this->_owner->removeElement($this->short_name);
+            $this->_owner->removeElement($this->shortName);
 
             // GC remove reference to app is AppScope in use
             if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp()) {

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -51,25 +51,25 @@ class Generic implements ITranslatorAdapter
      */
     protected function processMessagePlural($definition, array $parameters = [], int $count = 1): string
     {
-        $definitions_forms = is_array($definition) ? $definition : explode('|', $definition);
-        $found_definition = null;
+        $definitionsForms = is_array($definition) ? $definition : explode('|', $definition);
+        $foundDefinition = null;
         switch ((int) $count) {
             case 0:
-                $found_definition = $definitions_forms['zero'] ?? end($definitions_forms);
+                $foundDefinition = $definitionsForms['zero'] ?? end($definitionsForms);
 
                 break;
             case 1:
-                $found_definition = $definitions_forms['one'] ?? null;
+                $foundDefinition = $definitionsForms['one'] ?? null;
 
                 break;
             default:
-                $found_definition = $definitions_forms['other'] ?? null;
+                $foundDefinition = $definitionsForms['other'] ?? null;
 
                 break;
         }
 
         // if no definition found get the first from array
-        $definition = $found_definition ?? array_shift($definitions_forms);
+        $definition = $foundDefinition ?? array_shift($definitionsForms);
 
         return $this->processMessage($definition, $parameters);
     }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -24,10 +24,10 @@ class Translator
     private $adapter;
 
     /** @var string Default domain of translations */
-    protected $default_domain = 'atk';
+    protected $defaultDomain = 'atk';
 
     /** @var string Default language of translations */
-    protected $default_locale = 'en';
+    protected $defaultLocale = 'en';
 
     /**
      * Singleton no public constructor.
@@ -50,12 +50,12 @@ class Translator
             throw new Exception('$adapter must be an instance of ITranslatorAdapter');
         }
 
-        if (!is_string($properties['default_domain'] ?? '')) {
-            throw new Exception('default_domain must be string');
+        if (!is_string($properties['defaultDomain'] ?? '')) {
+            throw new Exception('defaultDomain must be string');
         }
 
-        if (!is_string($properties['default_locale'] ?? '')) {
-            throw new Exception('default_locale must be string');
+        if (!is_string($properties['defaultLocale'] ?? '')) {
+            throw new Exception('defaultLocale must be string');
         }
 
         $this->_setDefaults($properties);
@@ -63,14 +63,14 @@ class Translator
 
     public function setDefaultLocale(string $locale): self
     {
-        $this->default_locale = $locale;
+        $this->defaultLocale = $locale;
 
         return $this;
     }
 
-    public function setDefaultDomain(string $default_domain): self
+    public function setDefaultDomain(string $defaultDomain): self
     {
-        $this->default_domain = $default_domain;
+        $this->defaultDomain = $defaultDomain;
 
         return $this;
     }
@@ -143,6 +143,6 @@ class Translator
      */
     public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string
     {
-        return $this->getAdapter()->_($message, $parameters, $domain ?? $this->default_domain, $locale ?? $this->default_locale);
+        return $this->getAdapter()->_($message, $parameters, $domain ?? $this->defaultDomain, $locale ?? $this->defaultLocale);
     }
 }

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -55,7 +55,7 @@ class AppScopeMock
      */
     public function add($obj, $args = []): object
     {
-        return $this->_add_Container($obj, $args);
+        return $this->_addContainer($obj, $args);
     }
 }
 
@@ -69,7 +69,7 @@ class AppScopeMock2
      */
     public function add($obj, $args = []): object
     {
-        return $this->_add_Container($obj, $args);
+        return $this->_addContainer($obj, $args);
     }
 }
 

--- a/tests/CollectionMock.php
+++ b/tests/CollectionMock.php
@@ -23,7 +23,7 @@ class CollectionMock
 
         $field = Factory::factory($seed);
 
-        $shortNameProp = $field instanceof FieldMockCustom ? 'short_name' : 'name';
+        $shortNameProp = $field instanceof FieldMockCustom ? 'shortName' : 'name';
         Factory::factory($seed, [$shortNameProp => $name]);
 
         return $this->_addIntoCollection($name, $field, 'fields');

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -40,7 +40,7 @@ class CollectionTraitTest extends TestCase
             /** @var string */
             public $name = 'app';
             /** @var int */
-            public $max_name_length = 40;
+            public $maxNameLength = 40;
         });
         $m->name = 'form';
 

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -52,7 +52,7 @@ class ContainerTraitTest extends TestCase
     {
         $app = new ContainerAppMock();
         $app->setApp($app);
-        $app->max_name_length = 40;
+        $app->maxNameLength = 40;
         $m = $app->add(new ContainerAppMock(), 'quick-brown-fox');
         $m = $m->add(new ContainerAppMock(), 'jumps-over-a-lazy-dog');
         $m = $m->add(new ContainerAppMock(), 'then-they-go-out-for-a-pint');
@@ -66,8 +66,8 @@ class ContainerTraitTest extends TestCase
             $m->unshortenName($this)
         );
 
-        $this->assertLessThan(5, count($app->unique_hashes));
-        $this->assertGreaterThan(2, count($app->unique_hashes));
+        $this->assertLessThan(5, count($app->uniqueNameHashes));
+        $this->assertGreaterThan(2, count($app->uniqueNameHashes));
 
         $m->removeElement($x);
 
@@ -81,31 +81,31 @@ class ContainerTraitTest extends TestCase
     {
         $app = new ContainerAppMock();
         $app->setApp($app);
-        $app->max_name_length = 40;
+        $app->maxNameLength = 40;
         $app->name = 'my-app-name-is-pretty-long';
 
-        $max_len = 0;
-        $min_len_v = '';
-        $min_len = 99;
-        $max_len_v = '';
+        $minLength = 9999;
+        $minLengthValue = '';
+        $maxLength = 0;
+        $maxLengthValue = '';
 
         for ($x = 1; $x < 100; ++$x) {
             $sh = str_repeat('x', $x);
             $m = $app->add(new ContainerAppMock(), $sh);
-            if (strlen($m->name) > $max_len) {
-                $max_len = strlen($m->name);
-                $max_len_v = $m->name;
+            if (strlen($m->name) > $maxLength) {
+                $maxLength = strlen($m->name);
+                $maxLengthValue = $m->name;
             }
-            if (strlen($m->name) < $min_len) {
-                $min_len = strlen($m->name);
-                $min_len_v = $m->name;
+            if (strlen($m->name) < $minLength) {
+                $minLength = strlen($m->name);
+                $minLengthValue = $m->name;
             }
         }
 
         // hash is 10 and we want 5 chars minimum for the right side e.g. XYXYXYXY__abcde
-        $this->assertGreaterThanOrEqual(15, $min_len);
+        $this->assertGreaterThanOrEqual(15, $minLength);
         // hash is 10 and we want 5 chars minimum for the right side e.g. XYXYXYXY__abcde
-        $this->assertLessThanOrEqual($app->max_name_length, $max_len);
+        $this->assertLessThanOrEqual($app->maxNameLength, $maxLength);
     }
 
     public function testPreservePresetNames(): void
@@ -113,7 +113,7 @@ class ContainerTraitTest extends TestCase
         $app = new ContainerAppMock();
         $app->setApp($app);
         $app->name = 'r';
-        $app->max_name_length = 40;
+        $app->maxNameLength = 40;
 
         $createTrackableMockFx = function (string $name, bool $isLongName = false) {
             return new class($name, $isLongName) extends TrackableMock {
@@ -124,7 +124,7 @@ class ContainerTraitTest extends TestCase
                     if ($isLongName) {
                         $this->name = $name;
                     } else {
-                        $this->short_name = $name;
+                        $this->shortName = $name;
                     }
                 }
             };
@@ -148,7 +148,7 @@ class ContainerTraitTest extends TestCase
 
         $m3 = $m->add([TrackableContainerMock::class], 'name');
         $this->assertSame(TrackableContainerMock::class, get_class($m3));
-        $this->assertSame('name', $m3->short_name);
+        $this->assertSame('name', $m3->shortName);
     }
 
     public function testArgs(): void
@@ -160,7 +160,7 @@ class ContainerTraitTest extends TestCase
             use Core\NameTrait;
         }, ['name' => 'foo']);
         $this->assertTrue($m->hasElement('foo'));
-        $this->assertSame('foo', $m2->short_name);
+        $this->assertSame('foo', $m2->shortName);
     }
 
     public function testExceptionExists(): void
@@ -248,7 +248,7 @@ class ContainerAppMock
     {
         $n = $this->name;
 
-        $d = array_flip($this->getApp()->unique_hashes);
+        $d = array_flip($this->getApp()->uniqueNameHashes);
 
         for ($x = 0; strpos($n, '__') !== false && $x < 100; ++$x) {
             [$l, $r] = explode('__', $n);

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -159,11 +159,9 @@ class DebugTraitTest extends TestCase
 class DebugMock
 {
     use AppScopeTrait;
-    use DebugTrait {
-        _echo_stderr as private __echo_stderr;
-    }
+    use DebugTrait;
 
-    protected function _echo_stderr(string $message): void
+    protected function _echoStderr(string $message): void
     {
         echo $message;
     }

--- a/tests/Translator/AdapterGenericTest.php
+++ b/tests/Translator/AdapterGenericTest.php
@@ -43,7 +43,7 @@ class AdapterGenericTest extends AdapterBaseTest
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([
-            'default_domain' => 123, // just to throw exception
+            'defaultDomain' => 123, // just to throw exception
         ]);
     }
 
@@ -51,7 +51,7 @@ class AdapterGenericTest extends AdapterBaseTest
     {
         $this->expectException(Exception::class);
         Translator::instance()->setDefaults([
-            'default_locale' => 123, // just to throw exception
+            'defaultLocale' => 123, // just to throw exception
         ]);
     }
 
@@ -89,8 +89,8 @@ class AdapterGenericTest extends AdapterBaseTest
         // test plurals
         Translator::instance()->setDefaults([
             'adapter' => $adapter,
-            'default_domain' => 'other',
-            'default_locale' => 'en',
+            'defaultDomain' => 'other',
+            'defaultLocale' => 'en',
         ]);
 
         $adapter->setDefinitionSingle('test', [
@@ -111,8 +111,8 @@ class AdapterGenericTest extends AdapterBaseTest
         // test plurals
         Translator::instance()->setDefaults([
             'adapter' => $adapter,
-            'default_domain' => 'other',
-            'default_locale' => 'en',
+            'defaultDomain' => 'other',
+            'defaultLocale' => 'en',
         ]);
 
         $adapter->setDefinitionSingle('test', [
@@ -132,8 +132,8 @@ class AdapterGenericTest extends AdapterBaseTest
         // test plurals
         Translator::instance()->setDefaults([
             'adapter' => $adapter,
-            'default_domain' => 'other',
-            'default_locale' => 'en',
+            'defaultDomain' => 'other',
+            'defaultLocale' => 'en',
         ]);
 
         $adapter->setDefinitionSingle('test', [


### PR DESCRIPTION
mainly rename `short_name` to `shortName`

regex used to find places to replace: `(->|\$)(?!(GITHUB_EVENT_NAME|LOG_COVERAGE|_atk__(core|data)__hintable_magic__\w+)(?!\w))_*((?!_)\w)+?_`

`(->|\$|function |::)`

to find places to fix your code, I advise to replace `(?<!\w)short_name(?!\w)` with `short_name` first