### PR TITLE
Improve Factory::mergeSeeds() return type

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -126,7 +126,7 @@ Return object if it exits in collection and false otherwise
 Same as _hasInCollection but throws exception if element is not found
 :::
 
-:::{php:method} _shortenMl($string $ownerName, string $itemShortName)
+:::{php:method} _shortenMl(string $ownerName, string $collectionName, string $itemShortName)
 Implements name shortening
 :::
 
@@ -240,7 +240,7 @@ or the object itself. This will be called if {php:meth}`TrackableTrait::destroy`
 is called.
 :::
 
-:::{php:method} _shorten($string $ownerName, string $itemShortName)
+:::{php:method} _shorten(string $ownerName, string $itemShortName)
 Given the long owner name and short child name, this method will attempt to shorten the length
 of your children. The reason for shortening a name is to impose reasonable
 limits on overly long names. Name can be used as key in the GET argument

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -465,7 +465,7 @@ Specify Form Field
 
 ### addField, addButton, etc
 
-Model::addField, Form::addButton, FormLayout::addHeader imply that the class of
+Model::addField, Form::addButton, Form\Layout::addHeader imply that the class of
 an added object is known so the argument you specify to those methods ends up
 being a factory's $default:
 

--- a/docs/hook.md
+++ b/docs/hook.md
@@ -15,7 +15,7 @@ want to have application-wide hook then use `app` property.
 ## Hook Spots
 
 Hook is described by a string identifier which we call hook-spot, which would
-normally be expressing desired action with prefixes "before" or "after if
+normally be expressing desired action with prefixes "before" or "after" if
 necessary.
 
 Some good examples for hook spots are:

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -58,7 +58,7 @@ trait CollectionTrait
             $item->shortName = $name;
             $item->setOwner($this);
             if (TraitUtil::hasTrackableTrait($this) && TraitUtil::hasNameTrait($this) && TraitUtil::hasNameTrait($item)) {
-                $item->name = $this->_shortenMl(($this->name ?? '') . '-' . $collection, $item->shortName, $item->name ?? null); // @phpstan-ignore-line
+                $item->name = $this->_shortenMl($this->name ?? '', $collection, $item->shortName, $item->name ?? null); // @phpstan-ignore-line
             }
         }
 
@@ -137,8 +137,10 @@ trait CollectionTrait
      *
      * Identical implementation to ContainerTrait::_shorten.
      */
-    protected function _shortenMl(string $ownerName, string $itemShortName, ?string $origItemName): string
+    protected function _shortenMl(string $ownerName, string $collectionName, string $itemShortName, ?string $origItemName): string
     {
+        $ownerName .= '-' . $collectionName;
+
         if (TraitUtil::hasContainerTrait($this)) {
             return $this->_shorten($ownerName, $itemShortName, $origItemName); // @phpstan-ignore-line
         }

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -139,6 +139,10 @@ trait CollectionTrait
      */
     protected function _shortenMl(string $ownerName, string $itemShortName, ?string $origItemName): string
     {
+        if (TraitUtil::hasContainerTrait($this)) {
+            return $this->_shorten($ownerName, $itemShortName, $origItemName);;
+        }
+
         // ugly hack to deduplicate code
         $collectionTraitHelper = new class() {
             use AppScopeTrait;

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -140,7 +140,7 @@ trait CollectionTrait
     protected function _shortenMl(string $ownerName, string $itemShortName, ?string $origItemName): string
     {
         if (TraitUtil::hasContainerTrait($this)) {
-            return $this->_shorten($ownerName, $itemShortName, $origItemName);;
+            return $this->_shorten($ownerName, $itemShortName, $origItemName); // @phpstan-ignore-line
         }
 
         // ugly hack to deduplicate code

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -125,7 +125,7 @@ abstract class RendererAbstract
                 ? ' (' . (get_object_vars($val)['name'] ?? ($val->shortName ?? '')) . ')'
                 : '');
         } elseif (is_resource($val)) {
-            return 'resource (' . get_resource_type($val) . ')';
+            return get_debug_type($val);
         } elseif (is_scalar($val) || $val === null) {
             $out = json_encode($val, \JSON_UNESCAPED_SLASHES | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
             $out = preg_replace('~\\\\"~', '"', preg_replace('~^"|"$~s', '\'', $out)); // use single quotes

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -124,7 +124,7 @@ abstract class RendererAbstract
             return get_class($val) . (TraitUtil::hasTrackableTrait($val)
                 ? ' (' . (get_object_vars($val)['name'] ?? ($val->shortName ?? '')) . ')'
                 : '');
-        } elseif (is_resource($val)) {
+        } elseif (str_replace(' (closed)', '', gettype($val)) === 'resource') {
             return get_debug_type($val);
         } elseif (is_scalar($val) || $val === null) {
             $out = json_encode($val, \JSON_UNESCAPED_SLASHES | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,7 +27,7 @@ class Factory
     /**
      * @param array<mixed>|object|null ...$seeds
      *
-     * @return array<mixed>|object
+     * @return ($args is object ? object : array<mixed>)
      */
     protected function _mergeSeeds(...$seeds)
     {
@@ -173,7 +173,7 @@ class Factory
      *
      * @param array<mixed>|object|null ...$seeds
      *
-     * @return object|array<mixed> if at least one seed is an object, will return object
+     * @return ($args is object ? object : array<mixed>) if at least one seed is an object, will return object
      */
     final public static function mergeSeeds(...$seeds)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,7 +27,7 @@ class Factory
     /**
      * @param array<mixed>|object|null ...$seeds
      *
-     * @return ($args is object ? object : array<mixed>)
+     * @return ($seeds is object ? object : array<mixed>)
      */
     protected function _mergeSeeds(...$seeds)
     {
@@ -173,7 +173,7 @@ class Factory
      *
      * @param array<mixed>|object|null ...$seeds
      *
-     * @return ($args is object ? object : array<mixed>) if one seed is an object, that object is returned
+     * @return ($seeds is object ? object : array<mixed>) if one seed is an object, that object is returned
      */
     final public static function mergeSeeds(...$seeds)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -173,7 +173,7 @@ class Factory
      *
      * @param array<mixed>|object|null ...$seeds
      *
-     * @return ($args is object ? object : array<mixed>) if at least one seed is an object, will return object
+     * @return ($args is object ? object : array<mixed>) if one seed is an object, that object is returned
      */
     final public static function mergeSeeds(...$seeds)
     {

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -93,7 +93,7 @@ trait HookTrait
                         // TODO we throw only if the class name is the same, otherwise the check is too strict
                         // and on a bad side - we should not throw when an object with a hook is cloned,
                         // but instead we should throw once the closure this object is cloned
-                        // example of legit use: https://github.com/atk4/audit/blob/eb9810e085a40caedb435044d7318f4d8dd93e11/src/Controller.php#L85
+                        // example of legit use: https://github.com/atk4/audit/blob/eb9810e085/src/Controller.php#L85
                         if (get_class($fxThis) === static::class || preg_match('~^Atk4\\\\(?:Core|Data)~', get_class($fxThis))) {
                             throw (new Exception('Object cannot be cloned with hook bound to a different object than this'))
                                 ->addMoreInfo('closure_file', $fxRefl->getFileName())

--- a/src/Phpunit/TestCase.php
+++ b/src/Phpunit/TestCase.php
@@ -112,7 +112,7 @@ abstract class TestCase extends BaseTestCase
         }
 
         // once PHP 8.0 support is dropped, needed only once, see:
-        // https://github.com/php/php-src/commit/b58d74547f7700526b2d7e632032ed808abab442
+        // https://github.com/php/php-src/commit/b58d74547f
         if (\PHP_VERSION_ID < 80100) {
             gc_collect_cycles();
         }
@@ -170,7 +170,7 @@ abstract class TestCase extends BaseTestCase
         $this->releaseObjectsFromExceptionTrace($e);
 
         // once PHP 8.0 support is dropped, needed only once, see:
-        // https://github.com/php/php-src/commit/b58d74547f7700526b2d7e632032ed808abab442
+        // https://github.com/php/php-src/commit/b58d74547f
         if (\PHP_VERSION_ID < 80100) {
             gc_collect_cycles();
         }

--- a/tests/CollectionTraitTest.php
+++ b/tests/CollectionTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Core\Tests;
 
 use Atk4\Core\AppScopeTrait;
+use Atk4\Core\ContainerTrait;
 use Atk4\Core\Exception;
 use Atk4\Core\InitializerTrait;
 use Atk4\Core\NameTrait;
@@ -53,6 +54,25 @@ class CollectionTraitTest extends TestCase
 
         $longField = $m->addField('very-long-and-annoying-name-which-will-be-shortened', [FieldMockCustom::class]);
         self::assertSame(40, strlen($longField->name));
+
+        $mWithContainerTrait = new class() extends CollectionMockWithApp {
+            use ContainerTrait {
+                _shorten as private __shorten;
+            }
+
+            protected function _shorten(string $ownerName, string $itemShortName, ?string $origItemName): string
+            {
+                return $this->__shorten($ownerName, 'X' . $itemShortName, $origItemName);
+            }
+        };
+        $mWithContainerTrait->setApp($m->getApp());
+        $mWithContainerTrait->name = 'form';
+
+        /** @var FieldMockCustom $surnameField2 */
+        $surnameField2 = $mWithContainerTrait->addField('surname', [FieldMockCustom::class]);
+
+        self::assertSame('form-fields_Xsurname', $surnameField2->name);
+        self::assertSame($mWithContainerTrait, $surnameField2->getOwner());
     }
 
     public function testCloneCollection(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -58,7 +58,10 @@ class ExceptionTest extends TestCase
 
         self::assertSame(\Closure::class, RendererAbstract::toSafeString(static fn () => true));
 
-        self::assertSame('resource (stream)', RendererAbstract::toSafeString(opendir(__DIR__)));
+        $resource = opendir(__DIR__);
+        self::assertSame('resource (stream)', RendererAbstract::toSafeString($resource));
+        closedir($resource);
+        self::assertSame('resource (closed)', RendererAbstract::toSafeString($resource));
 
         $a = new TrackableMock();
         $a->shortName = 'foo';


### PR DESCRIPTION
related PHPStan issue: https://github.com/phpstan/phpstan/issues/10529

this PR is helpful to return `array` from `Factory::mergeSeeds()` only if not object is passed