### PR TITLE
Optimize hook clone performance

### DIFF
--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -84,6 +84,7 @@ trait CollectionTrait
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);
         }
+
         unset($this->{$collection}[$name]);
     }
 
@@ -112,9 +113,7 @@ trait CollectionTrait
      */
     public function _hasInCollection(string $name, string $collection): bool
     {
-        $data = $this->{$collection};
-
-        return isset($data[$name]);
+        return isset($this->{$collection}[$name]);
     }
 
     /**
@@ -122,13 +121,14 @@ trait CollectionTrait
      */
     public function _getFromCollection(string $name, string $collection): object
     {
-        if (!$this->_hasInCollection($name, $collection)) {
+        $res = $this->{$collection}[$name] ?? null;
+        if ($res === null) {
             throw (new Exception('Element is NOT in the collection'))
                 ->addMoreInfo('collection', $collection)
                 ->addMoreInfo('name', $name);
         }
 
-        return $this->{$collection}[$name];
+        return $res;
     }
 
     /**

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -139,32 +139,21 @@ trait CollectionTrait
     protected function _shortenMl(string $ownerName, string $itemShortName, ?string $origItemName): string
     {
         // ugly hack to deduplicate code
-        $collectionTraitHelper = \Closure::bind(function () {
-            $factory = Factory::getInstance();
-            if (!property_exists($factory, 'collectionTraitHelper')) {
-                $collectionTraitHelper = new class() {
-                    use AppScopeTrait;
-                    use ContainerTrait;
+        $collectionTraitHelper = new class() {
+            use AppScopeTrait;
+            use ContainerTrait;
 
-                    public function shorten(?object $app, string $ownerName, string $itemShortName, ?string $origItemName): string
-                    {
-                        try {
-                            $this->setApp($app);
+            public function shorten(?object $app, string $ownerName, string $itemShortName, ?string $origItemName): string
+            {
+                try {
+                    $this->setApp($app);
 
-                            return $this->_shorten($ownerName, $itemShortName, $origItemName);
-                        } finally {
-                            $this->_app = null; // important for GC
-                        }
-                    }
-                };
-
-                // @phpstan-ignore-next-line
-                @$factory->collectionTraitHelper = $collectionTraitHelper;
+                    return $this->_shorten($ownerName, $itemShortName, $origItemName);
+                } finally {
+                    $this->_app = null; // important for GC
+                }
             }
-
-            // @phpstan-ignore-next-line
-            return $factory->collectionTraitHelper;
-        }, null, Factory::class)();
+        };
 
         return $collectionTraitHelper->shorten(TraitUtil::hasAppScopeTrait($this) ? $this->getApp() : null, $ownerName, $itemShortName, $origItemName);
     }

--- a/src/HookInstanceWithoutConstructorCache.php
+++ b/src/HookInstanceWithoutConstructorCache.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core;
+
+/**
+ * TODO move to anonymous class into HookTrait once https://github.com/phpstan/phpstan/issues/8741 is fixed.
+ */
+class HookInstanceWithoutConstructorCache
+{
+    /** @var array<class-string, object> */
+    private static array $_instances = [];
+
+    /**
+     * @param class-string $class
+     */
+    public function getInstance(string $class): object
+    {
+        if (!isset(self::$_instances[$class])) {
+            self::$_instances[$class] = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        }
+
+        return self::$_instances[$class];
+    }
+}

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -106,7 +106,7 @@ trait HookTrait
                 return $fx(...$args);
             };
         } elseif ($fxThis === null) {
-            $fxLong = \Closure::bind(function ($ignore, &...$args) use ($fx) {
+            $fxLong = \Closure::bind(static function ($ignore, &...$args) use ($fx) {
                 return $fx(...$args);
             }, null, $fxScopeClassRefl->getName());
         } else {
@@ -123,13 +123,13 @@ trait HookTrait
      */
     private function makeHookDynamicFx(\Closure $getFxThisFx, \Closure $fx, array $args, bool $isShort): \Closure
     {
-        return function ($ignore, &...$args) use ($getFxThisFx, $fx, $isShort) {
-            $fxThis = $getFxThisFx($this);
-            if ($fxThis === null) {
-                throw new Exception('New $this cannot be null');
+        return static function (self $target, &...$args) use ($getFxThisFx, $fx, $isShort) {
+            $fxThis = $getFxThisFx($target);
+            if (!is_object($fxThis)) {
+                throw new Exception('New $this must be an object');
             }
 
-            return \Closure::bind($fx, $fxThis)(...($isShort ? [] : [$this]), ...$args);
+            return \Closure::bind($fx, $fxThis)(...($isShort ? [] : [$target]), ...$args);
         };
     }
 

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -26,9 +26,9 @@ trait HookTrait
                 return;
             }
 
-            foreach ($this->hooks as &$hooksByPriority) {
-                foreach ($hooksByPriority as &$hooksByIndex) {
-                    foreach ($hooksByIndex as &$hookData) {
+            foreach ($this->hooks as $spot => $hooksByPriority) {
+                foreach ($hooksByPriority as $priority => $hooksByIndex) {
+                    foreach ($hooksByIndex as $index => $hookData) {
                         $fxRefl = new \ReflectionFunction($hookData[0]);
                         $fxThis = $fxRefl->getClosureThis();
                         if ($fxThis === null) {
@@ -49,11 +49,10 @@ trait HookTrait
                             continue;
                         }
 
-                        $hookData[0] = \Closure::bind($hookData[0], $this);
+                        $this->hooks[$spot][$priority][$index][0] = \Closure::bind($hookData[0], $this);
                     }
                 }
             }
-            unset($hooksByPriority, $hooksByIndex, $hookData);
         }
 
         $this->_hookOrigThis = $this;

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -236,6 +236,12 @@ class HookTraitTest extends TestCase
     {
         $m = new HookMock();
 
+        // unscoped callback
+        $m->onHookShort('inc', \Closure::bind(static function (...$args) {
+            TestCase::assertSame(['y', 'x'], $args);
+        }, null, null), ['x']);
+        $m->hook('inc', ['y']);
+
         // unbound callback
         $m->onHookShort('inc', static function (...$args) {
             static::assertSame(['y', 'x'], $args);
@@ -323,8 +329,8 @@ class HookTraitTest extends TestCase
 
         static::assertSame([$hookThis], $m->hook('inc'));
         static::assertSame(1, $m->result);
-        $mCloned = clone $m;
 
+        $mCloned = clone $m;
         static::assertSame([$hookThis], $m->hook('inc'));
         static::assertSame(2, $m->result);
         static::assertSame(1, $mCloned->result);
@@ -347,6 +353,66 @@ class HookTraitTest extends TestCase
         static::assertSame([$hookThis], $mCloned->hook('inc'));
         static::assertSame(5, $m->result);
         static::assertSame(3, $mCloned->result);
+
+        $m->onHookDynamicShort('incShort', static function () use (&$hookThis) {
+            return $hookThis;
+        }, function (...$args) use (&$hookThis) {
+            TestCase::assertSame($hookThis, $this);
+            TestCase::assertSame(['y', 'x'], $args);
+
+            return $this->hook('inc');
+        }, ['x']);
+        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        static::assertSame(6, $m->result);
+        static::assertSame(3, $mCloned->result);
+
+        $mCloned = clone $m;
+        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        static::assertSame(7, $m->result);
+        static::assertSame(6, $mCloned->result);
+        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        static::assertSame(8, $m->result);
+        static::assertSame(6, $mCloned->result);
+
+        $hookThis = $mCloned;
+        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        static::assertSame(8, $m->result);
+        static::assertSame(7, $mCloned->result);
+        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        static::assertSame(8, $m->result);
+        static::assertSame(8, $mCloned->result);
+
+        $hookThis = $m;
+        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        static::assertSame(9, $m->result);
+        static::assertSame(8, $mCloned->result);
+        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        static::assertSame(10, $m->result);
+        static::assertSame(8, $mCloned->result);
+    }
+
+    public function testOnHookDynamicBoundGetterException(): void
+    {
+        $m = new HookMock();
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('New $this getter must be static');
+        $m->onHookDynamic('inc', function (HookMock $m) {
+            return $m;
+        }, fn ($v) => $v);
+    }
+
+    public function testOnHookDynamicGetterNullException(): void
+    {
+        $m = new HookMock();
+
+        $m->onHookDynamic('inc', static function (HookMock $m) {
+            return null;
+        }, fn ($v) => $v);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('New $this must be an object');
+        $m->hook('inc');
     }
 
     public function testPassByReference(): void

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -317,7 +317,7 @@ class HookTraitTest extends TestCase
         };
 
         $hookThis = $m;
-        $m->onHookDynamic('inc', function () use (&$hookThis) {
+        $m->onHookDynamic('inc', static function () use (&$hookThis) {
             return $hookThis;
         }, $m->makeCallback());
 
@@ -373,7 +373,7 @@ class HookTraitTest extends TestCase
 
         $value = 0;
         $m = new HookMock();
-        $m->onHookDynamic('inc', function () use ($m) {
+        $m->onHookDynamic('inc', static function () use ($m) {
             return clone $m;
         }, function ($ignoreObject, $ignore1st, int &$value) {
             ++$value;

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -225,7 +225,7 @@ class HookTraitTest extends TestCase
         $m->result = 0;
 
         $m->onHook('inc', function ($obj) {
-            throw new \Atk4\Core\Exception('stuff went wrong');
+            throw new Exception('stuff went wrong');
         });
 
         $this->expectException(Exception::class);


### PR DESCRIPTION
atk4/data entity is created using clone, performance is critical

Time spent in `Model::createEntity()` is reduced by ~65%.