### PR TITLE
Fix Markdown links in reStructured Text

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,11 @@ Agile Core Documentation
 
 Agile Core is a collection of PHP Traits for designing object-oriented
 frameworks. The main purpose for this project is to work as a foundation for
-[Agile UI](https://github.com/atk4/ui) and [Agile Data](https://github.com/atk4/data),
+`Agile UI`_ and `Agile Data`_,
 but you are welcome to use some or all traits elsewhere.
+
+.. _Agile UI: https://github.com/atk4/ui
+.. _Agile Data: https://github.com/atk4/data
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Currently broken: https://agile-core.readthedocs.io/en/develop/
Preview: https://github.com/szepeviktor/atk4_core/blob/patch-1/docs/index.rst

Docs: https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#links-to-external-web-pages
