### PR TITLE
Fix coverage collection for skipped/incomplete tests

### DIFF
--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends BaseTestCase
                 }
             };
             $alreadyAdded = false;
-            foreach (\Closure::bind(fn () => $testResult->listeners, null, TestResult::class)() as $listener) {
+            foreach (\Closure::bind(fn () => $testResult->listeners, null, TestResult::class)() as $listener) { // @phpstan-ignore-line
                 if ($listener instanceof TestListenerAdapter) {
                     foreach (\Closure::bind(fn () => $listener->hooks, null, TestListenerAdapter::class)() as $hook) {
                         if (get_class($hook) === get_class($afterHookTest)) {
@@ -104,7 +104,7 @@ abstract class TestCase extends BaseTestCase
             if (!$alreadyAdded) {
                 $testListenerAdapter = new TestListenerAdapter();
                 $testListenerAdapter->add($afterHookTest);
-                $testResult->addListener($testListenerAdapter);
+                $testResult->addListener($testListenerAdapter); // @phpstan-ignore-line
             }
             $testResult->beStrictAboutTestsThatDoNotTestAnything(false);
         }

--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -85,6 +85,10 @@ abstract class TestCase extends BaseTestCase
                     $linesToBeUsed = TestUtil::getLinesToBeUsed(static::class, $this->getName(false));
                     $coverage->stop(true, $linesToBeCovered, $linesToBeUsed);
                     $coverage->start($coverageId);
+
+                    // DEBUG cov
+                    $coverage->stop(true, $linesToBeCovered, $linesToBeUsed);
+                    $coverage->start($coverageId);
                 }
             }
         }

--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -6,6 +6,9 @@ namespace Atk4\Core\Phpunit;
 
 use Atk4\Core\WarnDynamicPropertyTrait;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Util\Test as TestUtil;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
 
 /**
  * Generic TestCase for PHPUnit tests for ATK4 repos.
@@ -66,8 +69,24 @@ abstract class TestCase extends BaseTestCase
 
         // fix coverage when no assertion is expected
         // https://github.com/sebastianbergmann/phpunit/pull/5010
-        if ($this->getNumAssertions() === 0 && $this->doesNotPerformAssertions()) {
+        if ($this->getStatus() === BaseTestRunner::STATUS_PASSED && $this->getNumAssertions() === 0 && $this->doesNotPerformAssertions()) {
             $this->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);
+        }
+
+        // fix coverage for skipped/incomplete tests
+        // https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L830
+        // https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L857
+        if (in_array($this->getStatus(), [BaseTestRunner::STATUS_SKIPPED, BaseTestRunner::STATUS_INCOMPLETE], true)) {
+            $coverage = $this->getTestResultObject()->getCodeCoverage();
+            if ($coverage !== null) {
+                $coverageId = \Closure::bind(fn () => $coverage->currentId, null, CodeCoverage::class)();
+                if ($coverageId !== null) { // @phpstan-ignore-line https://github.com/sebastianbergmann/php-code-coverage/pull/923
+                    $linesToBeCovered = TestUtil::getLinesToBeCovered(static::class, $this->getName(false));
+                    $linesToBeUsed = TestUtil::getLinesToBeUsed(static::class, $this->getName(false));
+                    $coverage->stop(true, $linesToBeCovered, $linesToBeUsed);
+                    $coverage->start($coverageId);
+                }
+            }
         }
     }
 

--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -85,10 +85,6 @@ abstract class TestCase extends BaseTestCase
                     $linesToBeUsed = TestUtil::getLinesToBeUsed(static::class, $this->getName(false));
                     $coverage->stop(true, $linesToBeCovered, $linesToBeUsed);
                     $coverage->start($coverageId);
-
-                    // DEBUG cov
-                    $coverage->stop(true, $linesToBeCovered, $linesToBeUsed);
-                    $coverage->start($coverageId);
                 }
             }
         }

--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -74,8 +74,8 @@ abstract class TestCase extends BaseTestCase
         }
 
         // fix coverage for skipped/incomplete tests
-        // https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L830
-        // https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L857
+        // based on https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L830
+        // and https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/TestResult.php#L857
         if (in_array($this->getStatus(), [BaseTestRunner::STATUS_SKIPPED, BaseTestRunner::STATUS_INCOMPLETE], true)) {
             $coverage = $this->getTestResultObject()->getCodeCoverage();
             if ($coverage !== null) {

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -17,7 +17,7 @@ trait WarnDynamicPropertyTrait
         $class = static::class;
         try {
             $propRefl = new \ReflectionProperty($class, $name);
-            if (!$propRefl->isPrivate()) {
+            if (!$propRefl->isPrivate() && !$propRefl->isPublic()) {
                 throw new \Error('Cannot access protected property ' . $class . '::$' . $name);
             }
         } catch (\ReflectionException $e) {

--- a/src/WarnDynamicPropertyTrait.php
+++ b/src/WarnDynamicPropertyTrait.php
@@ -17,7 +17,7 @@ trait WarnDynamicPropertyTrait
         $class = static::class;
         try {
             $propRefl = new \ReflectionProperty($class, $name);
-            if (!$propRefl->isPrivate() && !$propRefl->isPublic()) {
+            if (!$propRefl->isPrivate() && !$propRefl->isPublic() && !$propRefl->isStatic()) {
                 throw new \Error('Cannot access protected property ' . $class . '::$' . $name);
             }
         } catch (\ReflectionException $e) {

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -41,7 +41,7 @@ class ResultPrinterTest extends TestCase
             public static int $counter = 0;
         });
         if (++$staticClass::$counter > 2) {
-            // allow this test to be run max. twice, phpunit new ExceptionWrapper() is leaking memory,
+            // allow this test to be run max. twice, new ExceptionWrapper() is leaking memory,
             // see https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/ExceptionWrapper.php#L112
             // https://github.com/sebastianbergmann/phpunit/pull/5012
             return;

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -56,12 +56,12 @@ class ResultPrinterTest extends TestCase
                         ]
                     ]
 
-                self.php:36
+                self.php:32
 
                 Caused by
                 Error: Inner Exception
 
-                self.php:35
+                self.php:31
                 EOF . "\n", // NL in the string is not parsed by Netbeans, see https://github.com/apache/netbeans/issues/4345
             str_replace(__FILE__, 'self.php', $res)
         );

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -37,6 +37,16 @@ class ResultPrinterTest extends TestCase
         $this->assertStringContainsString((string) $exception, $resNotWrapped);
         $this->assertStringContainsString((string) $innerException, $resNotWrapped);
 
+        $staticClass = get_class(new class() {
+            public static int $counter = 0;
+        });
+        if (++$staticClass::$counter > 2) {
+            // allow this test to be run max. twice, phpunit new ExceptionWrapper() is leaking memory,
+            // see https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/ExceptionWrapper.php#L112
+            // https://github.com/sebastianbergmann/phpunit/pull/5012
+            return;
+        }
+
         $res = $this->printAndReturnDefectTrace(ResultPrinter::class, new ExceptionWrapper($exception));
         $this->assertTrue(strlen($res) < strlen($resNotWrapped));
         if (\PHP_MAJOR_VERSION < 8) {

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -44,7 +44,9 @@ class ResultPrinterTest extends TestCase
             // allow this test to be run max. twice, new ExceptionWrapper() is leaking memory,
             // see https://github.com/sebastianbergmann/phpunit/blob/9.5.21/src/Framework/ExceptionWrapper.php#L112
             // https://github.com/sebastianbergmann/phpunit/pull/5012
+            // @codeCoverageIgnoreStart
             return;
+            // @codeCoverageIgnoreEnd
         }
 
         $res = $this->printAndReturnDefectTrace(ResultPrinter::class, new ExceptionWrapper($exception));

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core\Tests\Phpunit;
+
+use Atk4\Core\Exception;
+use Atk4\Core\Phpunit\ResultPrinter;
+use Atk4\Core\Phpunit\TestCase;
+use PHPUnit\Framework\ExceptionWrapper;
+use PHPUnit\Framework\TestFailure;
+
+class ResultPrinterTest extends TestCase
+{
+    /**
+     * @param class-string<ResultPrinter> $resultPrinterClass
+     */
+    private function printAndReturnDefectTrace($resultPrinterClass, \Throwable $exception): string
+    {
+        $defect = new TestFailure($this, $exception);
+        $stream = fopen('php://memory', 'w+');
+        $printer = new $resultPrinterClass($stream);
+        \Closure::bind(fn () => $printer->printDefectTrace($defect), null, $resultPrinterClass)();
+        fseek($stream, 0);
+
+        return stream_get_contents($stream);
+    }
+
+    public function testBasic(): void
+    {
+        $innerException = new \Error('Inner Exception');
+        $exception = (new Exception('My exception', 0, $innerException))
+            ->addMoreInfo('x', 'foo')
+            ->addMoreInfo('y', ['bar' => 2.4, [], [[1]]]);
+
+        $resNotWrapped = $this->printAndReturnDefectTrace(ResultPrinter::class, $exception);
+        $this->assertStringContainsString((string) $exception, $resNotWrapped);
+        $this->assertStringContainsString((string) $innerException, $resNotWrapped);
+
+        $res = $this->printAndReturnDefectTrace(ResultPrinter::class, new ExceptionWrapper($exception));
+        $this->assertTrue(strlen($res) < strlen($resNotWrapped));
+        if (\PHP_MAJOR_VERSION < 8) {
+            // phpvfscomposer:// is not correctly filtered from stacktrace
+            // by PHPUnit\Util\Filter::getFilteredStacktrace() method
+            return;
+        }
+        $this->assertSame(
+            <<<'EOF'
+                Atk4\Core\Exception: My exception
+                  x: 'foo'
+                  y: [
+                      'bar': 2.4,
+                      0: [],
+                      1: [
+                          ...
+                        ]
+                    ]
+
+                self.php:36
+
+                Caused by
+                Error: Inner Exception
+
+                self.php:35
+                EOF . "\n", // NL in the string is not parsed by Netbeans, see https://github.com/apache/netbeans/issues/4345
+            str_replace(__FILE__, 'self.php', $res)
+        );
+    }
+}

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -22,7 +22,10 @@ class TestCaseTest extends TestCase
      */
     public function testProviderCoverage1(string $v): void
     {
-        $this->markTestIncomplete('test II');
+        if ($v === 'y') {
+            $this->assertSame(2, self::$providerCallCounter);
+        }
+        $this->assertTrue(in_array($v, ['a', 'x', 'y'], true));
     }
 
     public function provideProviderCoverage1(): \Traversable

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -22,10 +22,7 @@ class TestCaseTest extends TestCase
      */
     public function testProviderCoverage1(string $v): void
     {
-        if ($v === 'y') {
-            $this->assertSame(2, self::$providerCallCounter);
-        }
-        $this->assertTrue(in_array($v, ['a', 'x', 'y'], true));
+        $this->markTestIncomplete('test II');
     }
 
     public function provideProviderCoverage1(): \Traversable

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -63,7 +63,7 @@ class TestCaseTest extends TestCase
 
         if ($v === 'b') {
             // make sure TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
-            // after this test by AfterTestHook hook added in our TestCase
+            // after this test by AfterTestHook hook added by our TestCase
             return;
         }
 

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -53,15 +53,15 @@ class TestCaseTest extends TestCase
             public static int $counter = 0;
         });
         if ($v === 'a' && ++$staticClass::$counter > 1) {
-            // allow phpunit TestCase::runBare() to be run more than once
+            // allow TestCase::runBare() to be run more than once
             return;
         }
 
         $this->assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
 
         if ($v === 'b') {
-            // make sure phpunit TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
-            // after this test using phpunit AfterTestHook hook
+            // make sure TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
+            // after this test by AfterTestHook hook added in our TestCase
             return;
         }
 

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -22,17 +22,18 @@ class TestCaseTest extends TestCase
      * @dataProvider provideProviderCoverage1
      * @dataProvider provideProviderCoverage2
      */
-    public function testProviderCoverage1(string $v): void
+    public function testProviderCoverage(string $v): void
     {
         if ($v === 'y') {
             $this->assertSame(2, self::$providerCallCounter);
         }
-        $this->assertTrue(in_array($v, ['a', 'x', 'y'], true));
+        $this->assertTrue(in_array($v, ['a', 'b', 'x', 'y'], true));
     }
 
     public function provideProviderCoverage1(): \Traversable
     {
         yield ['a'];
+        yield ['b'];
     }
 
     public function provideProviderCoverage2(): \Traversable
@@ -42,6 +43,38 @@ class TestCaseTest extends TestCase
         yield ['y'];
     }
 
+    /**
+     * @dataProvider provideProviderCoverage1
+     */
+    public function testCoverageImplForDoesNotPerformAssertions(string $v): void
+    {
+        $this->assertFalse($this->doesNotPerformAssertions());
+        $this->assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
+
+        if ($v === 'b') {
+            // make sure TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
+            // after this test using phpunit AfterTestHook
+            return;
+        }
+
+        $testStatusOrig = \Closure::bind(fn () => $this->status, $this, PhpunitTestCase::class)();
+        \Closure::bind(fn () => $this->status = BaseTestRunner::STATUS_PASSED, $this, PhpunitTestCase::class)();
+        try {
+            \Closure::bind(fn () => $this->doesNotPerformAssertions = true, $this, PhpunitTestCase::class)();
+            try {
+                $this->tearDown();
+            } finally {
+                \Closure::bind(fn () => $this->doesNotPerformAssertions = false, $this, PhpunitTestCase::class)();
+            }
+        } finally {
+            \Closure::bind(fn () => $this->status = $testStatusOrig, $this, PhpunitTestCase::class)();
+        }
+        $this->assertFalse($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCoverageImplForTestMarkedAsIncomplete(): void
     {
         $testStatusOrig = \Closure::bind(fn () => $this->status, $this, PhpunitTestCase::class)();

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -10,8 +10,7 @@ use PHPUnit\Runner\BaseTestRunner;
 
 class TestCaseTest extends TestCase
 {
-    /** @var int */
-    private static $providerCallCounter = 0;
+    private static int $providerCallCounter = 0;
 
     private function coverCoverageFromProvider(): void
     {
@@ -49,11 +48,20 @@ class TestCaseTest extends TestCase
     public function testCoverageImplForDoesNotPerformAssertions(string $v): void
     {
         $this->assertFalse($this->doesNotPerformAssertions());
+
+        $staticClass = get_class(new class() {
+            public static int $counter = 0;
+        });
+        if ($v === 'a' && ++$staticClass::$counter > 1) {
+            // allow phpunit TestCase::runBare() to be run more than once
+            return;
+        }
+
         $this->assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
 
         if ($v === 'b') {
-            // make sure TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
-            // after this test using phpunit AfterTestHook
+            // make sure phpunit TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
+            // after this test using phpunit AfterTestHook hook
             return;
         }
 
@@ -69,6 +77,7 @@ class TestCaseTest extends TestCase
         } finally {
             \Closure::bind(fn () => $this->status = $testStatusOrig, $this, PhpunitTestCase::class)();
         }
+
         $this->assertFalse($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
     }
 

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -24,6 +24,8 @@ class TestCaseTest extends TestCase
     {
         if ($v === 'y') {
             $this->assertSame(2, self::$providerCallCounter);
+        } else {
+            $this->markTestIncomplete('test');
         }
         $this->assertTrue(in_array($v, ['a', 'x', 'y'], true));
     }

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -24,8 +24,6 @@ class TestCaseTest extends TestCase
     {
         if ($v === 'y') {
             $this->assertSame(2, self::$providerCallCounter);
-        } else {
-            $this->markTestIncomplete('test');
         }
         $this->assertTrue(in_array($v, ['a', 'x', 'y'], true));
     }

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Atk4\Core\Tests\Phpunit;
 
 use Atk4\Core\Phpunit\TestCase;
+use PHPUnit\Framework\TestCase as PhpunitTestCase;
+use PHPUnit\Runner\BaseTestRunner;
 
 class TestCaseTest extends TestCase
 {
@@ -38,5 +40,16 @@ class TestCaseTest extends TestCase
         yield ['x'];
         $this->coverCoverageFromProvider();
         yield ['y'];
+    }
+
+    public function testCoverageImplForTestMarkedAsIncomplete(): void
+    {
+        $testStatusOrig = \Closure::bind(fn () => $this->status, $this, PhpunitTestCase::class)();
+        \Closure::bind(fn () => $this->status = BaseTestRunner::STATUS_INCOMPLETE, $this, PhpunitTestCase::class)();
+        try {
+            $this->tearDown();
+        } finally {
+            \Closure::bind(fn () => $this->status = $testStatusOrig, $this, PhpunitTestCase::class)();
+        }
     }
 }

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -54,7 +54,9 @@ class TestCaseTest extends TestCase
         });
         if ($v === 'a' && ++$staticClass::$counter > 1) {
             // allow TestCase::runBare() to be run more than once
+            // @codeCoverageIgnoreStart
             return;
+            // @codeCoverageIgnoreEnd
         }
 
         $this->assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core\Tests;
+
+use Atk4\Core\Exception as ClassWithWarnDynamicPropertyTrait;
+use Atk4\Core\Phpunit\TestCase;
+
+class WarnDynamicPropertyTraitTest extends TestCase
+{
+    protected function runWithErrorConvertedToException(\Closure $fx): void
+    {
+        set_error_handler(function (int $errno, string $errstr): void {
+            throw new WarnError($errstr);
+        });
+        try {
+            $fx();
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public function testIssetException(): void
+    {
+        $this->runWithErrorConvertedToException(function () {
+            $test = new ClassWithWarnDynamicPropertyTrait();
+
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
+            isset($test->xxx);
+        });
+    }
+
+    public function testGetException(): void
+    {
+        $this->runWithErrorConvertedToException(function () {
+            $test = new ClassWithWarnDynamicPropertyTrait();
+
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
+            $test->xxx;
+        });
+    }
+
+    public function testSetException(): void
+    {
+        $this->runWithErrorConvertedToException(function () {
+            $test = new ClassWithWarnDynamicPropertyTrait();
+
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
+            $test->xxx = 5;
+        });
+    }
+
+    public function testUnsetException(): void
+    {
+        $this->runWithErrorConvertedToException(function () {
+            $test = new ClassWithWarnDynamicPropertyTrait();
+
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
+            unset($test->xxx);
+        });
+    }
+
+    public function testGetProtectedPropertyException(): void
+    {
+        $test = new ClassWithWarnDynamicPropertyTrait();
+
+        $this->expectException(\Error::class);
+        $this->expectErrorMessage('Cannot access protected property Atk4\Core\Exception::$customExceptionTitle');
+        $test->customExceptionTitle;
+    }
+}
+
+class WarnError extends \Exception
+{
+}

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -62,7 +62,22 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            unset($test->{'xxx'}); // @phpstan-ignore-line
+            unset($test->{'xxx'});
+        });
+    }
+
+    public function testGetSetPublicProperty(): void
+    {
+        $test = new ClassWithWarnDynamicPropertyTrait();
+        $this->assertTrue(isset($test->params)); // @phpstan-ignore-line
+        $test->params = ['foo'];
+        $this->assertSame(['foo'], $test->params);
+        unset($test->{'params'});
+
+        $this->runWithErrorConvertedToException(function () use ($test) {
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$params');
+            $test->params; // @phpstan-ignore-line
         });
     }
 
@@ -72,7 +87,18 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
         $this->expectException(\Error::class);
         $this->expectErrorMessage('Cannot access protected property Atk4\Core\Exception::$customExceptionTitle');
-        $test->customExceptionTitle;
+        $test->customExceptionTitle; // @phpstan-ignore-line
+    }
+
+    public function testGetPrivateProperty(): void
+    {
+        $this->runWithErrorConvertedToException(function () {
+            $test = new ClassWithWarnDynamicPropertyTrait();
+
+            $this->expectException(WarnError::class);
+            $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$trace2');
+            $test->trace2; // @phpstan-ignore-line
+        });
     }
 }
 

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -28,7 +28,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            isset($test->xxx);
+            isset($test->xxx); // @phpstan-ignore-line
         });
     }
 
@@ -39,7 +39,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            $test->xxx;
+            $test->xxx; // @phpstan-ignore-line
         });
     }
 
@@ -50,7 +50,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            $test->xxx = 5;
+            $test->xxx = 5; // @phpstan-ignore-line
         });
     }
 
@@ -61,7 +61,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            unset($test->{'xxx'});
+            unset($test->{'xxx'}); // @phpstan-ignore-line
         });
     }
 

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -61,7 +61,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
             $this->expectException(WarnError::class);
             $this->expectErrorMessage('Undefined property: Atk4\Core\Exception::$xxx');
-            unset($test->xxx);
+            unset($test->{'xxx'});
         });
     }
 

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -23,6 +23,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
 
     public function testIssetException(): void
     {
+        $this->runWithErrorConvertedToException(fn () => null);
         $this->runWithErrorConvertedToException(function () {
             $test = new ClassWithWarnDynamicPropertyTrait();
 


### PR DESCRIPTION
fix https://github.com/sebastianbergmann/php-code-coverage/issues/922

also fix https://github.com/atk4/core/pull/355 so the global TestResult is reset (by AfterTestHook hook)