### PR TITLE
Remove dynamic global method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://atk4-core.readthedocs.io/
 ## Community and Support
 
 [![Stack Overflow Community](https://img.shields.io/stackexchange/stackoverflow/t/atk4.svg)](https://stackoverflow.com/questions/ask?tags=atk4)
-[![Discord Community](https://img.shields.io/badge/discord-User_Forum-green.svg)](https://forum.agiletoolkit.org/c/44)
+[![Discord Community](https://img.shields.io/badge/discord-User_Forum-green.svg)](https://discord.gg/QVKSk2B)
 
 ## Install from Composer
 

--- a/docs/dynamicmethod.md
+++ b/docs/dynamicmethod.md
@@ -18,26 +18,6 @@ $object->addMethod('test', function ($o, $args) {
 $object->test('world');
 ```
 
-## Global Methods
-
-If object has application scope {php:trait}`AppScopeTrait` and the application
-implements {php:trait}`HookTrait` then executing $object->test() will also
-look for globally-registered method inside the application:
-
-```
-$object->getApp()->addGlobalMethod('test', function ($app, $o, $args) {
-    echo 'hello, ' . $args[0];
-});
-
-$object->test('world');
-```
-
-Of course calling test() on the other object afterwards will trigger same
-global method.
-
-If you attempt to register same method multiple times you will receive an
-exception.
-
 ## Dynamic Method Arguments
 
 When calling dynamic method first argument which is passed to the method will
@@ -74,12 +54,4 @@ Returns true also if specified methods is defined globally.
 
 :::{php:method} removeMethod($name)
 Remove dynamically registered method.
-:::
-
-:::{php:method} addGlobalMethod($name, $closure)
-Registers a globally-recognized method for all objects.
-:::
-
-:::{php:method} hasGlobalMethod($name)
-Return true if such global method exists.
 :::

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,5 +18,5 @@ parameters:
 
         -
             path: 'tests/DynamicMethodTraitTest.php'
-            message: '~^Call to an undefined method Atk4\\Core\\Tests\\(DynamicMethodMock|DynamicMethodWithoutHookMock|GlobalMethodObjectMock)::\w+\(\)\.$~'
-            count: 35
+            message: '~^Call to an undefined method Atk4\\Core\\Tests\\(DynamicMethodMock|DynamicMethodWithoutHookMock)::\w+\(\)\.$~'
+            count: 10

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,9 +4,9 @@ includes:
 parameters:
     level: 6
     paths:
-        - ./
+        - .
     excludePaths:
-        - vendor/
+        - vendor
 
     ignoreErrors:
         # relax strict rules


### PR DESCRIPTION
I would understand global per class (not per instance) support, but that was not the case, thus better to remove it completely, the sooner, the better.