### PR TITLE
Allow psr/log v2 and v3 dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": ">=7.4 <8.4",
         "benmorel/weakmap-polyfill": "^0.4.0",
-        "psr/log": "^1.0",
+        "psr/log": "^3.0",
         "symfony/polyfill-php80": "^1.28",
         "symfony/polyfill-php81": "^1.28",
         "symfony/polyfill-php82": "^1.28",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": ">=7.4 <8.4",
         "benmorel/weakmap-polyfill": "^0.4.0",
-        "psr/log": "^3.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/polyfill-php80": "^1.28",
         "symfony/polyfill-php81": "^1.28",
         "symfony/polyfill-php82": "^1.28",

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -28,8 +28,8 @@ described below:
 
 The design goal of Debug is to be able to display contextual debug information
 only when it's manually enabled. For instance, if you are having problem with
-user authentication, you should enable `$auth->debug()`. On other hand - if
-you wish to see persistence-related debug info, then `$db->debug()` will
+user authentication, you should enable `$auth->debug(true)`. On other hand - if
+you wish to see persistence-related debug info, then `$db->debug(true)` will
 enable that.
 
 Information logged through debug like this on any object that implements
@@ -48,7 +48,7 @@ most cases this will simply be ignored right away unless you manually enable
 debugging for the object:
 
 ```
-$obj1->debug(); // enable debugging
+$obj1->debug(true); // enable debugging
 $obj1->debug(false); // disable debugging
 $obj1->debug(true); // also enables debugging
 

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -41,8 +41,8 @@ trait DebugTrait
     /**
      * Detailed debug information.
      *
-     * @param bool|string|\Stringable                   $message
-     * @param ($message is bool ? never : array<mixed>) $context
+     * @param bool|string|\Stringable $message
+     * @param array<mixed>            $context
      */
     public function debug($message, array $context = []): void
     {

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -23,20 +23,33 @@ trait DebugTrait
     }
 
     /**
-     * Send some info to debug stream.
+     * Logs with an arbitrary level.
+     *
+     * @param string       $message
+     * @param array<mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
+            $this->getApp()->logger->log($level, $message, $context);
+        } else {
+            $this->_echoStderr($message . "\n");
+        }
+    }
+
+    /**
+     * Detailed debug information.
      *
      * @param bool|string  $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function debug($message = true, array $context = [])
+    public function debug($message, array $context = []): void
     {
         // using this to switch on/off the debug for this object
         if (is_bool($message)) {
             $this->debug = $message;
 
-            return $this;
+            return;
         }
 
         // if debug is enabled, then log it
@@ -46,28 +59,6 @@ trait DebugTrait
             }
             $this->log(LogLevel::DEBUG, $message, $context);
         }
-
-        return $this;
-    }
-
-    /**
-     * Output log message.
-     *
-     * @param mixed        $level
-     * @param string       $message
-     * @param array<mixed> $context
-     *
-     * @return $this
-     */
-    public function log($level, $message, array $context = [])
-    {
-        if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && $this->getApp()->logger instanceof \Psr\Log\LoggerInterface) {
-            $this->getApp()->logger->log($level, $message, $context);
-        } else {
-            $this->_echoStderr($message . "\n");
-        }
-
-        return $this;
     }
 
     /**
@@ -79,7 +70,7 @@ trait DebugTrait
      * Place debugTraceChange inside your hook and give unique $trace identifier. If the method
      * is invoked through different call paths, this debug info will be logged.
      *
-     * Do not leave this method in production code !!!
+     * Do not use this method in production code !!!
      */
     public function debugTraceChange(string $trace = 'default'): void
     {
@@ -105,12 +96,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
-        return $this->log(LogLevel::EMERGENCY, $message, $context);
+        $this->log(LogLevel::EMERGENCY, $message, $context);
     }
 
     /**
@@ -121,12 +110,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
-        return $this->log(LogLevel::ALERT, $message, $context);
+        $this->log(LogLevel::ALERT, $message, $context);
     }
 
     /**
@@ -136,12 +123,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
-        return $this->log(LogLevel::CRITICAL, $message, $context);
+        $this->log(LogLevel::CRITICAL, $message, $context);
     }
 
     /**
@@ -150,12 +135,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
-        return $this->log(LogLevel::ERROR, $message, $context);
+        $this->log(LogLevel::ERROR, $message, $context);
     }
 
     /**
@@ -166,12 +149,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
-        return $this->log(LogLevel::WARNING, $message, $context);
+        $this->log(LogLevel::WARNING, $message, $context);
     }
 
     /**
@@ -179,12 +160,10 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
-        return $this->log(LogLevel::NOTICE, $message, $context);
+        $this->log(LogLevel::NOTICE, $message, $context);
     }
 
     /**
@@ -194,11 +173,9 @@ trait DebugTrait
      *
      * @param string       $message
      * @param array<mixed> $context
-     *
-     * @return $this
      */
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
-        return $this->log(LogLevel::INFO, $message, $context);
+        $this->log(LogLevel::INFO, $message, $context);
     }
 }

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -25,8 +25,9 @@ trait DebugTrait
     /**
      * Logs with an arbitrary level.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param mixed              $level
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function log($level, $message, array $context = []): void
     {
@@ -40,8 +41,8 @@ trait DebugTrait
     /**
      * Detailed debug information.
      *
-     * @param bool|string  $message
-     * @param array<mixed> $context
+     * @param bool|string|\Stringable $message
+     * @param array<mixed>            $context
      */
     public function debug($message, array $context = []): void
     {
@@ -94,8 +95,8 @@ trait DebugTrait
     /**
      * System is unusable.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function emergency($message, array $context = []): void
     {
@@ -108,8 +109,8 @@ trait DebugTrait
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function alert($message, array $context = []): void
     {
@@ -121,8 +122,8 @@ trait DebugTrait
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function critical($message, array $context = []): void
     {
@@ -133,8 +134,8 @@ trait DebugTrait
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function error($message, array $context = []): void
     {
@@ -147,8 +148,8 @@ trait DebugTrait
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function warning($message, array $context = []): void
     {
@@ -158,8 +159,8 @@ trait DebugTrait
     /**
      * Normal but significant events.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function notice($message, array $context = []): void
     {
@@ -171,8 +172,8 @@ trait DebugTrait
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param string|\Stringable $message
+     * @param array<mixed>       $context
      */
     public function info($message, array $context = []): void
     {

--- a/src/DebugTrait.php
+++ b/src/DebugTrait.php
@@ -41,8 +41,8 @@ trait DebugTrait
     /**
      * Detailed debug information.
      *
-     * @param bool|string|\Stringable $message
-     * @param array<mixed>            $context
+     * @param bool|string|\Stringable                   $message
+     * @param ($message is bool ? never : array<mixed>) $context
      */
     public function debug($message, array $context = []): void
     {
@@ -86,7 +86,7 @@ trait DebugTrait
             $d1 = array_diff($this->_previousTrace[$trace], $bt);
             $d2 = array_diff($bt, $this->_previousTrace[$trace]);
 
-            $this->log('debug', 'Call path for ' . $trace . ' has diverged (was ' . implode(', ', $d1) . ', now ' . implode(', ', $d2) . ")\n");
+            $this->log(LogLevel::DEBUG, 'Call path for ' . $trace . ' has diverged (was ' . implode(', ', $d1) . ', now ' . implode(', ', $d2) . ")\n");
         }
 
         $this->_previousTrace[$trace] = $bt;

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -16,7 +16,7 @@ class DebugTraitTest extends TestCase
 
         self::assertFalse($m->debug);
 
-        $m->debug();
+        $m->debug(true);
         self::assertTrue($m->debug);
 
         $m->debug(false);
@@ -28,34 +28,31 @@ class DebugTraitTest extends TestCase
 
     public function testDebugOutput(): void
     {
-        $this->expectOutputString("[Atk4\\Core\\Tests\\DebugMock]: debug test1\n");
-
         $m = new DebugMock();
-        $m->debug();
+        $m->debug(true);
 
+        $this->expectOutputString("[Atk4\\Core\\Tests\\DebugMock]: debug test1\n");
         $m->debug('debug test1');
     }
 
     public function testDebugNoOutput(): void
     {
-        $this->expectOutputString('');
-
         $m = new DebugMock();
 
+        $this->expectOutputString('');
         $m->debug('debug test2');
     }
 
     public function testDebugApp(): void
     {
-        $this->expectOutputString('');
-
         $app = new DebugAppMock();
         $app->logger = $app;
 
         $m = new DebugMock();
         $m->setApp($app);
-        $m->debug();
+        $m->debug(true);
 
+        $this->expectOutputString('');
         $m->debug('debug test2');
 
         self::assertSame(['debug', 'debug test2', []], $app->log);
@@ -63,21 +60,21 @@ class DebugTraitTest extends TestCase
 
     public function testLog1(): void
     {
-        $this->expectOutputString("debug test3\n");
-
         $m = new DebugMock();
+
+        $this->expectOutputString("debug test3\n");
         $m->log('warning', 'debug test3');
     }
 
     public function testLog2(): void
     {
-        $this->expectOutputString('');
-
         $app = new DebugAppMock();
         $app->logger = $app;
 
         $m = new DebugMock();
         $m->setApp($app);
+
+        $this->expectOutputString('');
         $m->log('warning', 'debug test3');
 
         self::assertSame(['warning', 'debug test3', []], $app->log);
@@ -166,9 +163,6 @@ class DebugAppMock implements \Psr\Log\LoggerInterface
     /** @var self */
     public $logger;
 
-    /**
-     * @param string $message
-     */
     public function log($level, $message, array $context = []): void
     {
         $this->log = [$level, $message, $context];

--- a/tests/DebugTraitTest.php
+++ b/tests/DebugTraitTest.php
@@ -167,10 +167,9 @@ class DebugAppMock implements \Psr\Log\LoggerInterface
     public $logger;
 
     /**
-     * @param mixed  $level
      * @param string $message
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->log = [$level, $message, $context];
     }


### PR DESCRIPTION
BC break: `void` is newly returned as per the PSR logging interface