### PR TITLE
Fix nullable parameter type for PHP 8.4

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -52,9 +52,6 @@ return (new Config())
         'general_phpdoc_annotation_remove' => [
             'annotations' => ['author', 'copyright', 'throws'],
         ],
-        'nullable_type_declaration_for_default_null_value' => [
-            'use_nullable_type_declaration' => false,
-        ],
 
         // fn => without curly brackets is less readable,
         // also prevent bounding of unwanted variables for GC

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -28,10 +28,10 @@ class Exception extends \Exception implements SelfDescribing
     /** @var list<string> */
     private $solutions = [];
 
-    /** @var ITranslatorAdapter */
+    /** @var ITranslatorAdapter|null */
     private $translator;
 
-    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 
@@ -162,7 +162,7 @@ class Exception extends \Exception implements SelfDescribing
      *
      * @return $this
      */
-    public function setTranslatorAdapter(ITranslatorAdapter $translator = null): self
+    public function setTranslatorAdapter(?ITranslatorAdapter $translator = null): self
     {
         $this->translator = $translator;
 

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -69,7 +69,8 @@ class Console extends RendererAbstract
         $this->output .= <<<'EOF'
 
             \e[1;41m--[ Stack Trace ]\e[0m
-            EOF . "\n";
+
+            EOF;
 
         $this->processStackTraceInternal();
     }
@@ -79,7 +80,8 @@ class Console extends RendererAbstract
     {
         $text = <<<'EOF'
             \e[0m{FILE}\e[0m:\e[0;31m{LINE}\e[0m {OBJECT} {CLASS}{FUNCTION_COLOR}{FUNCTION}{FUNCTION_ARGS}
-            EOF . "\n";
+
+            EOF;
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);

--- a/src/ExceptionRenderer/RendererAbstract.php
+++ b/src/ExceptionRenderer/RendererAbstract.php
@@ -26,7 +26,7 @@ abstract class RendererAbstract
 
     public ?ITranslatorAdapter $adapter;
 
-    public function __construct(\Throwable $exception, ITranslatorAdapter $adapter = null, \Throwable $parentException = null)
+    public function __construct(\Throwable $exception, ?ITranslatorAdapter $adapter = null, ?\Throwable $parentException = null)
     {
         $this->exception = $exception;
         $this->parentException = $parentException;
@@ -226,7 +226,7 @@ abstract class RendererAbstract
     /**
      * @param array<string, mixed> $parameters
      */
-    public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string
+    public function _(string $message, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return $this->adapter
             ? $this->adapter->_($message, $parameters, $domain, $locale)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -123,12 +123,8 @@ class Factory
      * @param array<mixed>|object $seed
      * @param array<mixed>        $defaults
      */
-    protected function _factory($seed, array $defaults = null): object
+    protected function _factory($seed, array $defaults): object
     {
-        if ($defaults === null) { // should be deprecated soon (with [] default value)
-            $defaults = [];
-        }
-
         if (!is_array($seed) && !is_object($seed)) { // @phpstan-ignore-line
             throw new Exception('Use of non-array (' . gettype($seed) . ') seed is not supported');
         }
@@ -193,10 +189,14 @@ class Factory
      * @param array<mixed>|object $seed
      * @param array<mixed>        $defaults
      */
-    final public static function factory($seed, $defaults = []): object
+    final public static function factory($seed, ?array $defaults = []): object
     {
         if ('func_num_args'() > 2) { // prevent bad usage
             throw new \Error('Too many method arguments');
+        }
+
+        if ($defaults === null) { // should be deprecated soon
+            $defaults = [];
         }
 
         return self::getInstance()->_factory($seed, $defaults);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -189,13 +189,13 @@ class Factory
      * @param array<mixed>|object $seed
      * @param array<mixed>        $defaults
      */
-    final public static function factory($seed, ?array $defaults = []): object
+    final public static function factory($seed, $defaults = []): object
     {
         if ('func_num_args'() > 2) { // prevent bad usage
             throw new \Error('Too many method arguments');
         }
 
-        if ($defaults === null) { // should be deprecated soon
+        if ($defaults === null) { // @phpstan-ignore-line should be deprecated soon
             $defaults = [];
         }
 

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -228,7 +228,7 @@ trait HookTrait
      * @param ($priorityIsIndex is true ? int : int|null) $priority        filter specific priority, null for all
      * @param bool                                        $priorityIsIndex filter by index instead of priority
      */
-    public function hookHasCallbacks(string $spot, int $priority = null, bool $priorityIsIndex = false): bool
+    public function hookHasCallbacks(string $spot, ?int $priority = null, bool $priorityIsIndex = false): bool
     {
         if (!isset($this->hooks[$spot])) {
             return false;
@@ -260,7 +260,7 @@ trait HookTrait
      *
      * @return static
      */
-    public function removeHook(string $spot, int $priority = null, bool $priorityIsIndex = false)
+    public function removeHook(string $spot, ?int $priority = null, bool $priorityIsIndex = false)
     {
         if ($priority !== null) {
             if ($priorityIsIndex) {
@@ -293,9 +293,11 @@ trait HookTrait
      *
      * @param array<int, mixed> $args
      *
+     * @param-out HookBreaker|null $brokenBy
+     *
      * @return array<int, mixed>|mixed Array of responses indexed by hook indexes or value specified to breakHook
      */
-    public function hook(string $spot, array $args = [], HookBreaker &$brokenBy = null)
+    public function hook(string $spot, array $args = [], &$brokenBy = null)
     {
         $brokenBy = null;
 

--- a/src/HookTrait.php
+++ b/src/HookTrait.php
@@ -292,6 +292,7 @@ trait HookTrait
      * Execute all closures assigned to $spot.
      *
      * @param array<int, mixed> $args
+     * @param mixed             $brokenBy
      *
      * @param-out HookBreaker|null $brokenBy
      *

--- a/src/TranslatableTrait.php
+++ b/src/TranslatableTrait.php
@@ -21,7 +21,7 @@ trait TranslatableTrait
      *
      * @return string The translated string
      */
-    public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string
+    public function _(string $message, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         if (TraitUtil::hasAppScopeTrait($this) && $this->issetApp() && method_exists($this->getApp(), '_')) {
             return $this->getApp()->_($message, $parameters, $domain, $locale);

--- a/src/Translator/Adapter/Generic.php
+++ b/src/Translator/Adapter/Generic.php
@@ -19,7 +19,7 @@ class Generic implements ITranslatorAdapter
     protected array $definitions = [];
 
     #[\Override]
-    public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string
+    public function _(string $message, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         $definition = $this->getDefinition($message, $domain ?? 'atk', $locale ?? 'en');
 

--- a/src/Translator/ITranslatorAdapter.php
+++ b/src/Translator/ITranslatorAdapter.php
@@ -16,5 +16,5 @@ interface ITranslatorAdapter
      *
      * @return string The translated string
      */
-    public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string;
+    public function _(string $message, array $parameters = [], ?string $domain = null, ?string $locale = null): string;
 }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -87,7 +87,7 @@ class Translator
      *
      * @return string The translated string
      */
-    public function _(string $message, array $parameters = [], string $domain = null, string $locale = null): string
+    public function _(string $message, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return $this->getAdapter()->_($message, $parameters, $domain ?? $this->defaultDomain, $locale ?? $this->defaultLocale);
     }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -148,7 +148,8 @@ class ExceptionTest extends TestCase
                           ...
                         ]
                     ]
-                EOF . "\n", // NL in the string is not parsed by Netbeans, see https://github.com/apache/netbeans/issues/4345
+
+                EOF,
             $m->toString()
         );
     }

--- a/tests/HookTraitTest.php
+++ b/tests/HookTraitTest.php
@@ -164,8 +164,8 @@ class HookTraitTest extends TestCase
     {
         $obj = new HookMock();
 
-        $incFx = static function ($obj, &$a) {
-            ++$a;
+        $incFx = static function ($obj, int &$value) {
+            ++$value;
         };
 
         $obj->onHook('inc', $incFx);

--- a/tests/QuietObjectWrapperTest.php
+++ b/tests/QuietObjectWrapperTest.php
@@ -41,7 +41,8 @@ class QuietObjectWrapperTest extends TestCase
             (
                 [wrappedClass] => stdClass
             )
-            EOF . "\n", print_r($o, true));
+
+            EOF, print_r($o, true));
 
         $o = new QuietObjectWrapper(new class() {
             /**
@@ -59,6 +60,7 @@ class QuietObjectWrapperTest extends TestCase
                 [foo] => 1
                 [Bar] => 2
             )
-            EOF . "\n", print_r($o, true));
+
+            EOF, print_r($o, true));
     }
 }


### PR DESCRIPTION
related with https://wiki.php.net/rfc/deprecate-implicitly-nullable-types