### PR TITLE
Fix CS to use self:: for phpunit static method calls

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -53,6 +53,8 @@ return (new PhpCsFixer\Config())
         // fn => without curly brackets is less readable,
         // also prevent bounding of unwanted variables for GC
         'use_arrow_functions' => false,
+
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'], // remove once PHP CS Fixer is upgraded to v3.17
     ])
     ->setFinder($finder)
     ->setCacheFile(sys_get_temp_dir() . '/php-cs-fixer.' . md5(__DIR__) . '.cache');

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,8 +9,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
-        '@PHP74Migration:risky' => true,
         '@PHP74Migration' => true,
+        '@PHP74Migration:risky' => true,
 
         // required by PSR-12
         'concat_space' => [

--- a/tests/AppScopeTraitTest.php
+++ b/tests/AppScopeTraitTest.php
@@ -20,16 +20,16 @@ class AppScopeTraitTest extends TestCase
         $m->setApp($fakeApp);
 
         $c = $m->add(new AppScopeChildBasic());
-        static::assertSame($fakeApp, $c->getApp());
+        self::assertSame($fakeApp, $c->getApp());
 
         $c = $m->add(new AppScopeChildWithoutAppScope());
-        static::assertFalse(property_exists($c, 'app'));
-        static::assertFalse(property_exists($c, '_app'));
+        self::assertFalse(property_exists($c, 'app'));
+        self::assertFalse(property_exists($c, '_app'));
 
         $m = new AppScopeMock2();
 
         $c = $m->add(new AppScopeChildBasic());
-        static::assertFalse($c->issetApp());
+        self::assertFalse($c->issetApp());
 
         // test for GC
         $m = new AppScopeMock();
@@ -37,8 +37,8 @@ class AppScopeTraitTest extends TestCase
         $child = new AppScopeChildTrackable();
         $m->add($child);
         $child->destroy();
-        static::assertNull($this->getProtected($child, '_app'));
-        static::assertFalse($child->issetOwner());
+        self::assertNull($this->getProtected($child, '_app'));
+        self::assertFalse($child->issetOwner());
     }
 
     public function testAppNotSetException(): void

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -19,17 +19,17 @@ class CollectionTraitTest extends TestCase
         $m = new CollectionMock();
         $m->addField('name');
 
-        static::assertTrue($m->hasField('name'));
+        self::assertTrue($m->hasField('name'));
 
         $m->addField('surname', [FieldMockCustom::class]);
 
-        static::assertSame(FieldMockCustom::class, get_class($m->getField('surname')));
+        self::assertSame(FieldMockCustom::class, get_class($m->getField('surname')));
         /** @var FieldMockCustom $field */
         $field = $m->getField('surname');
-        static::assertTrue($field->var);
+        self::assertTrue($field->var);
 
         $m->removeField('name');
-        static::assertFalse($m->hasField('name'));
+        self::assertFalse($m->hasField('name'));
     }
 
     /**
@@ -51,13 +51,13 @@ class CollectionTraitTest extends TestCase
         /** @var FieldMockCustom $surnameField */
         $surnameField = $m->addField('surname', [FieldMockCustom::class]);
 
-        static::assertSame('app', $surnameField->getApp()->name);
+        self::assertSame('app', $surnameField->getApp()->name);
 
-        static::assertSame('form-fields_surname', $surnameField->name);
-        static::assertSame($m, $surnameField->getOwner());
+        self::assertSame('form-fields_surname', $surnameField->name);
+        self::assertSame($m, $surnameField->getOwner());
 
         $longField = $m->addField('very-long-and-annoying-name-which-will-be-shortened', [FieldMockCustom::class]);
-        static::assertSame(40, strlen($longField->name));
+        self::assertSame(40, strlen($longField->name));
     }
 
     /**
@@ -138,11 +138,11 @@ class CollectionTraitTest extends TestCase
         $m->addField('surname', [FieldMockCustom::class]);
 
         $c = clone $m;
-        static::assertTrue($c->hasField('name'));
+        self::assertTrue($c->hasField('name'));
         /** @var FieldMockCustom $field */
         $field = $c->getField('surname');
-        static::assertSame(FieldMockCustom::class, get_class($field));
-        static::assertTrue($field->var);
+        self::assertSame(FieldMockCustom::class, get_class($field));
+        self::assertTrue($field->var);
     }
 }
 

--- a/tests/ConfigTraitTest.php
+++ b/tests/ConfigTraitTest.php
@@ -135,11 +135,11 @@ class ConfigTraitTest extends TestCase
         static::{'assertEquals'}($a, $m->getConfigProp());
 
         // test getConfig
-        static::assertSame(789, $m->getConfig('num'));
-        static::assertNull($m->getConfig('unknown'));
-        static::assertSame('default', $m->getConfig('unknown', 'default'));
-        static::assertSame('another', $m->getConfig('arr/sub/two', 'default'));
-        static::assertSame('default', $m->getConfig('arr/sub/three', 'default'));
+        self::assertSame(789, $m->getConfig('num'));
+        self::assertNull($m->getConfig('unknown'));
+        self::assertSame('default', $m->getConfig('unknown', 'default'));
+        self::assertSame('another', $m->getConfig('arr/sub/two', 'default'));
+        self::assertSame('default', $m->getConfig('arr/sub/three', 'default'));
     }
 
     public function testCaseGetConfigPathThatNotExists(): void
@@ -147,7 +147,7 @@ class ConfigTraitTest extends TestCase
         $m = new ConfigMock();
         $m->readConfig($this->dir . '/config.php', 'php');
         $excepted = $m->getConfig('arr/num/notExists');
-        static::assertNull($excepted);
+        self::assertNull($excepted);
     }
 }
 

--- a/tests/ConfigTraitTest.php
+++ b/tests/ConfigTraitTest.php
@@ -62,17 +62,17 @@ class ConfigTraitTest extends TestCase
         // default config
         $m = new ConfigMock();
         $m->readConfig($this->dir . '/config.php', 'php');
-        static::{'assertEquals'}($a, $m->getConfigProp());
+        self::{'assertEquals'}($a, $m->getConfigProp());
 
         // json config
         $m = new ConfigMock();
         $m->readConfig($this->dir . '/config.json', 'json');
-        static::{'assertEquals'}($b, $m->getConfigProp());
+        self::{'assertEquals'}($b, $m->getConfigProp());
 
         // yaml config
         $m = new ConfigMock();
         $m->readConfig($this->dir . '/config.yml', 'yaml');
-        static::{'assertEquals'}($c, $m->getConfigProp());
+        self::{'assertEquals'}($c, $m->getConfigProp());
     }
 
     public function testFileReadException(): void
@@ -132,7 +132,7 @@ class ConfigTraitTest extends TestCase
             'arr/sub/two' => 'another', // add one more in deep structure
             'arr' => ['foo' => 'bar'], // merge arrays
         ]);
-        static::{'assertEquals'}($a, $m->getConfigProp());
+        self::{'assertEquals'}($a, $m->getConfigProp());
 
         // test getConfig
         self::assertSame(789, $m->getConfig('num'));

--- a/tests/ContainerTraitTest.php
+++ b/tests/ContainerTraitTest.php
@@ -21,13 +21,13 @@ class ContainerTraitTest extends TestCase
         // add to return object
         $tr2 = new \stdClass();
         $tr = $m->add($tr2);
-        static::assertSame($tr, $tr2);
+        self::assertSame($tr, $tr2);
 
         // trackable object can be referenced by name
         $tr3 = new TrackableMock();
         $m->add($tr3, 'foo');
         $tr = $m->getElement('foo');
-        static::assertSame($tr, $tr3);
+        self::assertSame($tr, $tr3);
     }
 
     public function testUniqueNames(): void
@@ -41,15 +41,15 @@ class ContainerTraitTest extends TestCase
         $m->add(new TrackableMock(), '123');
         $m->add(new TrackableMock(), 'false');
 
-        static::assertTrue($m->hasElement('foo bar'));
-        static::assertTrue($m->hasElement('123'));
-        static::assertTrue($m->hasElement('false'));
-        static::assertSame(5, $m->getElementCount());
+        self::assertTrue($m->hasElement('foo bar'));
+        self::assertTrue($m->hasElement('123'));
+        self::assertTrue($m->hasElement('false'));
+        self::assertSame(5, $m->getElementCount());
 
         $m->getElement('foo bar')->destroy();
-        static::assertSame(4, $m->getElementCount());
+        self::assertSame(4, $m->getElementCount());
         $anon->destroy();
-        static::assertSame(3, $m->getElementCount());
+        self::assertSame(3, $m->getElementCount());
     }
 
     public function testLongNames(): void
@@ -65,20 +65,20 @@ class ContainerTraitTest extends TestCase
         $x = $m->add(new ContainerAppMock(), 'a');
         $x = $m->add(new ContainerAppMock(), 'mint');
 
-        static::assertSame(
+        self::assertSame(
             '_quick-brown-fox_jumps-over-a-lazy-dog_then-they-go-out-for-a-pint_eat-a-stake',
             $m->unshortenName($this)
         );
 
-        static::assertLessThan(5, count($app->uniqueNameHashes));
-        static::assertGreaterThan(2, count($app->uniqueNameHashes));
+        self::assertLessThan(5, count($app->uniqueNameHashes));
+        self::assertGreaterThan(2, count($app->uniqueNameHashes));
 
         $m->removeElement($x);
 
-        static::assertSame(2, $m->getElementCount());
+        self::assertSame(2, $m->getElementCount());
         $m->add(new \stdClass());
 
-        static::assertSame(2, $m->getElementCount());
+        self::assertSame(2, $m->getElementCount());
     }
 
     public function testLongNames2(): void
@@ -107,9 +107,9 @@ class ContainerTraitTest extends TestCase
         }
 
         // hash is 10 and we want 5 chars minimum for the right side e.g. XYXYXYXY__abcde
-        static::assertGreaterThanOrEqual(15, $minLength);
+        self::assertGreaterThanOrEqual(15, $minLength);
         // hash is 10 and we want 5 chars minimum for the right side e.g. XYXYXYXY__abcde
-        static::assertLessThanOrEqual($app->maxNameLength, $maxLength);
+        self::assertLessThanOrEqual($app->maxNameLength, $maxLength);
     }
 
     public function testPreservePresetNames(): void
@@ -134,15 +134,15 @@ class ContainerTraitTest extends TestCase
             };
         };
 
-        static::assertSame('r_foo', $app->add($createTrackableMockFx('foo'))->name);
-        static::assertSame('r_bar', $app->add($createTrackableMockFx('bar'))->name);
-        static::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100)))->name));
-        static::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100)))->name));
+        self::assertSame('r_foo', $app->add($createTrackableMockFx('foo'))->name);
+        self::assertSame('r_bar', $app->add($createTrackableMockFx('bar'))->name);
+        self::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100)))->name));
+        self::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100)))->name));
 
-        static::assertSame('foo', $app->add($createTrackableMockFx('foo', true))->name);
+        self::assertSame('foo', $app->add($createTrackableMockFx('foo', true))->name);
 
         $this->expectException(Exception::class);
-        static::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100), true))->name));
+        self::assertSame(40, strlen($app->add($createTrackableMockFx(str_repeat('x', 100), true))->name));
     }
 
     public function testOwnerNotSetException(): void
@@ -170,12 +170,12 @@ class ContainerTraitTest extends TestCase
         $m = new TrackableMock();
         $owner = new \stdClass();
         $m->setOwner($owner);
-        static::assertSame($owner, $m->getOwner());
+        self::assertSame($owner, $m->getOwner());
         $m->unsetOwner();
 
         $owner = new \stdClass();
         $m->setOwner($owner);
-        static::assertSame($owner, $m->getOwner());
+        self::assertSame($owner, $m->getOwner());
         $m->unsetOwner();
     }
 
@@ -183,11 +183,11 @@ class ContainerTraitTest extends TestCase
     {
         $m = new ContainerFactoryMock();
         $m2 = $m->add([ContainerMock::class]);
-        static::assertSame(ContainerMock::class, get_class($m2));
+        self::assertSame(ContainerMock::class, get_class($m2));
 
         $m3 = $m->add([TrackableContainerMock::class], 'name');
-        static::assertSame(TrackableContainerMock::class, get_class($m3));
-        static::assertSame('name', $m3->shortName);
+        self::assertSame(TrackableContainerMock::class, get_class($m3));
+        self::assertSame('name', $m3->shortName);
     }
 
     public function testArgs(): void
@@ -198,8 +198,8 @@ class ContainerTraitTest extends TestCase
             use DiContainerTrait;
             use NameTrait;
         }, ['name' => 'foo']);
-        static::assertTrue($m->hasElement('foo'));
-        static::assertSame('foo', $m2->shortName);
+        self::assertTrue($m->hasElement('foo'));
+        self::assertSame('foo', $m2->shortName);
     }
 
     public function testExceptionExists(): void
@@ -216,7 +216,7 @@ class ContainerTraitTest extends TestCase
         $m->add(new TrackableMock(), ['desired_name' => 'foo']);
         $m->add(new TrackableMock(), ['desired_name' => 'foo']);
 
-        static::assertTrue($m->hasElement('foo'));
+        self::assertTrue($m->hasElement('foo'));
     }
 
     public function testExceptionShortName(): void

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -14,16 +14,16 @@ class DebugTraitTest extends TestCase
     {
         $m = new DebugMock();
 
-        static::assertFalse($m->debug);
+        self::assertFalse($m->debug);
 
         $m->debug();
-        static::assertTrue($m->debug);
+        self::assertTrue($m->debug);
 
         $m->debug(false);
-        static::assertFalse($m->debug);
+        self::assertFalse($m->debug);
 
         $m->debug(true);
-        static::assertTrue($m->debug);
+        self::assertTrue($m->debug);
     }
 
     public function testDebugOutput(): void
@@ -58,7 +58,7 @@ class DebugTraitTest extends TestCase
 
         $m->debug('debug test2');
 
-        static::assertSame(['debug', 'debug test2', []], $app->log);
+        self::assertSame(['debug', 'debug test2', []], $app->log);
     }
 
     public function testLog1(): void
@@ -80,7 +80,7 @@ class DebugTraitTest extends TestCase
         $m->setApp($app);
         $m->log('warning', 'debug test3');
 
-        static::assertSame(['warning', 'debug test3', []], $app->log);
+        self::assertSame(['warning', 'debug test3', []], $app->log);
     }
 
     protected function triggerDebugTraceChange(DebugMock $o, string $trace): void
@@ -101,9 +101,9 @@ class DebugTraitTest extends TestCase
 
         // Changes detected
         preg_match('~Call path for .* has diverged \(was (.*):(.*), now (.*):(.*)\)~', $app->log[1], $matches);
-        static::assertCount(5, $matches);
-        static::assertSame($matches[1], $matches[3]);
-        static::assertSame((string) ((int) $matches[2] + 1), $matches[4]);
+        self::assertCount(5, $matches);
+        self::assertSame($matches[1], $matches[3]);
+        self::assertSame((string) ((int) $matches[2] + 1), $matches[4]);
 
         $app->log = null;
 
@@ -112,7 +112,7 @@ class DebugTraitTest extends TestCase
         }
 
         // No changes in the trace change detected
-        static::assertNull($app->log);
+        self::assertNull($app->log);
     }
 
     public function testPsr(): void
@@ -124,25 +124,25 @@ class DebugTraitTest extends TestCase
         $m->setApp($app);
 
         $m->info('i', ['x']);
-        static::assertSame(['info', 'i', ['x']], $app->log);
+        self::assertSame(['info', 'i', ['x']], $app->log);
 
         $m->warning('t', ['x']);
-        static::assertSame(['warning', 't', ['x']], $app->log);
+        self::assertSame(['warning', 't', ['x']], $app->log);
 
         $m->emergency('em', ['x', 'y']);
-        static::assertSame(['emergency', 'em', ['x', 'y']], $app->log);
+        self::assertSame(['emergency', 'em', ['x', 'y']], $app->log);
 
         $m->alert('al', ['x']);
-        static::assertSame(['alert', 'al', ['x']], $app->log);
+        self::assertSame(['alert', 'al', ['x']], $app->log);
 
         $m->critical('cr', ['x']);
-        static::assertSame(['critical', 'cr', ['x']], $app->log);
+        self::assertSame(['critical', 'cr', ['x']], $app->log);
 
         $m->error('er', ['x']);
-        static::assertSame(['error', 'er', ['x']], $app->log);
+        self::assertSame(['error', 'er', ['x']], $app->log);
 
         $m->notice('nt', ['x']);
-        static::assertSame(['notice', 'nt', ['x']], $app->log);
+        self::assertSame(['notice', 'nt', ['x']], $app->log);
     }
 }
 

--- a/tests/DiContainerTraitTest.php
+++ b/tests/DiContainerTraitTest.php
@@ -12,8 +12,8 @@ class DiContainerTraitTest extends TestCase
 {
     public function testFromSeed(): void
     {
-        static::assertSame(StdSat::class, get_class(StdSat::fromSeed([StdSat::class])));
-        static::assertSame(StdSat2::class, get_class(StdSat::fromSeed([StdSat2::class])));
+        self::assertSame(StdSat::class, get_class(StdSat::fromSeed([StdSat::class])));
+        self::assertSame(StdSat2::class, get_class(StdSat::fromSeed([StdSat2::class])));
 
         $this->expectException(Exception::class);
         StdSat2::fromSeed([StdSat::class]);
@@ -38,11 +38,11 @@ class DiContainerTraitTest extends TestCase
         $m = new FactoryDiMock2();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar']);
-        static::assertSame([$m->a, $m->b, $m->c], ['foo', 'BBB', 'bar']);
+        self::assertSame([$m->a, $m->b, $m->c], ['foo', 'BBB', 'bar']);
 
         $m = new FactoryDiMock2();
         $m->setDefaults(['a' => null, 'c' => false]);
-        static::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
+        self::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
     }
 
     public function testPropertiesPassively(): void
@@ -50,16 +50,16 @@ class DiContainerTraitTest extends TestCase
         $m = new FactoryDiMock2();
 
         $m->setDefaults(['a' => 'foo', 'c' => 'bar'], true);
-        static::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', 'bar']);
+        self::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', 'bar']);
 
         $m = new FactoryDiMock2();
         $m->setDefaults(['a' => null, 'c' => false], true);
-        static::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
+        self::assertSame([$m->a, $m->b, $m->c], ['AAA', 'BBB', false]);
 
         $m = new FactoryDiMock2();
         $m->a = ['foo'];
         $m->setDefaults(['a' => ['bar']], true);
-        static::assertSame([$m->a, $m->b, $m->c], [['foo'], 'BBB', null]);
+        self::assertSame([$m->a, $m->b, $m->c], [['foo'], 'BBB', null]);
     }
 
     /**

--- a/tests/DynamicMethodTraitTest.php
+++ b/tests/DynamicMethodTraitTest.php
@@ -31,10 +31,10 @@ class DynamicMethodTraitTest extends TestCase
             return 'world';
         });
 
-        static::assertTrue($m->hasMethod('test'));
+        self::assertTrue($m->hasMethod('test'));
 
         $res = 'Hello, ' . $m->test();
-        static::assertSame('Hello, world', $res);
+        self::assertSame('Hello, world', $res);
     }
 
     public function testExceptionUndefinedMethod(): void
@@ -103,11 +103,11 @@ class DynamicMethodTraitTest extends TestCase
         $m = new DynamicMethodMock();
         $m->addMethod('sum', $this->createSumFx());
         $res = $m->sum(3, 5);
-        static::assertSame(8, $res);
+        self::assertSame(8, $res);
 
         $m = new DynamicMethodMock();
         $m->addMethod('getElementCount', \Closure::fromCallable([new ContainerMock(), 'getElementCount']));
-        static::assertSame(0, $m->getElementCount());
+        self::assertSame(0, $m->getElementCount());
     }
 
     /**
@@ -116,9 +116,9 @@ class DynamicMethodTraitTest extends TestCase
     public function testWithoutHookTrait(): void
     {
         $m = new DynamicMethodWithoutHookMock();
-        static::assertFalse($m->hasMethod('sum'));
+        self::assertFalse($m->hasMethod('sum'));
 
-        static::assertSame($m, $m->removeMethod('sum'));
+        self::assertSame($m, $m->removeMethod('sum'));
     }
 
     public function testDoubleMethodException(): void
@@ -138,9 +138,9 @@ class DynamicMethodTraitTest extends TestCase
         // simple method
         $m = new DynamicMethodMock();
         $m->addMethod('sum', $this->createSumFx());
-        static::assertTrue($m->hasMethod('sum'));
+        self::assertTrue($m->hasMethod('sum'));
         $m->removeMethod('sum');
-        static::assertFalse($m->hasMethod('sum'));
+        self::assertFalse($m->hasMethod('sum'));
     }
 
     public function testGlobalMethodException1(): void
@@ -164,13 +164,13 @@ class DynamicMethodTraitTest extends TestCase
         $m2->setApp($app);
 
         $m->addGlobalMethod('sum', $this->createSumFx(true));
-        static::assertTrue($m->hasGlobalMethod('sum'));
+        self::assertTrue($m->hasGlobalMethod('sum'));
 
         $res = $m2->sum(3, 5);
-        static::assertSame(8, $res);
+        self::assertSame(8, $res);
 
         $m->removeGlobalMethod('sum');
-        static::assertFalse($m2->hasGlobalMethod('sum'));
+        self::assertFalse($m2->hasGlobalMethod('sum'));
     }
 
     public function testDoubleGlobalMethodException(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -18,57 +18,57 @@ class ExceptionTest extends TestCase
             ->addMoreInfo('a1', 111)
             ->addMoreInfo('a2', 222);
 
-        static::assertSame(['a1' => 111, 'a2' => 222], $m->getParams());
+        self::assertSame(['a1' => 111, 'a2' => 222], $m->getParams());
 
         $m = new Exception('PrevError');
         $m = new Exception('TestIt', 123, $m);
         $m->addMoreInfo('a1', 222);
         $m->addMoreInfo('a2', 333);
 
-        static::assertSame(['a1' => 222, 'a2' => 333], $m->getParams());
+        self::assertSame(['a1' => 222, 'a2' => 333], $m->getParams());
 
         // get HTML
         $ret = $m->getHtml();
-        static::assertMatchesRegularExpression('~TestIt~', $ret);
-        static::assertMatchesRegularExpression('~PrevError~', $ret);
-        static::assertMatchesRegularExpression('~333~', $ret);
+        self::assertMatchesRegularExpression('~TestIt~', $ret);
+        self::assertMatchesRegularExpression('~PrevError~', $ret);
+        self::assertMatchesRegularExpression('~333~', $ret);
 
         // get colorful text
         $ret = $m->getColorfulText();
-        static::assertMatchesRegularExpression('~TestIt~', $ret);
-        static::assertMatchesRegularExpression('~PrevError~', $ret);
-        static::assertMatchesRegularExpression('~333~', $ret);
+        self::assertMatchesRegularExpression('~TestIt~', $ret);
+        self::assertMatchesRegularExpression('~PrevError~', $ret);
+        self::assertMatchesRegularExpression('~333~', $ret);
 
         // get JSON
         $ret = $m->getJson();
-        static::assertMatchesRegularExpression('~TestIt~', $ret);
-        static::assertMatchesRegularExpression('~PrevError~', $ret);
-        static::assertMatchesRegularExpression('~333~', $ret);
+        self::assertMatchesRegularExpression('~TestIt~', $ret);
+        self::assertMatchesRegularExpression('~PrevError~', $ret);
+        self::assertMatchesRegularExpression('~333~', $ret);
 
         // to safe string
         $ret = RendererAbstract::toSafeString(1);
-        static::assertSame('1', $ret);
+        self::assertSame('1', $ret);
 
         $ret = RendererAbstract::toSafeString('abc');
-        static::assertSame('\'abc\'', $ret);
+        self::assertSame('\'abc\'', $ret);
 
         $ret = RendererAbstract::toSafeString(new \stdClass());
-        static::assertSame('stdClass', $ret);
+        self::assertSame('stdClass', $ret);
 
         $a = new TrackableMock();
         $a->shortName = 'foo';
         $ret = RendererAbstract::toSafeString($a);
-        static::assertSame(TrackableMock::class . ' (foo)', $ret);
+        self::assertSame(TrackableMock::class . ' (foo)', $ret);
 
         $a = new TrackableMock2();
         $a->shortName = 'foo';
         $ret = RendererAbstract::toSafeString($a);
-        static::assertSame(TrackableMock2::class . ' (foo)', $ret);
+        self::assertSame(TrackableMock2::class . ' (foo)', $ret);
 
         $a = new TrackableMock2();
         $a->name = 'foo';
         $ret = RendererAbstract::toSafeString($a);
-        static::assertSame(TrackableMock2::class . ' (foo)', $ret);
+        self::assertSame(TrackableMock2::class . ' (foo)', $ret);
     }
 
     public function testMore(): void
@@ -79,16 +79,16 @@ class ExceptionTest extends TestCase
         $m->setMessage('bumbum');
 
         $ret = $m->getHtml();
-        static::assertMatchesRegularExpression('~Classic~', $ret);
-        static::assertMatchesRegularExpression('~bumbum~', $ret);
+        self::assertMatchesRegularExpression('~Classic~', $ret);
+        self::assertMatchesRegularExpression('~bumbum~', $ret);
 
         $ret = $m->getColorfulText();
-        static::assertMatchesRegularExpression('~Classic~', $ret);
-        static::assertMatchesRegularExpression('~bumbum~', $ret);
+        self::assertMatchesRegularExpression('~Classic~', $ret);
+        self::assertMatchesRegularExpression('~bumbum~', $ret);
 
         $ret = $m->getJson();
-        static::assertMatchesRegularExpression('~Classic~', $ret);
-        static::assertMatchesRegularExpression('~bumbum~', $ret);
+        self::assertMatchesRegularExpression('~Classic~', $ret);
+        self::assertMatchesRegularExpression('~bumbum~', $ret);
     }
 
     public function testSolution(): void
@@ -97,13 +97,13 @@ class ExceptionTest extends TestCase
         $m->addSolution('One Solution');
 
         $ret = $m->getHtml();
-        static::assertMatchesRegularExpression('~One Solution~', $ret);
+        self::assertMatchesRegularExpression('~One Solution~', $ret);
 
         $ret = $m->getColorfulText();
-        static::assertMatchesRegularExpression('~One Solution~', $ret);
+        self::assertMatchesRegularExpression('~One Solution~', $ret);
 
         $ret = $m->getJson();
-        static::assertMatchesRegularExpression('~One Solution~', $ret);
+        self::assertMatchesRegularExpression('~One Solution~', $ret);
     }
 
     public function testSolution2(): void
@@ -112,15 +112,15 @@ class ExceptionTest extends TestCase
             ->addSolution('1st Solution');
 
         $ret = $m->getColorfulText();
-        static::assertMatchesRegularExpression('~1st Solution~', $ret);
+        self::assertMatchesRegularExpression('~1st Solution~', $ret);
 
         $m = (new Exception('Exception with solution'))
             ->addSolution('1st Solution')
             ->addSolution('2nd Solution');
 
         $ret = $m->getColorfulText();
-        static::assertMatchesRegularExpression('~1st Solution~', $ret);
-        static::assertMatchesRegularExpression('~2nd Solution~', $ret);
+        self::assertMatchesRegularExpression('~1st Solution~', $ret);
+        self::assertMatchesRegularExpression('~2nd Solution~', $ret);
     }
 
     public function testExceptionFallback(): void
@@ -128,9 +128,9 @@ class ExceptionTest extends TestCase
         $m = new ExceptionTestThrowError('test', 2);
         $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
             . ExceptionTestThrowError::class . '(2): test !!';
-        static::assertSame($expectedFallbackText, $m->getHtml());
-        static::assertSame($expectedFallbackText, $m->getColorfulText());
-        static::assertSame(
+        self::assertSame($expectedFallbackText, $m->getHtml());
+        self::assertSame($expectedFallbackText, $m->getColorfulText());
+        self::assertSame(
             json_encode(
                 [
                     'success' => false,

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -222,10 +222,10 @@ class FactoryTest extends TestCase
     {
         /*
         $s1 = Factory::factory([FactoryTestMock::class, 'hello']);
-        static::{'assertEquals'}(['hello'], $s1->args);
+        self::{'assertEquals'}(['hello'], $s1->args);
 
         $s1 = Factory::factory([FactoryTestMock::class, 'hello', 'world']);
-        static::{'assertEquals'}(['hello', 'world'], $s1->args);
+        self::{'assertEquals'}(['hello', 'world'], $s1->args);
          */
 
         $s1 = Factory::factory([FactoryTestMock::class, null, 'world']);

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -15,26 +15,26 @@ class FactoryTest extends TestCase
     public function testMerge1(): void
     {
         // string become array
-        static::assertSame(
+        self::assertSame(
             ['hello'],
             Factory::mergeSeeds(['hello'], null)
         );
 
         // left-most value is used
-        static::assertSame(
+        self::assertSame(
             ['one'],
             Factory::mergeSeeds(['one'], ['two'], ['three'], ['four'])
         );
 
         // nulls are ignored
-        static::assertSame(
+        self::assertSame(
             ['two'],
             Factory::mergeSeeds(null, ['two'], ['three'], ['four'])
         );
 
         // object takes precedence
         $o = new FactoryTestDiMock();
-        static::assertSame(
+        self::assertSame(
             $o,
             Factory::mergeSeeds(null, ['two'], $o, ['four'])
         );
@@ -50,27 +50,27 @@ class FactoryTest extends TestCase
     public function testMerge2(): void
     {
         // array argument merging
-        static::assertSame(
+        self::assertSame(
             ['a1', 'a2'],
             Factory::mergeSeeds(['a1', 'a2'], null, ['b1', 'b2'])
         );
 
         // nulls are ignored
-        static::assertSame(
+        self::assertSame(
             ['b1', 'a2', 'c3'],
             Factory::mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'])
         );
 
         // object takes precedence
         $o = new FactoryTestDiMock();
-        static::assertSame(
+        self::assertSame(
             $o,
             Factory::mergeSeeds(['a1'], $o)
         );
 
         // is object is wrapped in array - we dont care
         $o = new FactoryTestDiMock();
-        static::assertSame(
+        self::assertSame(
             ['b1', 'a2', 'c3'],
             Factory::mergeSeeds([null, 'a2', null], ['b1'], ['c1', null, 'c3'], [1 => $o])
         );
@@ -86,13 +86,13 @@ class FactoryTest extends TestCase
     public function testMerge3(): void
     {
         // key/value support
-        static::assertSame(
+        self::assertSame(
             ['a' => 1],
             Factory::mergeSeeds(['a' => 1], ['a' => 2])
         );
 
         // values has no special treatment
-        static::assertSame(
+        self::assertSame(
             ['a' => [1]],
             Factory::mergeSeeds(['a' => [1]], ['a' => 2])
         );
@@ -101,24 +101,24 @@ class FactoryTest extends TestCase
         $o = new FactoryTestDiMock();
         $oo = Factory::mergeSeeds(['foo' => 1], $o);
 
-        static::assertSame($o, $oo);
-        static::assertSame(1, $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(1, $oo->foo);
 
         // even it already has value
         $o = new FactoryTestDiMock();
         $o->foo = 5;
         $oo = Factory::mergeSeeds(['foo' => 1], $o);
 
-        static::assertSame($o, $oo);
-        static::assertSame(1, $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(1, $oo->foo);
 
         // but this way existing value is respected
         $o = new FactoryTestDiMock();
         $o->foo = 5;
         $oo = Factory::mergeSeeds($o, ['foo' => 1]);
 
-        static::assertSame($o, $oo);
-        static::assertSame(5, $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(5, $oo->foo);
     }
 
     public function testMerge4(): void
@@ -128,20 +128,20 @@ class FactoryTest extends TestCase
         $o->foo = ['red'];
         $oo = Factory::mergeSeeds(['foo' => ['green']], $o);
 
-        static::assertSame($o, $oo);
-        static::assertSame(['red', 'green'], $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(['red', 'green'], $oo->foo);
 
         $oo = Factory::mergeSeeds($o, ['foo' => ['white']]);
-        static::assertSame($o, $oo);
-        static::assertSame(['white', 'red', 'green'], $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(['white', 'red', 'green'], $oo->foo);
 
         // still we don't care if they are to the right of the object
         $o = new FactoryTestDiMock();
         $o->foo = ['red'];
         $oo = Factory::mergeSeeds($o, ['foo' => ['green']]);
 
-        static::assertSame($o, $oo);
-        static::assertSame(['red'], $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(['red'], $oo->foo);
     }
 
     public function testMerge5(): void
@@ -152,37 +152,37 @@ class FactoryTest extends TestCase
         $oo = Factory::mergeSeeds(['foo' => ['green']], $o);
         $oo = Factory::mergeSeeds(['foo' => ['xx']], $o);
 
-        static::assertSame($o, $oo);
-        static::assertSame(['red', 'green', 'xx'], $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame(['red', 'green', 'xx'], $oo->foo);
 
         // also without arrays
         $o = new FactoryTestDiMock();
         $o->foo = 'red';
         $oo = Factory::mergeSeeds(['foo' => 'xx'], ['foo' => 'green'], $o, ['foo' => 5]);
 
-        static::assertSame($o, $oo);
-        static::assertSame('xx', $oo->foo);
+        self::assertSame($o, $oo);
+        self::assertSame('xx', $oo->foo);
     }
 
     public function testMerge6(): void
     {
         $oo = Factory::mergeSeeds([4 => 'four'], [5 => 'five']);
-        static::assertSame([4 => 'four', 5 => 'five'], $oo);
+        self::assertSame([4 => 'four', 5 => 'five'], $oo);
 
         $oo = Factory::mergeSeeds([4 => ['four']], [5 => ['five']]);
-        static::assertSame([4 => ['four'], 5 => ['five']], $oo);
+        self::assertSame([4 => ['four'], 5 => ['five']], $oo);
 
         $oo = Factory::mergeSeeds([4 => 'four'], [5 => 'five'], [6 => 'six']);
-        static::assertSame([4 => 'four', 5 => 'five', 6 => 'six'], $oo);
+        self::assertSame([4 => 'four', 5 => 'five', 6 => 'six'], $oo);
 
         $oo = Factory::mergeSeeds(['x' => ['four']], ['x' => ['five']]);
-        static::assertSame(['x' => ['four']], $oo);
+        self::assertSame(['x' => ['four']], $oo);
 
         $oo = Factory::mergeSeeds([4 => ['four']], [4 => ['five']]);
-        static::assertSame([4 => ['four']], $oo);
+        self::assertSame([4 => ['four']], $oo);
 
         $oo = Factory::mergeSeeds([4 => ['200']], [4 => ['201']]);
-        static::assertSame([4 => ['200']], $oo);
+        self::assertSame([4 => ['200']], $oo);
     }
 
     public function testMergeNoDiFail(): void
@@ -197,25 +197,25 @@ class FactoryTest extends TestCase
     public function testBasic(): void
     {
         $s1 = Factory::factory([FactoryTestMock::class]);
-        static::assertSame([], $s1->args);
+        self::assertSame([], $s1->args);
 
         $s1 = Factory::factory(new FactoryTestMock());
-        static::assertSame([], $s1->args);
+        self::assertSame([], $s1->args);
 
         $s1 = Factory::factory(new FactoryTestMock('hello', 'world'));
-        static::assertSame(['hello', 'world'], $s1->args);
+        self::assertSame(['hello', 'world'], $s1->args);
 
         $s1 = Factory::factory(new FactoryTestMock(null, 'world'));
-        static::assertSame([null, 'world'], $s1->args);
+        self::assertSame([null, 'world'], $s1->args);
     }
 
     public function testInjection(): void
     {
         $s1 = Factory::factory(new FactoryTestDiMock(), null); // @phpstan-ignore-line
-        static::assertNotSame('bar', $s1->foo);
+        self::assertNotSame('bar', $s1->foo);
 
         $s1 = Factory::factory(new FactoryTestDiMock(), ['foo' => 'bar']);
-        static::assertSame('bar', $s1->foo);
+        self::assertSame('bar', $s1->foo);
     }
 
     public function testArguments(): void
@@ -229,20 +229,20 @@ class FactoryTest extends TestCase
          */
 
         $s1 = Factory::factory([FactoryTestMock::class, null, 'world']);
-        static::assertSame([null, 'world'], $s1->args);
+        self::assertSame([null, 'world'], $s1->args);
 
         $s1 = Factory::factory([FactoryTestDiMock::class, 'hello', 'foo' => 'bar', 'world']);
-        static::assertSame(['hello', 'world'], $s1->args);
-        static::assertSame('bar', $s1->foo);
+        self::assertSame(['hello', 'world'], $s1->args);
+        self::assertSame('bar', $s1->foo);
     }
 
     public function testDefaults(): void
     {
         $s1 = Factory::factory([FactoryTestDiMock::class, 'hello', 'foo' => 'bar', 'world'], ['more', 'baz' => '', 'more', 'args']);
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['hello', 'world', 'args'], $s1->args);
-        static::assertSame('bar', $s1->foo);
-        static::assertSame('', $s1->baz);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['hello', 'world', 'args'], $s1->args);
+        self::assertSame('bar', $s1->foo);
+        self::assertSame('', $s1->baz);
 
         $s1->setDefaults([]);
     }
@@ -250,27 +250,27 @@ class FactoryTest extends TestCase
     public function testNull(): void
     {
         $s1 = Factory::factory([FactoryTestDiMock::class, 'foo' => null, null, 'world'], ['more', 'foo' => 'bar', 'more', 'args']);
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['more', 'world', 'args'], $s1->args);
-        static::assertSame('bar', $s1->foo);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['more', 'world', 'args'], $s1->args);
+        self::assertSame('bar', $s1->foo);
 
         $s1 = Factory::factory(Factory::mergeSeeds([FactoryTestDiMock::class, 'foo' => null, null, 'world'], [FactoryTestMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['more', 'world', 'args'], $s1->args);
-        static::assertSame('bar', $s1->foo);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['more', 'world', 'args'], $s1->args);
+        self::assertSame('bar', $s1->foo);
 
         $s1 = Factory::factory(Factory::mergeSeeds([null, 'foo' => null, null, 'world'], [FactoryTestDiMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['more', 'world', 'args'], $s1->args);
-        static::assertSame('bar', $s1->foo);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['more', 'world', 'args'], $s1->args);
+        self::assertSame('bar', $s1->foo);
 
         $s1 = Factory::factory(Factory::mergeSeeds(null, [FactoryTestDiMock::class, 'more', 'foo' => 'bar', 'more', 'args']));
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['more', 'more', 'args'], $s1->args);
-        static::assertSame('bar', $s1->foo);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['more', 'more', 'args'], $s1->args);
+        self::assertSame('bar', $s1->foo);
 
         $s1 = Factory::factory(Factory::mergeSeeds([], [FactoryTestDiMock::class, 'test']));
-        static::assertSame(['test'], $s1->args);
+        self::assertSame(['test'], $s1->args);
     }
 
     public function testDefaultsObject(): void
@@ -282,26 +282,26 @@ class FactoryTest extends TestCase
     public function testMerge(): void
     {
         $s1 = Factory::factory([FactoryTestDiMock::class, 'hello', 'world'], ['more', 'more', 'args']);
-        static::assertSame(['hello', 'world', 'args'], $s1->args);
+        self::assertSame(['hello', 'world', 'args'], $s1->args);
 
         $s1 = Factory::factory([FactoryTestDiMock::class, null, 'world'], ['more', 'more', 'args']);
-        static::assertSame(['more', 'world', 'args'], $s1->args);
+        self::assertSame(['more', 'world', 'args'], $s1->args);
     }
 
     public function testMerge7(): void
     {
         $s1 = Factory::mergeSeeds(new FactoryTestDefMock(), ['foo']);
-        static::assertInstanceOf(FactoryTestDefMock::class, $s1);
-        static::assertNull($s1->def);
+        self::assertInstanceOf(FactoryTestDefMock::class, $s1);
+        self::assertNull($s1->def);
         $s1 = Factory::mergeSeeds(new FactoryTestDefMock(), ['foo' => 'x']);
-        static::assertInstanceOf(FactoryTestDefMock::class, $s1);
-        static::assertSame(['foo' => 'x'], $s1->def);
+        self::assertInstanceOf(FactoryTestDefMock::class, $s1);
+        self::assertSame(['foo' => 'x'], $s1->def);
     }
 
     public function testMerge8(): void
     {
         $s1 = Factory::mergeSeeds(['foo', null, 'arg'], []);
-        static::assertSame(['foo', null, 'arg'], $s1);
+        self::assertSame(['foo', null, 'arg'], $s1);
     }
 
     public function testSeedMustBe(): void
@@ -337,13 +337,13 @@ class FactoryTest extends TestCase
     public function testStringDefault(): void
     {
         $s1 = Factory::factory([FactoryTestDiMock::class], ['hello']);
-        static::assertTrue($s1 instanceof FactoryTestDiMock);
-        static::assertSame(['hello'], $s1->args);
+        self::assertTrue($s1 instanceof FactoryTestDiMock);
+        self::assertSame(['hello'], $s1->args);
 
         // also OK if it's not a DIContainer object
         $s1 = Factory::factory([FactoryTestMock::class], ['hello']);
-        static::assertTrue($s1 instanceof FactoryTestMock);
-        static::assertSame(['hello'], $s1->args);
+        self::assertTrue($s1 instanceof FactoryTestMock);
+        self::assertSame(['hello'], $s1->args);
     }
 
     /**
@@ -365,11 +365,11 @@ class FactoryTest extends TestCase
             ['foo' => ['Label', 'red']]
         );
 
-        static::assertSame(['Button', 'icon' => 'red'], $s1->foo);
+        self::assertSame(['Button', 'icon' => 'red'], $s1->foo);
 
         $s1->setDefaults(['foo' => ['Message', 'detail' => 'blah']]);
 
-        static::assertSame(['Message', 'detail' => 'blah'], $s1->foo);
+        self::assertSame(['Message', 'detail' => 'blah'], $s1->foo);
     }
 
     public function testFactory(): void
@@ -379,11 +379,11 @@ class FactoryTest extends TestCase
         // pass object
         $m1 = new FactoryFactoryMock();
         $m2 = Factory::factory($m1);
-        static::assertSame($m1, $m2);
+        self::assertSame($m1, $m2);
 
         // from array seed
         $m1 = Factory::factory([FactoryFactoryMock::class]);
-        static::assertSame(FactoryFactoryMock::class, get_class($m1));
+        self::assertSame(FactoryFactoryMock::class, get_class($m1));
 
         // from string seed
         $this->expectException(Exception::class);
@@ -410,44 +410,44 @@ class FactoryTest extends TestCase
 
         // as class name
         $m1 = Factory::factory([FactoryFactoryMock::class]);
-        static::assertSame(FactoryFactoryMock::class, get_class($m1));
+        self::assertSame(FactoryFactoryMock::class, get_class($m1));
 
         $m2 = Factory::factory([HookBreaker::class], ['ok']);
-        static::assertSame(HookBreaker::class, get_class($m2));
+        self::assertSame(HookBreaker::class, get_class($m2));
 
         // as object
         $m2 = Factory::factory($m1);
-        static::assertSame(FactoryFactoryMock::class, get_class($m2));
+        self::assertSame(FactoryFactoryMock::class, get_class($m2));
 
         // as class name with parameters
         $m1 = Factory::factory([FactoryFactoryDiMock::class], ['a' => 'XXX', 'b' => 'YYY']);
-        static::assertSame('XXX', $m1->a);
-        static::assertSame('YYY', $m1->b);
-        static::assertNull($m1->c);
+        self::assertSame('XXX', $m1->a);
+        self::assertSame('YYY', $m1->b);
+        self::assertNull($m1->c);
 
         $m1 = Factory::factory([FactoryFactoryDiMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
-        static::assertSame('AAA', $m1->a);
-        static::assertSame('YYY', $m1->b);
-        static::assertSame('ZZZ', $m1->c);
+        self::assertSame('AAA', $m1->a);
+        self::assertSame('YYY', $m1->b);
+        self::assertSame('ZZZ', $m1->c);
 
         // as object with parameters
         $m1 = Factory::factory([FactoryFactoryDiMock::class]);
         $m2 = Factory::factory($m1, ['a' => 'XXX', 'b' => 'YYY']);
-        static::assertSame('XXX', $m2->a);
-        static::assertSame('YYY', $m2->b);
-        static::assertNull($m2->c);
+        self::assertSame('XXX', $m2->a);
+        self::assertSame('YYY', $m2->b);
+        self::assertNull($m2->c);
 
         $m1 = Factory::factory([FactoryFactoryDiMock::class]);
         $m2 = Factory::factory($m1, ['a' => null, 'b' => 'YYY', 'c' => 'ZZZ']);
-        static::assertSame('AAA', $m2->a);
-        static::assertSame('YYY', $m2->b);
-        static::assertSame('ZZZ', $m2->c);
+        self::assertSame('AAA', $m2->a);
+        self::assertSame('YYY', $m2->b);
+        self::assertSame('ZZZ', $m2->c);
 
         $m1 = Factory::factory([FactoryFactoryDiMock::class], ['a' => null, 'b' => 'YYY', 'c' => 'SSS']);
         $m2 = Factory::factory($m1, ['a' => 'XXX', 'b' => null, 'c' => 'ZZZ']);
-        static::assertSame('XXX', $m2->a);
-        static::assertSame('YYY', $m2->b);
-        static::assertSame('ZZZ', $m2->c);
+        self::assertSame('XXX', $m2->a);
+        self::assertSame('YYY', $m2->b);
+        self::assertSame('ZZZ', $m2->c);
 
         // as object wrapped in array
         $this->expectException(Exception::class);

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -244,13 +244,13 @@ class HookTraitTest extends TestCase
 
         // unbound callback
         $m->onHookShort('inc', static function (...$args) {
-            static::assertSame(['y', 'x'], $args);
+            self::assertSame(['y', 'x'], $args);
         }, ['x']);
         $m->hook('inc', ['y']);
 
         // bound callback
         $m->onHookShort('inc', function (...$args) {
-            static::assertSame(['y', 'x'], $args);
+            self::assertSame(['y', 'x'], $args);
         }, ['x']);
         $m->hook('inc', ['y']);
     }

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -21,11 +21,11 @@ class HookTraitTest extends TestCase
             ++$result;
         });
 
-        static::assertSame(0, $result);
+        self::assertSame(0, $result);
 
         $m->hook('test1');
         $m->hook('test1');
-        static::assertSame(2, $result);
+        self::assertSame(2, $result);
     }
 
     public function testAdvanced(): void
@@ -42,7 +42,7 @@ class HookTraitTest extends TestCase
         }, [], 1);
 
         $m->hook('test1'); // zero will be executed first, then increment
-        static::assertSame(1, $result);
+        self::assertSame(1, $result);
     }
 
     public function testHookException1(): void
@@ -57,7 +57,7 @@ class HookTraitTest extends TestCase
 
         $m->hook('tst', ['parameter']);
 
-        static::assertSame('parameter', $result);
+        self::assertSame('parameter', $result);
     }
 
     public function testOrder(): void
@@ -99,7 +99,7 @@ class HookTraitTest extends TestCase
 
         $ret = $m->hook('spot');
 
-        static::assertSame([
+        self::assertSame([
             $ind + 2 => 1,
             $ind + 1 => 2,
             $ind => 3,
@@ -128,10 +128,10 @@ class HookTraitTest extends TestCase
         $obj->onHook('test', $addFunc);
 
         $res1 = $obj->hook('test', [2, 2]);
-        static::assertSame([4, 4], $res1);
+        self::assertSame([4, 4], $res1);
 
         $res2 = $obj->hook('test', [3, 3]);
-        static::assertSame([9, 6], $res2);
+        self::assertSame([9, 6], $res2);
     }
 
     public function testArgs(): void
@@ -154,10 +154,10 @@ class HookTraitTest extends TestCase
         $obj->onHook('test', $powFunc, [7]);
 
         $res1 = $obj->hook('test', [2, 2]);
-        static::assertSame([4, 4, 8, 256], $res1);
+        self::assertSame([4, 4, 8, 256], $res1);
 
         $res2 = $obj->hook('test', [2, 3]);
-        static::assertSame([6, 5, 13, 2315], $res2);
+        self::assertSame([6, 5, 13, 2315], $res2);
     }
 
     public function testReferences(): void
@@ -173,7 +173,7 @@ class HookTraitTest extends TestCase
         $a = [&$v];
         $obj->hook('inc', $a);
 
-        static::assertSame([2], $a);
+        self::assertSame([2], $a);
 
         $obj = new HookMock();
 
@@ -181,7 +181,7 @@ class HookTraitTest extends TestCase
         $obj->onHook('inc', $incFunc);
         $obj->hook('inc', [&$v]);
 
-        static::assertSame(2, $v);
+        self::assertSame(2, $v);
     }
 
     public function testBreakHook(): void
@@ -201,8 +201,8 @@ class HookTraitTest extends TestCase
         $m->onHook('inc', $incFunc);
 
         $ret = $m->hook('inc');
-        static::assertSame(2, $m->result);
-        static::assertSame('stop', $ret);
+        self::assertSame(2, $m->result);
+        self::assertSame('stop', $ret);
     }
 
     public function testBreakHookBrokenBy(): void
@@ -214,9 +214,9 @@ class HookTraitTest extends TestCase
         });
 
         $ret = $m->hook('inc', [], $brokenBy);
-        static::assertSame('stop', $ret);
-        static::assertInstanceOf(HookBreaker::class, $brokenBy);
-        static::assertSame('stop', $brokenBy->getReturnValue());
+        self::assertSame('stop', $ret);
+        self::assertInstanceOf(HookBreaker::class, $brokenBy);
+        self::assertSame('stop', $brokenBy->getReturnValue());
     }
 
     public function testExceptionInHook(): void
@@ -277,7 +277,7 @@ class HookTraitTest extends TestCase
         $m->onHookShort('null_scope_class', \Closure::fromCallable('trim'), ['x']);
         $m = clone $m;
         foreach ($m->hook('inc') as $v) {
-            static::assertNull($v);
+            self::assertNull($v);
         }
 
         // callback bound to the same object
@@ -286,18 +286,18 @@ class HookTraitTest extends TestCase
         $m->onHookShort('inc', $m->makeCallback());
         $m = clone $m;
         foreach ($m->hook('inc') as $v) {
-            static::assertSame($m, $v);
+            self::assertSame($m, $v);
         }
-        static::assertSame(2, $m->result);
+        self::assertSame(2, $m->result);
         foreach ($m->hook('inc') as $v) { // 2nd dispatch
-            static::assertSame($m, $v);
+            self::assertSame($m, $v);
         }
-        static::assertSame(4, $m->result);
+        self::assertSame(4, $m->result);
         $m = clone $m; // 2nd clone
         foreach ($m->hook('inc') as $v) {
-            static::assertSame($m, $v);
+            self::assertSame($m, $v);
         }
-        static::assertSame(6, $m->result);
+        self::assertSame(6, $m->result);
 
         // callback bound to a different object
         $m = $makeMock();
@@ -327,32 +327,32 @@ class HookTraitTest extends TestCase
             return $hookThis;
         }, $m->makeCallback());
 
-        static::assertSame([$hookThis], $m->hook('inc'));
-        static::assertSame(1, $m->result);
+        self::assertSame([$hookThis], $m->hook('inc'));
+        self::assertSame(1, $m->result);
 
         $mCloned = clone $m;
-        static::assertSame([$hookThis], $m->hook('inc'));
-        static::assertSame(2, $m->result);
-        static::assertSame(1, $mCloned->result);
-        static::assertSame([$hookThis], $mCloned->hook('inc'));
-        static::assertSame(3, $m->result);
-        static::assertSame(1, $mCloned->result);
+        self::assertSame([$hookThis], $m->hook('inc'));
+        self::assertSame(2, $m->result);
+        self::assertSame(1, $mCloned->result);
+        self::assertSame([$hookThis], $mCloned->hook('inc'));
+        self::assertSame(3, $m->result);
+        self::assertSame(1, $mCloned->result);
 
         $hookThis = $mCloned;
-        static::assertSame([$hookThis], $m->hook('inc'));
-        static::assertSame(3, $m->result);
-        static::assertSame(2, $mCloned->result);
-        static::assertSame([$hookThis], $mCloned->hook('inc'));
-        static::assertSame(3, $m->result);
-        static::assertSame(3, $mCloned->result);
+        self::assertSame([$hookThis], $m->hook('inc'));
+        self::assertSame(3, $m->result);
+        self::assertSame(2, $mCloned->result);
+        self::assertSame([$hookThis], $mCloned->hook('inc'));
+        self::assertSame(3, $m->result);
+        self::assertSame(3, $mCloned->result);
 
         $hookThis = $m;
-        static::assertSame([$hookThis], $m->hook('inc'));
-        static::assertSame(4, $m->result);
-        static::assertSame(3, $mCloned->result);
-        static::assertSame([$hookThis], $mCloned->hook('inc'));
-        static::assertSame(5, $m->result);
-        static::assertSame(3, $mCloned->result);
+        self::assertSame([$hookThis], $m->hook('inc'));
+        self::assertSame(4, $m->result);
+        self::assertSame(3, $mCloned->result);
+        self::assertSame([$hookThis], $mCloned->hook('inc'));
+        self::assertSame(5, $m->result);
+        self::assertSame(3, $mCloned->result);
 
         $m->onHookDynamicShort('incShort', static function () use (&$hookThis) {
             return $hookThis;
@@ -362,33 +362,33 @@ class HookTraitTest extends TestCase
 
             return $this->hook('inc');
         }, ['x']);
-        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
-        static::assertSame(6, $m->result);
-        static::assertSame(3, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        self::assertSame(6, $m->result);
+        self::assertSame(3, $mCloned->result);
 
         $mCloned = clone $m;
-        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
-        static::assertSame(7, $m->result);
-        static::assertSame(6, $mCloned->result);
-        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
-        static::assertSame(8, $m->result);
-        static::assertSame(6, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        self::assertSame(7, $m->result);
+        self::assertSame(6, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        self::assertSame(8, $m->result);
+        self::assertSame(6, $mCloned->result);
 
         $hookThis = $mCloned;
-        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
-        static::assertSame(8, $m->result);
-        static::assertSame(7, $mCloned->result);
-        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
-        static::assertSame(8, $m->result);
-        static::assertSame(8, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        self::assertSame(8, $m->result);
+        self::assertSame(7, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        self::assertSame(8, $m->result);
+        self::assertSame(8, $mCloned->result);
 
         $hookThis = $m;
-        static::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
-        static::assertSame(9, $m->result);
-        static::assertSame(8, $mCloned->result);
-        static::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
-        static::assertSame(10, $m->result);
-        static::assertSame(8, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $m->hook('incShort', ['y']));
+        self::assertSame(9, $m->result);
+        self::assertSame(8, $mCloned->result);
+        self::assertSame([1 => [$hookThis]], $mCloned->hook('incShort', ['y']));
+        self::assertSame(10, $m->result);
+        self::assertSame(8, $mCloned->result);
     }
 
     public function testOnHookDynamicBoundGetterException(): void
@@ -423,9 +423,9 @@ class HookTraitTest extends TestCase
             ++$value;
         });
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(1, $value);
+        self::assertSame(1, $value);
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(2, $value);
+        self::assertSame(2, $value);
 
         $value = 0;
         $m = new HookMock();
@@ -433,9 +433,9 @@ class HookTraitTest extends TestCase
             ++$value;
         });
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(1, $value);
+        self::assertSame(1, $value);
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(2, $value);
+        self::assertSame(2, $value);
 
         $value = 0;
         $m = new HookMock();
@@ -445,9 +445,9 @@ class HookTraitTest extends TestCase
             ++$value;
         });
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(1, $value);
+        self::assertSame(1, $value);
         $m->hook('inc', ['x', &$value]);
-        static::assertSame(2, $value);
+        self::assertSame(2, $value);
     }
 }
 

--- a/tests/InitializerTraitTest.php
+++ b/tests/InitializerTraitTest.php
@@ -14,10 +14,10 @@ class InitializerTraitTest extends TestCase
     public function testInit(): void
     {
         $m = new InitializerMock();
-        static::assertFalse($m->isInitialized());
+        self::assertFalse($m->isInitialized());
         $m->invokeInit();
-        static::assertTrue($m->isInitialized());
-        static::assertTrue($m->result);
+        self::assertTrue($m->isInitialized());
+        self::assertTrue($m->result);
         $m->assertIsInitialized();
     }
 
@@ -29,15 +29,15 @@ class InitializerTraitTest extends TestCase
 
         $m = new InitializerMock();
         $container->add($m);
-        static::assertTrue($m->isInitialized());
-        static::assertTrue($m->result);
+        self::assertTrue($m->isInitialized());
+        self::assertTrue($m->result);
         $m->assertIsInitialized();
     }
 
     public function testInitNotCalled(): void
     {
         $m = new InitializerMock();
-        static::assertFalse($m->isInitialized());
+        self::assertFalse($m->isInitialized());
 
         $this->expectException(Exception::class);
         $m->assertIsInitialized();
@@ -55,7 +55,7 @@ class InitializerTraitTest extends TestCase
     {
         $m = new InitializerMock();
         $m->invokeInit();
-        static::assertTrue($m->isInitialized());
+        self::assertTrue($m->isInitialized());
 
         $this->expectException(Exception::class);
         $m->invokeInit();

--- a/tests/Phpunit/ResultPrinterTest.php
+++ b/tests/Phpunit/ResultPrinterTest.php
@@ -34,17 +34,17 @@ class ResultPrinterTest extends TestCase
             ->addMoreInfo('y', ['bar' => 2.4, [], [[1]]]);
 
         $resNotWrapped = $this->printAndReturnDefectTrace(ResultPrinter::class, $exception);
-        static::assertStringContainsString((string) $exception, $resNotWrapped);
-        static::assertStringContainsString((string) $innerException, $resNotWrapped);
+        self::assertStringContainsString((string) $exception, $resNotWrapped);
+        self::assertStringContainsString((string) $innerException, $resNotWrapped);
 
         $res = $this->printAndReturnDefectTrace(ResultPrinter::class, new ExceptionWrapper($exception));
-        static::assertTrue(strlen($res) < strlen($resNotWrapped));
+        self::assertTrue(strlen($res) < strlen($resNotWrapped));
         if (\PHP_MAJOR_VERSION < 8) {
             // phpvfscomposer:// is not correctly filtered from stacktrace
             // by PHPUnit\Util\Filter::getFilteredStacktrace() method
             return;
         }
-        static::assertSame(
+        self::assertSame(
             <<<'EOF'
                 Atk4\Core\Exception: My exception
                   x: 'foo'

--- a/tests/Phpunit/TestCaseTest.php
+++ b/tests/Phpunit/TestCaseTest.php
@@ -52,33 +52,33 @@ class TestCaseTest extends TestCase
      */
     public function testObjectsAreReleasedAfterTest(string $v): void
     {
-        static::assertSame(0, self::$activeObjectsCounter);
-        static::assertSame('default', $this->object);
-        static::assertNull($this->objectTyped);
+        self::assertSame(0, self::$activeObjectsCounter);
+        self::assertSame('default', $this->object);
+        self::assertNull($this->objectTyped);
         $reflectionProperty = new \ReflectionProperty($this, 'objectTypedNoDefault');
         $reflectionProperty->setAccessible(true);
-        static::assertFalse($reflectionProperty->isInitialized($this));
+        self::assertFalse($reflectionProperty->isInitialized($this));
 
         if ($v === 'a') {
             $o = $this->createAndCountObject();
-            static::assertSame(1, self::$activeObjectsCounter);
+            self::assertSame(1, self::$activeObjectsCounter);
             $o = null;
-            static::assertSame(0, self::$activeObjectsCounter);
+            self::assertSame(0, self::$activeObjectsCounter);
             $this->object = $this->createAndCountObject();
-            static::assertSame(1, self::$activeObjectsCounter);
+            self::assertSame(1, self::$activeObjectsCounter);
 
             $this->object = $this->createAndCountObject();
             $this->objectTyped = $this->createAndCountObject();
             // @ is needed because of https://github.com/php/php-src/issues/9389 for burn testing
             @$this->objectTypedNoDefault = $this->createAndCountObject();
-            static::assertNotNull($this->objectTypedNoDefault); // remove once https://github.com/phpstan/phpstan/issues/7818 is fixed
-            static::assertSame(3, self::$activeObjectsCounter);
+            self::assertNotNull($this->objectTypedNoDefault); // remove once https://github.com/phpstan/phpstan/issues/7818 is fixed
+            self::assertSame(3, self::$activeObjectsCounter);
         }
     }
 
     public function testObjectsAreReleasedFromUncaughtException(): void
     {
-        static::assertSame(0, self::$activeObjectsCounter);
+        self::assertSame(0, self::$activeObjectsCounter);
 
         $throwFx = function (object $arg): never {
             throw (new Exception())
@@ -90,16 +90,16 @@ class TestCaseTest extends TestCase
         } catch (\Exception $e) {
             $e = new \Error('wrap', 0, $e);
         }
-        static::assertSame(2, self::$activeObjectsCounter);
+        self::assertSame(2, self::$activeObjectsCounter);
 
         $e2 = null;
         try {
             $this->onNotSuccessfulTest($e);
         } catch (\Error $e2) {
         }
-        static::assertSame($e, $e2);
+        self::assertSame($e, $e2);
 
-        static::assertSame(0, self::$activeObjectsCounter);
+        self::assertSame(0, self::$activeObjectsCounter);
     }
 
     /**
@@ -118,9 +118,9 @@ class TestCaseTest extends TestCase
     public function testProviderCoverage(string $v): void
     {
         if ($v === 'y') {
-            static::assertSame(2, self::$providerCoverageCallCounter);
+            self::assertSame(2, self::$providerCoverageCallCounter);
         }
-        static::assertTrue(in_array($v, ['a', 'b', 'x', 'y'], true));
+        self::assertTrue(in_array($v, ['a', 'b', 'x', 'y'], true));
     }
 
     /**
@@ -138,7 +138,7 @@ class TestCaseTest extends TestCase
      */
     public function testCoverageImplForDoesNotPerformAssertions(string $v): void
     {
-        static::assertFalse($this->doesNotPerformAssertions());
+        self::assertFalse($this->doesNotPerformAssertions());
 
         $staticClass = get_class(new class() {
             public static int $counter = 0;
@@ -150,7 +150,7 @@ class TestCaseTest extends TestCase
             // @codeCoverageIgnoreEnd
         }
 
-        static::assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
+        self::assertTrue($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
 
         if ($v === 'b') {
             // make sure TestResult::$beStrictAboutTestsThatDoNotTestAnything is reset
@@ -171,7 +171,7 @@ class TestCaseTest extends TestCase
             \Closure::bind(fn () => $this->status = $testStatusOrig, $this, PhpunitTestCase::class)();
         }
 
-        static::assertFalse($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
+        self::assertFalse($this->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything());
     }
 
     /**

--- a/tests/QuietObjectWrapperTest.php
+++ b/tests/QuietObjectWrapperTest.php
@@ -14,7 +14,7 @@ class QuietObjectWrapperTest extends TestCase
     {
         $oOrig = new \stdClass();
         $o = new QuietObjectWrapper($oOrig);
-        static::assertSame($oOrig, $o->get());
+        self::assertSame($oOrig, $o->get());
     }
 
     public function testNotCloneable(): void
@@ -36,7 +36,7 @@ class QuietObjectWrapperTest extends TestCase
     public function testDebugInfoQuiet(): void
     {
         $o = new QuietObjectWrapper(new \stdClass());
-        static::assertSame(<<<'EOF'
+        self::assertSame(<<<'EOF'
             Atk4\Core\QuietObjectWrapper Object
             (
                 [wrappedClass] => stdClass
@@ -52,7 +52,7 @@ class QuietObjectWrapperTest extends TestCase
                 return ['foo' => 1, 'Bar' => 2];
             }
         });
-        static::assertSame(<<<'EOF'
+        self::assertSame(<<<'EOF'
             Atk4\Core\QuietObjectWrapper Object
             (
                 [wrappedClass] => class@anonymous

--- a/tests/ReadableCaptionTraitTest.php
+++ b/tests/ReadableCaptionTraitTest.php
@@ -13,12 +13,12 @@ class ReadableCaptionTraitTest extends TestCase
     {
         $a = new ReadableCaptionMock();
 
-        static::assertSame('User Defined Entity', $a->readableCaption('userDefinedEntity'));
-        static::assertSame('New NASA Module', $a->readableCaption('newNASA_module'));
-        static::assertSame('This Is NASA My Big Bull Shit 123 Foo', $a->readableCaption('this\ _isNASA_MyBigBull shit_123\Foo'));
+        self::assertSame('User Defined Entity', $a->readableCaption('userDefinedEntity'));
+        self::assertSame('New NASA Module', $a->readableCaption('newNASA_module'));
+        self::assertSame('This Is NASA My Big Bull Shit 123 Foo', $a->readableCaption('this\ _isNASA_MyBigBull shit_123\Foo'));
 
-        static::assertSame('ID', $a->readableCaption('id'));
-        static::assertSame('Account ID', $a->readableCaption('account_id'));
+        self::assertSame('ID', $a->readableCaption('id'));
+        self::assertSame('Account ID', $a->readableCaption('account_id'));
     }
 }
 

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -60,12 +60,12 @@ class StaticAddToTest extends TestCase
 
         // add to return object
         $tr = StdSat::addTo($m);
-        static::assertSame(StdSat::class, get_class($tr));
+        self::assertSame(StdSat::class, get_class($tr));
 
         // trackable object can be referenced by name
         $tr3 = TrackableMockSat::addTo($m, [], ['foo']);
         $tr = $m->getElement('foo');
-        static::assertSame($tr, $tr3);
+        self::assertSame($tr, $tr3);
 
         // not the same or extended class
         $this->expectException(\TypeError::class);
@@ -77,7 +77,7 @@ class StaticAddToTest extends TestCase
         // object is of the same class
         StdSat::assertInstanceOf(new StdSat());
         $o = new StdSat();
-        static::assertSame($o, StdSat::assertInstanceOf($o));
+        self::assertSame($o, StdSat::assertInstanceOf($o));
 
         // object is a subtype
         StdSat::assertInstanceOf(new StdSat2());
@@ -93,19 +93,19 @@ class StaticAddToTest extends TestCase
 
         // the same class
         $tr = StdSat::addToWithCl($m, [StdSat::class]);
-        static::assertSame(StdSat::class, get_class($tr));
+        self::assertSame(StdSat::class, get_class($tr));
 
         // add object - for BC
         $tr = StdSat::addToWithCl($m, $tr);
-        static::assertSame(StdSat::class, get_class($tr));
+        self::assertSame(StdSat::class, get_class($tr));
 
         // extended class
         $tr = StdSat::addToWithCl($m, [StdSat2::class]);
-        static::assertSame(StdSat2::class, get_class($tr));
+        self::assertSame(StdSat2::class, get_class($tr));
 
         // not the same or extended class - unsafe enabled
         $tr = StdSat::addToWithClUnsafe($m, [\stdClass::class]);
-        static::assertSame(\stdClass::class, get_class($tr));
+        self::assertSame(\stdClass::class, get_class($tr));
 
         // not the same or extended class - unsafe disabled
         $this->expectException(Exception::class);
@@ -123,28 +123,28 @@ class StaticAddToTest extends TestCase
         TrackableMockSat::addTo($m, [], ['123']);
         TrackableMockSat::addTo($m, [], ['false']);
 
-        static::assertTrue($m->hasElement('foo bar'));
-        static::assertTrue($m->hasElement('123'));
-        static::assertTrue($m->hasElement('false'));
-        static::assertSame(5, $m->getElementCount());
+        self::assertTrue($m->hasElement('foo bar'));
+        self::assertTrue($m->hasElement('123'));
+        self::assertTrue($m->hasElement('false'));
+        self::assertSame(5, $m->getElementCount());
 
         $m->getElement('foo bar')->destroy();
-        static::assertSame(4, $m->getElementCount());
+        self::assertSame(4, $m->getElementCount());
         $anon->destroy();
-        static::assertSame(3, $m->getElementCount());
+        self::assertSame(3, $m->getElementCount());
     }
 
     public function testFactoryMock(): void
     {
         $m = new ContainerFactoryMockSat();
         $m1 = DiMockSat::addTo($m, ['a' => 'XXX', 'b' => 'YYY']);
-        static::assertSame('XXX', $m1->a);
-        static::assertSame('YYY', $m1->b);
-        static::assertNull($m1->c);
+        self::assertSame('XXX', $m1->a);
+        self::assertSame('YYY', $m1->b);
+        self::assertNull($m1->c);
 
         $m2 = DiConstructorMockSat::addTo($m, ['a' => 'XXX', 'John', 'b' => 'YYY']);
-        static::assertSame('XXX', $m2->a);
-        static::assertSame('YYY', $m2->b);
-        static::assertSame('John', $m2->c);
+        self::assertSame('XXX', $m2->a);
+        self::assertSame('YYY', $m2->b);
+        self::assertSame('John', $m2->c);
     }
 }

--- a/tests/TraitUtilTest.php
+++ b/tests/TraitUtilTest.php
@@ -13,24 +13,24 @@ class TraitUtilTest extends TestCase
 {
     public function testHasTrait(): void
     {
-        static::assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, NameTrait::class));
+        self::assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, NameTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, NameTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, NameTrait::class));
 
-        static::assertFalse(TraitUtil::hasTrait(new TraitUtilTestA(), NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(new TraitUtilTestB(), NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(new TraitUtilTestC(), NameTrait::class));
+        self::assertFalse(TraitUtil::hasTrait(new TraitUtilTestA(), NameTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(new TraitUtilTestB(), NameTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(new TraitUtilTestC(), NameTrait::class));
 
-        static::assertFalse(TraitUtil::hasTrait(new class() extends TraitUtilTestA {
+        self::assertFalse(TraitUtil::hasTrait(new class() extends TraitUtilTestA {
         }, NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestB {
+        self::assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestB {
         }, NameTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestC {
+        self::assertTrue(TraitUtil::hasTrait(new class() extends TraitUtilTestC {
         }, NameTrait::class));
 
-        static::assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, HookTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, HookTrait::class));
-        static::assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, HookTrait::class));
+        self::assertFalse(TraitUtil::hasTrait(TraitUtilTestA::class, HookTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(TraitUtilTestB::class, HookTrait::class));
+        self::assertTrue(TraitUtil::hasTrait(TraitUtilTestC::class, HookTrait::class));
     }
 }
 

--- a/tests/Translator/AdapterBaseTest.php
+++ b/tests/Translator/AdapterBaseTest.php
@@ -47,10 +47,10 @@ abstract class AdapterBaseTest extends TestCase
         $message = 'Field requires array for defaults';
 
         $actual = $this->translate($message, [], 'atk', 'en');
-        static::assertSame($message, $actual);
+        self::assertSame($message, $actual);
 
         $actual = $this->translate($message, [], 'atk', 'it');
-        static::assertSame('Il campo richiede un array per i valori predefiniti', $actual);
+        self::assertSame('Il campo richiede un array per i valori predefiniti', $actual);
     }
 
     public function testSubstitution(): void
@@ -58,7 +58,7 @@ abstract class AdapterBaseTest extends TestCase
         $message = 'Unable to serialize field value on load';
 
         $actual = $this->translate($message, ['field' => 'field_name'], 'atk', 'en');
-        static::assertSame('Unable to serialize field value on load (field_name)', $actual);
+        self::assertSame('Unable to serialize field value on load (field_name)', $actual);
     }
 
     public function testPluralZero(): void
@@ -66,7 +66,7 @@ abstract class AdapterBaseTest extends TestCase
         $message = 'Test with plural';
 
         $actual = $this->translate($message, ['count' => 0], 'atk', 'it');
-        static::assertSame('Test zero', $actual);
+        self::assertSame('Test zero', $actual);
     }
 
     public function testPluralBig(): void
@@ -74,7 +74,7 @@ abstract class AdapterBaseTest extends TestCase
         $message = 'Test with plural';
 
         $actual = $this->translate($message, ['count' => 50], 'atk', 'it');
-        static::assertSame('Test sono 50', $actual);
+        self::assertSame('Test sono 50', $actual);
     }
 
     public function testPluralOne(): void
@@ -82,6 +82,6 @@ abstract class AdapterBaseTest extends TestCase
         $message = 'Test with plural';
 
         $actual = $this->translate($message, ['count' => 1], 'atk', 'it');
-        static::assertSame('Test è uno', $actual);
+        self::assertSame('Test è uno', $actual);
     }
 }

--- a/tests/Translator/AdapterGenericTest.php
+++ b/tests/Translator/AdapterGenericTest.php
@@ -19,7 +19,7 @@ class AdapterGenericTest extends AdapterBaseTest
 
     public function testExceptionDiNotFound(): void
     {
-        static::assertSame('no key return self', Translator::instance()->_('no key return self'));
+        self::assertSame('no key return self', Translator::instance()->_('no key return self'));
     }
 
     public function testAdapter(): void
@@ -30,23 +30,23 @@ class AdapterGenericTest extends AdapterBaseTest
 
         Translator::instance()->setAdapter($adapter);
 
-        static::assertSame('custom definition', Translator::instance()->_('test', [], 'other', 'en'));
+        self::assertSame('custom definition', Translator::instance()->_('test', [], 'other', 'en'));
 
         // test replace
         $adapter->setDefinitionSingle('test', 'custom definition replaced', 'en', 'other');
 
-        static::assertSame('custom definition replaced', Translator::instance()->_('test', [], 'other', 'en'));
+        self::assertSame('custom definition replaced', Translator::instance()->_('test', [], 'other', 'en'));
 
         // test other language
         $adapter->setDefinitionSingle('test', 'definizione personalizzata', 'it', 'other');
 
-        static::assertSame('definizione personalizzata', Translator::instance()->_('test', [], 'other', 'it'));
+        self::assertSame('definizione personalizzata', Translator::instance()->_('test', [], 'other', 'it'));
 
         Translator::instance()->setDefaultLocale('it');
-        static::assertSame('definizione personalizzata', Translator::instance()->_('test', [], 'other'));
+        self::assertSame('definizione personalizzata', Translator::instance()->_('test', [], 'other'));
 
         Translator::instance()->setDefaultDomain('other');
-        static::assertSame('definizione personalizzata', Translator::instance()->_('test'));
+        self::assertSame('definizione personalizzata', Translator::instance()->_('test'));
     }
 
     public function testAdapterPlurals(): void
@@ -66,9 +66,9 @@ class AdapterGenericTest extends AdapterBaseTest
             'other' => 'is {{count}}',
         ], 'en', 'other');
 
-        static::assertSame('is empty', Translator::instance()->_('test', ['count' => 0]));
-        static::assertSame('is one', Translator::instance()->_('test', ['count' => 1]));
-        static::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
+        self::assertSame('is empty', Translator::instance()->_('test', ['count' => 0]));
+        self::assertSame('is one', Translator::instance()->_('test', ['count' => 1]));
+        self::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
     }
 
     public function testAdapterPluralsNotFullDefinition(): void
@@ -87,9 +87,9 @@ class AdapterGenericTest extends AdapterBaseTest
             'other' => 'is {{count}}',
         ], 'en', 'other');
 
-        static::assertSame('is 0', Translator::instance()->_('test', ['count' => 0]));
-        static::assertSame('is one', Translator::instance()->_('test', ['count' => 1]));
-        static::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
+        self::assertSame('is 0', Translator::instance()->_('test', ['count' => 0]));
+        self::assertSame('is one', Translator::instance()->_('test', ['count' => 1]));
+        self::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
     }
 
     public function testAdapterPluralsSingular(): void
@@ -107,8 +107,8 @@ class AdapterGenericTest extends AdapterBaseTest
             'other' => 'is {{count}}',
         ], 'en', 'other');
 
-        static::assertSame('is 0', Translator::instance()->_('test', ['count' => 0]));
-        static::assertSame('is 1', Translator::instance()->_('test', ['count' => 1]));
-        static::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
+        self::assertSame('is 0', Translator::instance()->_('test', ['count' => 0]));
+        self::assertSame('is 1', Translator::instance()->_('test', ['count' => 1]));
+        self::assertSame('is 500', Translator::instance()->_('test', ['count' => 500]));
     }
 }

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -99,7 +99,7 @@ class WarnDynamicPropertyTraitTest extends TestCase
     {
         $this->runWithErrorConvertedToException(function () {
             $test = new ClassWithWarnDynamicPropertyTrait();
-            static::assertTrue((new \ReflectionClass(get_parent_class($test)))->hasProperty('trace'));
+            self::assertTrue((new \ReflectionClass(get_parent_class($test)))->hasProperty('trace'));
 
             $this->expectException(WarnError::class);
             $this->expectExceptionMessage('Undefined property: Atk4\Core\Exception::$trace');

--- a/tests/WarnDynamicPropertyTraitTest.php
+++ b/tests/WarnDynamicPropertyTraitTest.php
@@ -74,9 +74,9 @@ class WarnDynamicPropertyTraitTest extends TestCase
         $test = new class() extends ClassWithWarnDynamicPropertyTrait {
             public bool $p = false;
         };
-        static::assertFalse($test->p);
+        self::assertFalse($test->p);
         $test->p = true;
-        static::assertTrue($test->p);
+        self::assertTrue($test->p);
         unset($test->{'p'});
 
         $this->runWithErrorConvertedToException(function () use ($test) {
@@ -117,14 +117,14 @@ class WarnDynamicPropertyTraitTest extends TestCase
             return true;
         });
         try {
-            static::assertTrue($test->__isset('p'));
-            static::assertFalse($test->p);
-            static::assertFalse($test->__get('p'));
+            self::assertTrue($test->__isset('p'));
+            self::assertFalse($test->p);
+            self::assertFalse($test->__get('p'));
             $test->__set('p', true);
-            static::assertTrue($test->p);
-            static::assertTrue($test->__get('p'));
+            self::assertTrue($test->p);
+            self::assertTrue($test->__get('p'));
             $test->__unset('p');
-            static::assertFalse($test->__isset('p'));
+            self::assertFalse($test->__isset('p'));
         } finally {
             restore_error_handler();
         }


### PR DESCRIPTION
related with https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6931