### PR TITLE
Fix console exception renderer

### DIFF
--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -130,25 +130,27 @@ class Console extends RendererAbstract
                 $inAtk = false;
             }
 
+            $functionColor = $escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW;
+
             $tokens = [
                 '{FILE}' => str_pad(mb_substr($call['file_rel'], -40), 40, ' ', \STR_PAD_LEFT),
                 '{LINE}' => str_pad($call['line'], 4, ' ', \STR_PAD_LEFT),
                 '{OBJECT}' => $call['object'] !== null ? ' - ' . $this->text($call['object_formatted'], [self::COLOR_GREEN]) : '',
                 '{CLASS}' => $call['class'] !== null ? $this->text($call['class_formatted'] . '::', [self::COLOR_GREEN]) : '',
-                '{FUNCTION}' => $call['function'] !== null ? $this->text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
+                '{FUNCTION}' => $call['function'] !== null ? $this->text($call['function'], [$functionColor]) : '',
             ];
 
             if ($index === 'self') {
                 $tokens['{FUNCTION_ARGS}'] = '';
             } elseif (count($call['args']) === 0) {
-                $tokens['{FUNCTION_ARGS}'] = '()';
+                $tokens['{FUNCTION_ARGS}'] = $this->text('()', [$functionColor]);
             } else {
                 if ($escapeFrame) {
                     $tokens['{FUNCTION_ARGS}'] = $this->text('(' . "\n" . str_repeat(' ', 40) . implode(',' . "\n" . str_repeat(' ', 40), array_map(static function ($arg) {
                         return static::toSafeString($arg);
                     }, $call['args'])) . ')', [self::COLOR_RED]);
                 } else {
-                    $tokens['{FUNCTION_ARGS}'] = '(...)';
+                    $tokens['{FUNCTION_ARGS}'] = $this->text('(...)', [$functionColor]);
                 }
             }
 

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -32,12 +32,13 @@ class Console extends RendererAbstract
             '{CODE}' => $this->exception->getCode() ? ' [code: ' . $this->exception->getCode() . ']' : '',
         ];
 
-        $this->output .= $this->replaceTokens("\n".
-            self::text('--[ {TITLE} ]', [self::BOLD, self::BG_COLOR_RED]) . "\n".
+        $this->output .= $this->replaceTokens("\n" .
+            self::text('--[ {TITLE} ]', [self::BOLD, self::BG_COLOR_RED]) . "\n" .
             self::text('{CLASS}: ') .
                 self::text('{MESSAGE}', [self::BOLD, self::COLOR_BLACK]) .
-                self::text(' {CODE}', [self::COLOR_RED]) . "\n"
-            , $tokens);
+                self::text(' {CODE}', [self::COLOR_RED]) . "\n",
+            $tokens
+        );
     }
 
     #[\Override]

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -29,6 +29,7 @@ class Console extends RendererAbstract
         return implode('', $formats) . $text . self::RESET;
     }
 
+    #[\Override]
     protected function processAll(): void
     {
         $this->output .= self::RESET;

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -32,7 +32,8 @@ class Console extends RendererAbstract
             '{CODE}' => $this->exception->getCode() ? ' [code: ' . $this->exception->getCode() . ']' : '',
         ];
 
-        $this->output .= $this->replaceTokens("\n" .
+        $this->output .= $this->replaceTokens(
+            "\n" .
             self::text('--[ {TITLE} ]', [self::BOLD, self::BG_COLOR_RED]) . "\n" .
             self::text('{CLASS}: ') .
                 self::text('{MESSAGE}', [self::BOLD, self::COLOR_BLACK]) .

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -35,7 +35,7 @@ class Console extends RendererAbstract
         $this->output .= $this->replaceTokens(
             "\n" .
             self::text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
-            self::text('{CLASS}: ') .
+            self::text('{CLASS}: ', [self::FORMAT_RESET]) .
                 self::text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
                 self::text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
@@ -144,15 +144,15 @@ class Console extends RendererAbstract
 
         $this->output .= "\n" .
             self::text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
-            self::text((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
+            self::text((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception)), [self::FORMAT_RESET]) .
             self::text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
     /**
      * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BG_COLOR_*> $formats
      */
-    private static function text(string $text, array $formats = []): string
+    private static function text(string $text, array $formats): string
     {
-        return implode('', $formats) . $text . (count($formats) === 0 ? '' : self::FORMAT_RESET);
+        return implode('', $formats) . $text . self::FORMAT_RESET;
     }
 }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -34,7 +34,7 @@ class Console extends RendererAbstract
 
         $this->output .= $this->replaceTokens(
             $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
-            . '{CLASS}: '
+                . '{CLASS}: '
                 . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK])
                 . $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
@@ -88,9 +88,9 @@ class Console extends RendererAbstract
     protected function processStackTraceInternal(): void
     {
         $text = '{FILE}:'
-                . $this->text('{LINE}', [self::COLOR_RED]) . ' '
-                . '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}'
-                . "\n";
+            . $this->text('{LINE}', [self::COLOR_RED]) . ' '
+            . '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}'
+            . "\n";
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -21,7 +21,7 @@ class Console extends RendererAbstract
             '{CODE}' => $this->exception->getCode() ? ' [code: ' . $this->exception->getCode() . ']' : '',
         ];
 
-        $this->output .= $this->replaceTokens(<<<'EOF'
+        $this->output .= $this->replaceTokens(<<<EOF
             \e[1;41m--[ {TITLE} ]\e[0m
             {CLASS}: \e[1;30m{MESSAGE}\e[0;31m {CODE}
             EOF, $tokens);
@@ -66,7 +66,7 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= <<<'EOF'
+        $this->output .= <<<EOF
 
             \e[1;41m--[ Stack Trace ]\e[0m
 
@@ -78,8 +78,8 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = <<<'EOF'
-            \e[0m{FILE}\e[0m:\e[0;31m{LINE}\e[0m {OBJECT} {CLASS}{FUNCTION_COLOR}{FUNCTION}{FUNCTION_ARGS}
+        $text = <<<EOF
+            \e[0m{FILE}\e[0m:\e[0;31m{LINE}\e[0m {OBJECT} {CLASS}{FUNCTION_COLOR}{FUNCTION}{FUNCTION_ARGS}\e[0m
 
             EOF;
 
@@ -137,7 +137,7 @@ class Console extends RendererAbstract
         $this->output .= \PHP_EOL . "\e[1;45mCaused by Previous Exception:\e[0m" . \PHP_EOL;
 
         $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
-        $this->output .= <<<'EOF'
+        $this->output .= <<<EOF
             \e[1;31m--
             \e[0m
             EOF;

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -33,8 +33,7 @@ class Console extends RendererAbstract
         ];
 
         $this->output .= $this->replaceTokens(
-            "\n"
-            . $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
+            $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
             . '{CLASS}: '
                 . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK])
                 . $this->text(' {CODE}', [self::COLOR_RED]) . "\n",

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -19,6 +19,13 @@ class Console extends RendererAbstract
     private const COLOR_BRIGHT_RED = "\e[91m";
     private const COLOR_BRIGHT_GREEN = "\e[92m";
 
+    protected function processAll(): void
+    {
+        $this->output .= self::RESET;
+
+        parent::processAll();
+    }
+
     #[\Override]
     protected function processHeader(): void
     {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -8,7 +8,7 @@ use Atk4\Core\Exception;
 
 class Console extends RendererAbstract
 {
-    private const FORMAT_RESET = "\e[0m";
+    private const RESET = "\e[0m";
     private const FORMAT_BOLD = "\e[1m";
     private const COLOR_BLACK = "\e[30m";
     private const COLOR_RED = "\e[31m";
@@ -35,7 +35,7 @@ class Console extends RendererAbstract
         $this->output .= $this->replaceTokens(
             "\n" .
             self::text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
-            self::text('{CLASS}: ', [self::FORMAT_RESET]) .
+            '{CLASS}: ' .
                 self::text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
                 self::text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
@@ -88,9 +88,9 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = self::text('{FILE}:', [self::FORMAT_RESET]) .
+        $text = '{FILE}:' .
                 self::text('{LINE}', [self::COLOR_RED]) . ' ' .
-                self::text('{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}', [self::FORMAT_RESET]) .
+                '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}' .
                 "\n";
 
         $inAtk = true;
@@ -144,7 +144,7 @@ class Console extends RendererAbstract
 
         $this->output .= "\n" .
             self::text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
-            self::text((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception)), [self::FORMAT_RESET]) .
+            ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
             self::text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
@@ -153,6 +153,6 @@ class Console extends RendererAbstract
      */
     private static function text(string $text, array $formats): string
     {
-        return implode('', $formats) . $text . self::FORMAT_RESET;
+        return implode('', $formats) . $text . self::RESET;
     }
 }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -150,6 +150,8 @@ class Console extends RendererAbstract
 
     /**
      * Style text with ASCII colors.
+     *
+     * @param array<int,string> $styles
      */
     private static function text(string $text, array $styles = []): string
     {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -9,7 +9,7 @@ use Atk4\Core\Exception;
 class Console extends RendererAbstract
 {
     private const RESET = "\e[0m";
-    private const BOLD = "\e[1m";
+    private const FORMAT_BOLD = "\e[1m";
     private const COLOR_BLACK = "\e[30m";
     private const COLOR_RED = "\e[31m";
     private const COLOR_GREEN = "\e[32m";
@@ -149,9 +149,7 @@ class Console extends RendererAbstract
     }
 
     /**
-     * Style text with ASCII colors.
-     *
-     * @param array<int,string> $styles
+     * @param non-empty-list<self::RESET|self::FORMAT_*|self::COLOR_*|BG_COLOR_*> $styles
      */
     private static function text(string $text, array $styles = []): string
     {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -62,7 +62,7 @@ class Console extends RendererAbstract
             $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
                 . '{CLASS}: '
                 . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) . ' '
-                . $this->text('{CODE}', [self::COLOR_RED]) . "\n",
+                . $this->text('{CODE}', [self::COLOR_RED]),
             $tokens
         );
     }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -35,8 +35,8 @@ class Console extends RendererAbstract
         $this->output .= $this->replaceTokens(
             $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
                 . '{CLASS}: '
-                . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK])
-                . $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
+                . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) . ' '
+                . $this->text('{CODE}', [self::COLOR_RED]) . "\n",
             $tokens
         );
     }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -135,7 +135,7 @@ class Console extends RendererAbstract
                 '{LINE}' => str_pad($call['line'], 4, ' ', \STR_PAD_LEFT),
                 '{OBJECT}' => $call['object'] !== null ? ' - ' . $this->text($call['object_formatted'], [self::COLOR_GREEN]) : '',
                 '{CLASS}' => $call['class'] !== null ? $this->text($call['class_formatted'] . '::', [self::COLOR_GREEN]) : '',
-                '{FUNCTION}' => $call['class'] !== null ? $this->text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
+                '{FUNCTION}' => $call['function'] !== null ? $this->text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
             ];
 
             if ($index === 'self') {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -33,11 +33,11 @@ class Console extends RendererAbstract
         ];
 
         $this->output .= $this->replaceTokens(
-            "\n" .
-            $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
-            '{CLASS}: ' .
-                $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
-                $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
+            "\n"
+            . $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n"
+            . '{CLASS}: '
+                . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK])
+                . $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
         );
     }
@@ -88,10 +88,10 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = '{FILE}:' .
-                $this->text('{LINE}', [self::COLOR_RED]) . ' ' .
-                '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}' .
-                "\n";
+        $text = '{FILE}:'
+                . $this->text('{LINE}', [self::COLOR_RED]) . ' '
+                . '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}'
+                . "\n";
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);
@@ -142,10 +142,10 @@ class Console extends RendererAbstract
             return;
         }
 
-        $this->output .= "\n" .
-            $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
-            ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
-            $this->text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
+        $this->output .= "\n"
+            . $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n"
+            . ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception)))
+            . $this->text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
     /**

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -14,8 +14,8 @@ class Console extends RendererAbstract
     private const COLOR_RED = "\e[31m";
     private const COLOR_GREEN = "\e[32m";
     private const COLOR_YELLOW = "\e[33m";
-    private const BG_COLOR_RED = "\e[41m";
-    private const BG_COLOR_MAGENTA = "\e[45m";
+    private const BACKGROUND_COLOR_RED = "\e[41m";
+    private const BACKGROUND_COLOR_MAGENTA = "\e[45m";
     private const COLOR_BRIGHT_RED = "\e[91m";
     private const COLOR_BRIGHT_GREEN = "\e[92m";
 
@@ -34,7 +34,7 @@ class Console extends RendererAbstract
 
         $this->output .= $this->replaceTokens(
             "\n"
-            . $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n"
+            . $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n"
             . '{CLASS}: '
                 . $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK])
                 . $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
@@ -81,7 +81,7 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= "\n" . $this->text('--[ Stack Trace ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n";
+        $this->output .= "\n" . $this->text('--[ Stack Trace ]', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_RED]) . "\n";
         $this->processStackTraceInternal();
     }
 
@@ -143,13 +143,13 @@ class Console extends RendererAbstract
         }
 
         $this->output .= "\n"
-            . $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n"
+            . $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_MAGENTA]) . "\n"
             . ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception)))
             . $this->text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
     /**
-     * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BG_COLOR_*> $formats
+     * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BACKGROUND_COLOR_*> $formats
      */
     private function text(string $text, array $formats): string
     {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -19,6 +19,25 @@ class Console extends RendererAbstract
     private const COLOR_BRIGHT_RED = "\e[91m";
     private const COLOR_BRIGHT_GREEN = "\e[92m";
 
+    /**
+     * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BACKGROUND_COLOR_*> $formats
+     */
+    private function text(string $text, array $formats): string
+    {
+        return implode('', $formats) . $text . self::RESET;
+    }
+
+    private function untextEmpty(string $value): string
+    {
+        return preg_replace('~' . "\e" . '\[\d+m' . preg_quote(self::RESET) . '~', '', $value);
+    }
+
+    #[\Override]
+    protected function replaceTokens(string $text, array $tokens): string
+    {
+        return $this->untextEmpty(parent::replaceTokens($text, $tokens));
+    }
+
     protected function processAll(): void
     {
         $this->output .= self::RESET;
@@ -152,13 +171,5 @@ class Console extends RendererAbstract
             . $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BACKGROUND_COLOR_MAGENTA]) . "\n"
             . ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception)))
             . $this->text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
-    }
-
-    /**
-     * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BACKGROUND_COLOR_*> $formats
-     */
-    private function text(string $text, array $formats): string
-    {
-        return implode('', $formats) . $text . self::RESET;
     }
 }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -27,17 +27,6 @@ class Console extends RendererAbstract
         return implode('', $formats) . $text . self::RESET;
     }
 
-    private function untextEmpty(string $value): string
-    {
-        return preg_replace('~' . "\e" . '\[\d+m' . preg_quote(self::RESET) . '~', '', $value);
-    }
-
-    #[\Override]
-    protected function replaceTokens(string $text, array $tokens): string
-    {
-        return $this->untextEmpty(parent::replaceTokens($text, $tokens));
-    }
-
     protected function processAll(): void
     {
         $this->output .= self::RESET;

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -8,6 +8,17 @@ use Atk4\Core\Exception;
 
 class Console extends RendererAbstract
 {
+    private const RESET = "\e[0m";
+    private const BOLD = "\e[1m";
+    private const COLOR_BLACK = "\e[30m";
+    private const COLOR_RED = "\e[31m";
+    private const COLOR_GREEN = "\e[32m";
+    private const COLOR_YELLOW = "\e[33m";
+    private const BG_COLOR_RED = "\e[41m";
+    private const BG_COLOR_MAGENTA = "\e[45m";
+    private const COLOR_BRIGHT_RED = "\e[91m";
+    private const COLOR_BRIGHT_GREEN = "\e[92m";
+
     #[\Override]
     protected function processHeader(): void
     {
@@ -21,10 +32,12 @@ class Console extends RendererAbstract
             '{CODE}' => $this->exception->getCode() ? ' [code: ' . $this->exception->getCode() . ']' : '',
         ];
 
-        $this->output .= $this->replaceTokens(<<<EOF
-            \e[1;41m--[ {TITLE} ]\e[0m
-            {CLASS}: \e[1;30m{MESSAGE}\e[0;31m {CODE}
-            EOF, $tokens);
+        $this->output .= $this->replaceTokens("\n".
+            self::text('--[ {TITLE} ]', [self::BOLD, self::BG_COLOR_RED]) . "\n".
+            self::text('{CLASS}: ') .
+                self::text('{MESSAGE}', [self::BOLD, self::COLOR_BLACK]) .
+                self::text(' {CODE}', [self::COLOR_RED]) . "\n"
+            , $tokens);
     }
 
     #[\Override]
@@ -43,7 +56,7 @@ class Console extends RendererAbstract
 
         foreach ($exception->getParams() as $key => $val) {
             $key = str_pad($key, 19, ' ', \STR_PAD_LEFT);
-            $this->output .= \PHP_EOL . "\e[91m" . $key . ': ' . static::toSafeString($val) . "\e[0m";
+            $this->output .= "\n" . self::text($key . ': ' . static::toSafeString($val), [self::COLOR_BRIGHT_RED]);
         }
     }
 
@@ -59,29 +72,24 @@ class Console extends RendererAbstract
         }
 
         foreach ($this->exception->getSolutions() as $key => $val) {
-            $this->output .= \PHP_EOL . "\e[92mSolution: " . $val . "\e[0m";
+            $this->output .= "\n" . self::text('Solution: ' . $val, [self::COLOR_BRIGHT_GREEN]);
         }
     }
 
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= <<<EOF
-
-            \e[1;41m--[ Stack Trace ]\e[0m
-
-            EOF;
-
+        $this->output .= "\n" . self::text('--[ Stack Trace ]', [self::BOLD, self::BG_COLOR_RED]) . "\n";
         $this->processStackTraceInternal();
     }
 
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = <<<EOF
-            \e[0m{FILE}\e[0m:\e[0;31m{LINE}\e[0m {OBJECT} {CLASS}{FUNCTION_COLOR}{FUNCTION}{FUNCTION_ARGS}\e[0m
-
-            EOF;
+        $text = self::text('{FILE}:', [self::RESET]) .
+                self::text('{LINE}', [self::COLOR_RED]) . ' ' .
+                self::text('{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}', [self::RESET]) .
+                "\n";
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);
@@ -95,14 +103,13 @@ class Console extends RendererAbstract
                 $inAtk = false;
             }
 
-            $tokens = [];
-            $tokens['{FILE}'] = str_pad(mb_substr($call['file_rel'], -40), 40, ' ', \STR_PAD_LEFT);
-            $tokens['{LINE}'] = str_pad($call['line'], 4, ' ', \STR_PAD_LEFT);
-            $tokens['{OBJECT}'] = $call['object'] !== null ? " - \e[0;32m" . $call['object_formatted'] . "\e[0m" : '';
-            $tokens['{CLASS}'] = $call['class'] !== null ? "\e[0;32m" . $call['class_formatted'] . "::\e[0m" : '';
-
-            $tokens['{FUNCTION_COLOR}'] = $escapeFrame ? "\e[0;31m" : "\e[0;33m";
-            $tokens['{FUNCTION}'] = $call['function'];
+            $tokens = [
+                '{FILE}' => str_pad(mb_substr($call['file_rel'], -40), 40, ' ', \STR_PAD_LEFT),
+                '{LINE}' => str_pad($call['line'], 4, ' ', \STR_PAD_LEFT),
+                '{OBJECT}' => $call['object'] !== null ? ' - ' . self::text($call['object_formatted'], [self::COLOR_GREEN]) : '',
+                '{CLASS}' => $call['class'] !== null ? self::text($call['class_formatted'] . '::', [self::COLOR_GREEN]) : '',
+                '{FUNCTION}' => $call['class'] !== null ? self::text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
+            ];
 
             if ($index === 'self') {
                 $tokens['{FUNCTION_ARGS}'] = '';
@@ -110,9 +117,9 @@ class Console extends RendererAbstract
                 $tokens['{FUNCTION_ARGS}'] = '()';
             } else {
                 if ($escapeFrame) {
-                    $tokens['{FUNCTION_ARGS}'] = "\e[0;31m(" . \PHP_EOL . str_repeat(' ', 40) . implode(',' . \PHP_EOL . str_repeat(' ', 40), array_map(static function ($arg) {
+                    $tokens['{FUNCTION_ARGS}'] = self::text('(' . "\n" . str_repeat(' ', 40) . implode(',' . "\n" . str_repeat(' ', 40), array_map(static function ($arg) {
                         return static::toSafeString($arg);
-                    }, $call['args'])) . ')';
+                    }, $call['args'])) . ')', [self::COLOR_RED]);
                 } else {
                     $tokens['{FUNCTION_ARGS}'] = '(...)';
                 }
@@ -122,8 +129,7 @@ class Console extends RendererAbstract
         }
 
         if ($isShortened) {
-            $this->output .= '...
-            ';
+            $this->output .= '...' . "\n";
         }
     }
 
@@ -134,12 +140,17 @@ class Console extends RendererAbstract
             return;
         }
 
-        $this->output .= \PHP_EOL . "\e[1;45mCaused by Previous Exception:\e[0m" . \PHP_EOL;
+        $this->output .= "\n" .
+            self::text('Caused by Previous Exception:', [self::BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
+            self::text((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
+            self::text('--', [self::BOLD, self::COLOR_RED]);
+    }
 
-        $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
-        $this->output .= <<<EOF
-            \e[1;31m--
-            \e[0m
-            EOF;
+    /**
+     * Style text with ASCII colors.
+     */
+    private static function text(string $text, array $styles = []): string
+    {
+        return implode('', $styles) . $text . (count($styles) === 0 ? '' : self::RESET);
     }
 }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -8,7 +8,7 @@ use Atk4\Core\Exception;
 
 class Console extends RendererAbstract
 {
-    private const RESET = "\e[0m";
+    private const FORMAT_RESET = "\e[0m";
     private const FORMAT_BOLD = "\e[1m";
     private const COLOR_BLACK = "\e[30m";
     private const COLOR_RED = "\e[31m";
@@ -34,9 +34,9 @@ class Console extends RendererAbstract
 
         $this->output .= $this->replaceTokens(
             "\n" .
-            self::text('--[ {TITLE} ]', [self::BOLD, self::BG_COLOR_RED]) . "\n" .
+            self::text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
             self::text('{CLASS}: ') .
-                self::text('{MESSAGE}', [self::BOLD, self::COLOR_BLACK]) .
+                self::text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
                 self::text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
         );
@@ -81,16 +81,16 @@ class Console extends RendererAbstract
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= "\n" . self::text('--[ Stack Trace ]', [self::BOLD, self::BG_COLOR_RED]) . "\n";
+        $this->output .= "\n" . self::text('--[ Stack Trace ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n";
         $this->processStackTraceInternal();
     }
 
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = self::text('{FILE}:', [self::RESET]) .
+        $text = self::text('{FILE}:', [self::FORMAT_RESET]) .
                 self::text('{LINE}', [self::COLOR_RED]) . ' ' .
-                self::text('{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}', [self::RESET]) .
+                self::text('{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}', [self::FORMAT_RESET]) .
                 "\n";
 
         $inAtk = true;
@@ -143,16 +143,16 @@ class Console extends RendererAbstract
         }
 
         $this->output .= "\n" .
-            self::text('Caused by Previous Exception:', [self::BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
+            self::text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
             self::text((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
-            self::text('--', [self::BOLD, self::COLOR_RED]);
+            self::text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
     /**
-     * @param non-empty-list<self::RESET|self::FORMAT_*|self::COLOR_*|BG_COLOR_*> $styles
+     * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BG_COLOR_*> $formats
      */
-    private static function text(string $text, array $styles = []): string
+    private static function text(string $text, array $formats = []): string
     {
-        return implode('', $styles) . $text . (count($styles) === 0 ? '' : self::RESET);
+        return implode('', $formats) . $text . (count($formats) === 0 ? '' : self::FORMAT_RESET);
     }
 }

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -24,6 +24,8 @@ class Console extends RendererAbstract
      */
     private function text(string $text, array $formats): string
     {
+        assert(!str_contains($text, "\e["));
+
         return implode('', $formats) . $text . self::RESET;
     }
 
@@ -104,8 +106,7 @@ class Console extends RendererAbstract
     {
         $text = '{FILE}:'
             . $this->text('{LINE}', [self::COLOR_RED]) . ' '
-            . '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}'
-            . "\n";
+            . '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}';
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);
@@ -143,7 +144,7 @@ class Console extends RendererAbstract
                 }
             }
 
-            $this->output .= $this->replaceTokens($text, $tokens);
+            $this->output .= rtrim($this->replaceTokens($text, $tokens), ' ') . "\n";
         }
 
         if ($isShortened) {

--- a/src/ExceptionRenderer/Console.php
+++ b/src/ExceptionRenderer/Console.php
@@ -34,10 +34,10 @@ class Console extends RendererAbstract
 
         $this->output .= $this->replaceTokens(
             "\n" .
-            self::text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
+            $this->text('--[ {TITLE} ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n" .
             '{CLASS}: ' .
-                self::text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
-                self::text(' {CODE}', [self::COLOR_RED]) . "\n",
+                $this->text('{MESSAGE}', [self::FORMAT_BOLD, self::COLOR_BLACK]) .
+                $this->text(' {CODE}', [self::COLOR_RED]) . "\n",
             $tokens
         );
     }
@@ -58,7 +58,7 @@ class Console extends RendererAbstract
 
         foreach ($exception->getParams() as $key => $val) {
             $key = str_pad($key, 19, ' ', \STR_PAD_LEFT);
-            $this->output .= "\n" . self::text($key . ': ' . static::toSafeString($val), [self::COLOR_BRIGHT_RED]);
+            $this->output .= "\n" . $this->text($key . ': ' . static::toSafeString($val), [self::COLOR_BRIGHT_RED]);
         }
     }
 
@@ -74,14 +74,14 @@ class Console extends RendererAbstract
         }
 
         foreach ($this->exception->getSolutions() as $key => $val) {
-            $this->output .= "\n" . self::text('Solution: ' . $val, [self::COLOR_BRIGHT_GREEN]);
+            $this->output .= "\n" . $this->text('Solution: ' . $val, [self::COLOR_BRIGHT_GREEN]);
         }
     }
 
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= "\n" . self::text('--[ Stack Trace ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n";
+        $this->output .= "\n" . $this->text('--[ Stack Trace ]', [self::FORMAT_BOLD, self::BG_COLOR_RED]) . "\n";
         $this->processStackTraceInternal();
     }
 
@@ -89,7 +89,7 @@ class Console extends RendererAbstract
     protected function processStackTraceInternal(): void
     {
         $text = '{FILE}:' .
-                self::text('{LINE}', [self::COLOR_RED]) . ' ' .
+                $this->text('{LINE}', [self::COLOR_RED]) . ' ' .
                 '{OBJECT} {CLASS}{FUNCTION}{FUNCTION_ARGS}' .
                 "\n";
 
@@ -108,9 +108,9 @@ class Console extends RendererAbstract
             $tokens = [
                 '{FILE}' => str_pad(mb_substr($call['file_rel'], -40), 40, ' ', \STR_PAD_LEFT),
                 '{LINE}' => str_pad($call['line'], 4, ' ', \STR_PAD_LEFT),
-                '{OBJECT}' => $call['object'] !== null ? ' - ' . self::text($call['object_formatted'], [self::COLOR_GREEN]) : '',
-                '{CLASS}' => $call['class'] !== null ? self::text($call['class_formatted'] . '::', [self::COLOR_GREEN]) : '',
-                '{FUNCTION}' => $call['class'] !== null ? self::text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
+                '{OBJECT}' => $call['object'] !== null ? ' - ' . $this->text($call['object_formatted'], [self::COLOR_GREEN]) : '',
+                '{CLASS}' => $call['class'] !== null ? $this->text($call['class_formatted'] . '::', [self::COLOR_GREEN]) : '',
+                '{FUNCTION}' => $call['class'] !== null ? $this->text($call['function'], [$escapeFrame ? self::COLOR_RED : self::COLOR_YELLOW]) : '',
             ];
 
             if ($index === 'self') {
@@ -119,7 +119,7 @@ class Console extends RendererAbstract
                 $tokens['{FUNCTION_ARGS}'] = '()';
             } else {
                 if ($escapeFrame) {
-                    $tokens['{FUNCTION_ARGS}'] = self::text('(' . "\n" . str_repeat(' ', 40) . implode(',' . "\n" . str_repeat(' ', 40), array_map(static function ($arg) {
+                    $tokens['{FUNCTION_ARGS}'] = $this->text('(' . "\n" . str_repeat(' ', 40) . implode(',' . "\n" . str_repeat(' ', 40), array_map(static function ($arg) {
                         return static::toSafeString($arg);
                     }, $call['args'])) . ')', [self::COLOR_RED]);
                 } else {
@@ -143,15 +143,15 @@ class Console extends RendererAbstract
         }
 
         $this->output .= "\n" .
-            self::text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
+            $this->text('Caused by Previous Exception:', [self::FORMAT_BOLD, self::BG_COLOR_MAGENTA]) . "\n" .
             ((string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception))) .
-            self::text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
+            $this->text('--', [self::FORMAT_BOLD, self::COLOR_RED]);
     }
 
     /**
      * @param non-empty-list<self::FORMAT_*|self::COLOR_*|self::BG_COLOR_*> $formats
      */
-    private static function text(string $text, array $formats): string
+    private function text(string $text, array $formats): string
     {
         return implode('', $formats) . $text . self::RESET;
     }

--- a/src/ExceptionRenderer/Html.php
+++ b/src/ExceptionRenderer/Html.php
@@ -21,7 +21,7 @@ class Html extends RendererAbstract
             '{CODE}' => $this->exception->getCode() ? ' [code: ' . $this->exception->getCode() . ']' : '',
         ];
 
-        $this->output .= $this->replaceTokens('
+        $this->output .= $this->replaceTokens(<<<'EOF'
             <div class="ui negative icon message">
                 <i class="warning sign icon"></i>
                 <div class="content">
@@ -30,7 +30,8 @@ class Html extends RendererAbstract
                     {MESSAGE}
                 </div>
             </div>
-        ', $tokens);
+
+            EOF, $tokens);
     }
 
     protected function encodeHtml(string $value): string
@@ -49,19 +50,23 @@ class Html extends RendererAbstract
             return;
         }
 
-        $text = '
+        $text = <<<'EOF'
+
             <table class="ui very compact small selectable table top aligned">
                 <thead><tr><th colspan="2" class="ui inverted red table">Exception Parameters</th></tr></thead>
                 <tbody>{PARAMS}
                 </tbody>
             </table>
-        ';
+
+            EOF;
 
         $tokens = [
             '{PARAMS}' => '',
         ];
-        $textInner = '
-                    <tr><td><b>{KEY}</b></td><td style="width: 100%;">{VAL}</td></tr>';
+        $textInner = <<<'EOF'
+
+                    <tr><td><b>{KEY}</b></td><td style="width: 100%;">{VAL}</td></tr>
+            EOF;
         foreach ($this->exception->getParams() as $key => $val) {
             $key = $this->encodeHtml($key);
             $val = '<span style="white-space: pre-wrap;">' . preg_replace('~(?<=\n)( +)~', '$1$1', $this->encodeHtml(static::toSafeString($val, true))) . '</span>';
@@ -89,19 +94,23 @@ class Html extends RendererAbstract
             return;
         }
 
-        $text = '
+        $text = <<<'EOF'
+
             <table class="ui very compact small selectable table top aligned">
                 <thead><tr><th colspan="2" class="ui inverted green table">Suggested solutions</th></tr></thead>
                 <tbody>{SOLUTIONS}
                 </tbody>
             </table>
-        ';
+
+            EOF;
 
         $tokens = [
             '{SOLUTIONS}' => '',
         ];
-        $textInner = '
-                    <tr><td>{VAL}</td></tr>';
+        $textInner = <<<'EOF'
+
+                    <tr><td>{VAL}</td></tr>
+            EOF;
         foreach ($exception->getSolutions() as $key => $val) {
             $tokens['{SOLUTIONS}'] .= $this->replaceTokens($textInner, ['{VAL}' => $this->encodeHtml($val)]);
         }
@@ -112,32 +121,38 @@ class Html extends RendererAbstract
     #[\Override]
     protected function processStackTrace(): void
     {
-        $this->output .= '
+        $this->output .= <<<'EOF'
+
             <table class="ui very compact small selectable table top aligned">
                 <thead><tr><th colspan="4">Stack Trace</th></tr></thead>
                 <thead><tr><th style="text-align: right">#</th><th>File</th><th>Object</th><th>Method</th></tr></thead>
                 <tbody>
-        ';
+
+            EOF;
 
         $this->processStackTraceInternal();
 
-        $this->output .= '
+        $this->output .= <<<'EOF'
+
                 </tbody>
             </table>
-        ';
+
+            EOF;
     }
 
     #[\Override]
     protected function processStackTraceInternal(): void
     {
-        $text = '
+        $text = <<<'EOF'
+
             <tr class="{CSS_CLASS}">
                 <td style="text-align: right">{INDEX}</td>
                 <td>{FILE_LINE}</td>
                 <td>{OBJECT}</td>
                 <td>{FUNCTION}{FUNCTION_ARGS}</td>
             </tr>
-        ';
+
+            EOF;
 
         $inAtk = true;
         $shortTrace = $this->getStackTrace(true);
@@ -178,14 +193,16 @@ class Html extends RendererAbstract
         }
 
         if ($isShortened) {
-            $this->output .= '
+            $this->output .= <<<'EOF'
+
                 <tr>
                     <td style="text-align: right">...</td>
                     <td></td>
                     <td></td>
                     <td></td>
                 </tr>
-            ';
+
+                EOF;
         }
     }
 
@@ -196,11 +213,13 @@ class Html extends RendererAbstract
             return;
         }
 
-        $this->output .= '
+        $this->output .= <<<'EOF'
+
             <div class="ui top attached segment">
                 <div class="ui top attached label">Caused by Previous Exception:</div>
             </div>
-        ';
+
+            EOF;
 
         $this->output .= (string) (new static($this->exception->getPrevious(), $this->adapter, $this->exception));
     }

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -153,6 +153,6 @@ class Json extends RendererAbstract
             ];
         }
 
-        return (string) json_encode($this->json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+        return json_encode($this->json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
     }
 }

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -153,6 +153,6 @@ class Json extends RendererAbstract
             ];
         }
 
-        return (string) json_encode($this->json, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE);
+        return (string) json_encode($this->json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
     }
 }

--- a/src/ExceptionRenderer/Json.php
+++ b/src/ExceptionRenderer/Json.php
@@ -129,8 +129,12 @@ class Json extends RendererAbstract
     #[\Override]
     public function __toString(): string
     {
+        $toStringFx = fn () => json_encode($this->json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+
         try {
             $this->processAll();
+
+            return $toStringFx();
         } catch (\Throwable $e) {
             // fallback if error occur
             $this->json = [
@@ -153,6 +157,6 @@ class Json extends RendererAbstract
             ];
         }
 
-        return json_encode($this->json, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+        return $toStringFx();
     }
 }

--- a/tests/ExceptionRendererTest.php
+++ b/tests/ExceptionRendererTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Atk4\Core\Tests;
 
 use Atk4\Core\Exception;
+use Atk4\Core\ExceptionRenderer\RendererAbstract;
+use Atk4\Core\NameTrait;
 use Atk4\Core\Phpunit\TestCase;
+use Atk4\Core\TrackableTrait;
 
 class ExceptionRendererTest extends TestCase
 {
@@ -167,5 +170,84 @@ class ExceptionRendererTest extends TestCase
                                          /a/main.php:\e[31m  20\e[0m  \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest::\e[0m\e[33mmain\e[0m\e[33m()\e[0m
 
             EOF, $ex->getColorfulText());
+    }
+
+    public function testToSafeString(): void
+    {
+        self::assertSame('1', RendererAbstract::toSafeString(1));
+
+        self::assertSame('\'abc\'', RendererAbstract::toSafeString('abc'));
+
+        self::assertSame(\stdClass::class, RendererAbstract::toSafeString(new \stdClass()));
+
+        self::assertSame(\DateTime::class, RendererAbstract::toSafeString(new \DateTime()));
+
+        self::assertSame(\Closure::class, RendererAbstract::toSafeString(static fn () => true));
+
+        $resource = opendir(__DIR__);
+        self::assertSame('resource (stream)', RendererAbstract::toSafeString($resource));
+        closedir($resource);
+        self::assertSame('resource (closed)', RendererAbstract::toSafeString($resource));
+
+        $a = new TrackableMock();
+        $a->shortName = 'foo';
+        self::assertSame(TrackableMock::class . ' (foo)', RendererAbstract::toSafeString($a));
+
+        $a = new TrackableMock();
+        self::assertSame(TrackableMock::class . ' ()', RendererAbstract::toSafeString($a));
+
+        $a = new TrackableMock2();
+        $a->shortName = 'foo';
+        self::assertSame(TrackableMock2::class . ' (foo)', RendererAbstract::toSafeString($a));
+
+        $a = new TrackableMock2();
+        $a->name = 'foo';
+        self::assertSame(TrackableMock2::class . ' (foo)', RendererAbstract::toSafeString($a));
+    }
+
+    public function testExceptionFallback(): void
+    {
+        $ex = new ExceptionThrowError('test', 2);
+        $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
+            . ExceptionThrowError::class . '(2): test !!';
+        self::assertSame($expectedFallbackText, $ex->getHtml());
+        self::assertSame($expectedFallbackText, $ex->getColorfulText());
+        self::assertSame(
+            json_encode(
+                [
+                    'success' => false,
+                    'code' => 2,
+                    'message' => 'Error during json renderer: test',
+                    'title' => ExceptionThrowError::class,
+                    'class' => ExceptionThrowError::class,
+                    'params' => [],
+                    'solution' => [],
+                    'trace' => [],
+                    'previous' => [
+                        'title' => 'Exception',
+                        'class' => 'Exception',
+                        'code' => 0,
+                        'message' => 'just to cover __string',
+                    ],
+                ],
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE
+            ),
+            $ex->getJson()
+        );
+    }
+}
+
+class TrackableMock2
+{
+    use NameTrait;
+    use TrackableTrait;
+}
+
+class ExceptionThrowError extends Exception
+{
+    #[\Override]
+    public function getCustomExceptionTitle(): string
+    {
+        throw new \Exception('just to cover __string');
     }
 }

--- a/tests/ExceptionRendererTest.php
+++ b/tests/ExceptionRendererTest.php
@@ -35,6 +35,9 @@ class ExceptionRendererTest extends TestCase
     {
         $ex = $this->createExceptionWithConstantTrace();
 
+        self::assertStringStartsWith('<', $ex->getHtml());
+        self::assertStringEndsWith(">\n", $ex->getHtml());
+
         self::assertSame(<<<'EOF'
             <div class="ui negative icon message">
                 <i class="warning sign icon"></i>
@@ -95,6 +98,9 @@ class ExceptionRendererTest extends TestCase
     {
         $ex = $this->createExceptionWithConstantTrace();
 
+        self::assertStringStartsWith('{', $ex->getJson());
+        self::assertStringEndsWith('}', $ex->getJson());
+
         self::assertSame(<<<'EOF'
             {
                 "success": false,
@@ -146,6 +152,8 @@ class ExceptionRendererTest extends TestCase
     {
         $ex = $this->createExceptionWithConstantTrace();
 
+        self::assertStringStartsWith("\e[0m", $ex->getColorfulText());
+        self::assertStringEndsWith("\n", $ex->getColorfulText());
         self::assertStringNotContainsString('\e[', $ex->getColorfulText());
 
         self::assertSame(<<<"EOF"

--- a/tests/ExceptionRendererTest.php
+++ b/tests/ExceptionRendererTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atk4\Core\Tests;
+
+use Atk4\Core\Exception;
+use Atk4\Core\Phpunit\TestCase;
+
+class ExceptionRendererTest extends TestCase
+{
+    protected function createExceptionWithConstantTrace(): Exception
+    {
+        $ex = new Exception('My exception for <a> tag');
+        $ex->addMoreInfo('foo', 111);
+        $ex->addSolution('Use <b> tag');
+
+        foreach ([
+            'file' => '/a/ex.php',
+            'line' => 10,
+            'trace' => [
+                ['file' => '/a/text.php', 'line' => 12345, 'function' => 'formatValue', 'class' => self::class, 'object' => $this, 'type' => '->', 'args' => ['xxx']],
+                ['file' => '/a/main.php', 'line' => 20, 'function' => 'main', 'class' => self::class, 'type' => '::', 'args' => []],
+            ],
+        ] as $k => $v) {
+            $propRefl = new \ReflectionProperty(\Exception::class, $k);
+            $propRefl->setAccessible(true);
+            $propRefl->setValue($ex, $v);
+        }
+
+        return $ex;
+    }
+
+    public function testFormatHtml(): void
+    {
+        $ex = $this->createExceptionWithConstantTrace();
+
+        self::assertSame(<<<"EOF"
+            <div class="ui negative icon message">
+                <i class="warning sign icon"></i>
+                <div class="content">
+                    <div class="header">Critical Error</div>
+                    Atk4\Core\Exception:
+                    My exception for <a> tag
+                </div>
+            </div>
+
+            <table class="ui very compact small selectable table top aligned">
+                <thead><tr><th colspan="2" class="ui inverted red table">Exception Parameters</th></tr></thead>
+                <tbody>
+                    <tr><td><b>foo</b></td><td style="width: 100%;"><span style="white-space: pre-wrap;">111</span></td></tr>
+                </tbody>
+            </table>
+
+            <table class="ui very compact small selectable table top aligned">
+                <thead><tr><th colspan="2" class="ui inverted green table">Suggested solutions</th></tr></thead>
+                <tbody>
+                    <tr><td>Use &lt;b&gt; tag</td></tr>
+                </tbody>
+            </table>
+
+            <table class="ui very compact small selectable table top aligned">
+                <thead><tr><th colspan="4">Stack Trace</th></tr></thead>
+                <thead><tr><th style="text-align: right">#</th><th>File</th><th>Object</th><th>Method</th></tr></thead>
+                <tbody>
+
+            <tr class="negative">
+                <td style="text-align: right"></td>
+                <td>/a/ex.php:10</td>
+                <td></td>
+                <td></td>
+            </tr>
+
+            <tr class="">
+                <td style="text-align: right">2</td>
+                <td>/a/text.php:12345</td>
+                <td>Atk4\Core\Tests\ExceptionRendererTest</td>
+                <td>formatValue(...)</td>
+            </tr>
+
+            <tr class="">
+                <td style="text-align: right">1</td>
+                <td>/a/main.php:20</td>
+                <td></td>
+                <td>main()</td>
+            </tr>
+
+                </tbody>
+            </table>
+
+            EOF, $ex->getHtml());
+    }
+
+    public function testFormatJson(): void
+    {
+        $ex = $this->createExceptionWithConstantTrace();
+
+        self::assertSame(<<<'EOF'
+            {
+                "success": false,
+                "code": 0,
+                "message": "My exception for <a> tag",
+                "title": "Critical Error",
+                "class": "Atk4\\Core\\Exception",
+                "params": {
+                    "foo": "111"
+                },
+                "solution": [
+                    "Use <b> tag"
+                ],
+                "trace": [],
+                "previous": [],
+                "stack": [
+                    {
+                        "line": 10,
+                        "file": "/a/ex.php",
+                        "class": null,
+                        "object": null,
+                        "function": null,
+                        "args": []
+                    },
+                    {
+                        "line": 12345,
+                        "file": "/a/text.php",
+                        "class": "Atk4\\Core\\Tests\\ExceptionRendererTest",
+                        "object": "Atk4\\Core\\Tests\\ExceptionRendererTest",
+                        "function": "formatValue",
+                        "args": [
+                            "xxx"
+                        ]
+                    },
+                    {
+                        "line": 20,
+                        "file": "/a/main.php",
+                        "class": "Atk4\\Core\\Tests\\ExceptionRendererTest",
+                        "object": null,
+                        "function": "main",
+                        "args": []
+                    }
+                ]
+            }
+            EOF, $ex->getJson());
+    }
+
+    public function testFormatConsole(): void
+    {
+        $ex = $this->createExceptionWithConstantTrace();
+
+        self::assertStringNotContainsString('\e[', $ex->getColorfulText());
+
+        self::assertSame(<<<"EOF"
+            \e[0m\e[1m\e[41m--[ Critical Error ]\e[0m
+            Atk4\Core\Exception: \e[1m\e[30mMy exception for <a> tag\e[0m \e[31m\e[0m
+            \e[91m                foo: 111\e[0m
+            \e[92mSolution: Use <b> tag\e[0m
+            \e[1m\e[41m--[ Stack Trace ]\e[0m
+                                           /a/ex.php:\e[31m  10\e[0m
+                                         /a/text.php:\e[31m12345\e[0m  - \e[32mAtk4\Core\Tests\ExceptionRendererTest\e[0m \e[32mAtk4\Core\Tests\ExceptionRendererTest::\e[0m\e[33mformatValue\e[0m\e[33m(...)\e[0m
+                                         /a/main.php:\e[31m  20\e[0m  \e[32mAtk4\Core\Tests\ExceptionRendererTest::\e[0m\e[33mmain\e[0m\e[33m()\e[0m
+
+            EOF, $ex->getColorfulText());
+    }
+}

--- a/tests/ExceptionRendererTest.php
+++ b/tests/ExceptionRendererTest.php
@@ -35,7 +35,7 @@ class ExceptionRendererTest extends TestCase
     {
         $ex = $this->createExceptionWithConstantTrace();
 
-        self::assertSame(<<<"EOF"
+        self::assertSame(<<<'EOF'
             <div class="ui negative icon message">
                 <i class="warning sign icon"></i>
                 <div class="content">
@@ -150,13 +150,13 @@ class ExceptionRendererTest extends TestCase
 
         self::assertSame(<<<"EOF"
             \e[0m\e[1m\e[41m--[ Critical Error ]\e[0m
-            Atk4\Core\Exception: \e[1m\e[30mMy exception for <a> tag\e[0m \e[31m\e[0m
+            Atk4\\Core\\Exception: \e[1m\e[30mMy exception for <a> tag\e[0m \e[31m\e[0m
             \e[91m                foo: 111\e[0m
             \e[92mSolution: Use <b> tag\e[0m
             \e[1m\e[41m--[ Stack Trace ]\e[0m
                                            /a/ex.php:\e[31m  10\e[0m
-                                         /a/text.php:\e[31m12345\e[0m  - \e[32mAtk4\Core\Tests\ExceptionRendererTest\e[0m \e[32mAtk4\Core\Tests\ExceptionRendererTest::\e[0m\e[33mformatValue\e[0m\e[33m(...)\e[0m
-                                         /a/main.php:\e[31m  20\e[0m  \e[32mAtk4\Core\Tests\ExceptionRendererTest::\e[0m\e[33mmain\e[0m\e[33m()\e[0m
+                                         /a/text.php:\e[31m12345\e[0m  - \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest\e[0m \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest::\e[0m\e[33mformatValue\e[0m\e[33m(...)\e[0m
+                                         /a/main.php:\e[31m  20\e[0m  \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest::\e[0m\e[33mmain\e[0m\e[33m()\e[0m
 
             EOF, $ex->getColorfulText());
     }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -48,22 +48,31 @@ class ExceptionTest extends TestCase
 
     public function testColorfulText(): void
     {
+        // there are no format codes after last reset code
+        $reset_at_end = '~\e\[0m(?!.*\e\[[0-9;]*m)~s';
+
+        // every sequence of format codes are reset before using another format
+        $reset_every_format = '~(\e\[[0-9;]*m)+(?!\e\[0m)(?=\e\[[0-9;]*m)~s';
+
         $m = new Exception('TestIt');
 
         $ret = $m->getColorfulText();
         self::assertStringContainsString("\e[", $ret);
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
+        self::assertMatchesRegularExpression($reset_at_end, $ret);
+        self::assertMatchesRegularExpression($reset_every_format, $ret);
 
         $m->addMoreInfo('a1', 111);
         $ret = $m->getColorfulText();
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
+        self::assertMatchesRegularExpression($reset_at_end, $ret);
+        self::assertMatchesRegularExpression($reset_every_format, $ret);
 
         $m->addSolution('Simple solution');
         $ret = $m->getColorfulText();
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
+        self::assertMatchesRegularExpression($reset_at_end, $ret);
+        self::assertMatchesRegularExpression($reset_every_format, $ret);
     }
 
     public function testToSafeString(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -53,19 +53,17 @@ class ExceptionTest extends TestCase
         $ret = $m->getColorfulText();
         self::assertStringContainsString("\e[", $ret);
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
 
         $m->addMoreInfo('a1', 111);
         $ret = $m->getColorfulText();
-        self::assertStringContainsString("\e[", $ret);
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
 
         $m->addSolution('Simple solution');
         $ret = $m->getColorfulText();
-        self::assertStringContainsString("\e[", $ret);
         self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // format is reset
     }
 
     public function testToSafeString(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -46,6 +46,28 @@ class ExceptionTest extends TestCase
         self::assertMatchesRegularExpression('~333~', $ret);
     }
 
+    public function testColorfulText(): void
+    {
+        $m = new Exception('TestIt');
+
+        $ret = $m->getColorfulText();
+        self::assertStringContainsString("\e[", $ret);
+        self::assertStringNotContainsString('\e[', $ret);
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+
+        $m->addMoreInfo('a1', 111);
+        $ret = $m->getColorfulText();
+        self::assertStringContainsString("\e[", $ret);
+        self::assertStringNotContainsString('\e[', $ret);
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+
+        $m->addSolution('Simple solution');
+        $ret = $m->getColorfulText();
+        self::assertStringContainsString("\e[", $ret);
+        self::assertStringNotContainsString('\e[', $ret);
+        self::assertMatchesRegularExpression('~\e\[0m(?!.*\e\[[0-9;]*m)~s', $ret); // reset colors at the end
+    }
+
     public function testToSafeString(): void
     {
         self::assertSame('1', RendererAbstract::toSafeString(1));

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Atk4\Core\Tests;
 
 use Atk4\Core\Exception;
-use Atk4\Core\ExceptionRenderer\RendererAbstract;
-use Atk4\Core\NameTrait;
 use Atk4\Core\Phpunit\TestCase;
-use Atk4\Core\TrackableTrait;
 
 class ExceptionTest extends TestCase
 {
@@ -41,39 +38,6 @@ class ExceptionTest extends TestCase
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
-    }
-
-    public function testToSafeString(): void
-    {
-        self::assertSame('1', RendererAbstract::toSafeString(1));
-
-        self::assertSame('\'abc\'', RendererAbstract::toSafeString('abc'));
-
-        self::assertSame(\stdClass::class, RendererAbstract::toSafeString(new \stdClass()));
-
-        self::assertSame(\DateTime::class, RendererAbstract::toSafeString(new \DateTime()));
-
-        self::assertSame(\Closure::class, RendererAbstract::toSafeString(static fn () => true));
-
-        $resource = opendir(__DIR__);
-        self::assertSame('resource (stream)', RendererAbstract::toSafeString($resource));
-        closedir($resource);
-        self::assertSame('resource (closed)', RendererAbstract::toSafeString($resource));
-
-        $a = new TrackableMock();
-        $a->shortName = 'foo';
-        self::assertSame(TrackableMock::class . ' (foo)', RendererAbstract::toSafeString($a));
-
-        $a = new TrackableMock();
-        self::assertSame(TrackableMock::class . ' ()', RendererAbstract::toSafeString($a));
-
-        $a = new TrackableMock2();
-        $a->shortName = 'foo';
-        self::assertSame(TrackableMock2::class . ' (foo)', RendererAbstract::toSafeString($a));
-
-        $a = new TrackableMock2();
-        $a->name = 'foo';
-        self::assertSame(TrackableMock2::class . ' (foo)', RendererAbstract::toSafeString($a));
     }
 
     public function testMore(): void
@@ -149,51 +113,5 @@ class ExceptionTest extends TestCase
                 EOF,
             $ex->toString()
         );
-    }
-
-    public function testExceptionFallback(): void
-    {
-        $ex = new ExceptionTestThrowError('test', 2);
-        $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
-            . ExceptionTestThrowError::class . '(2): test !!';
-        self::assertSame($expectedFallbackText, $ex->getHtml());
-        self::assertSame($expectedFallbackText, $ex->getColorfulText());
-        self::assertSame(
-            json_encode(
-                [
-                    'success' => false,
-                    'code' => 2,
-                    'message' => 'Error during json renderer: test',
-                    'title' => ExceptionTestThrowError::class,
-                    'class' => ExceptionTestThrowError::class,
-                    'params' => [],
-                    'solution' => [],
-                    'trace' => [],
-                    'previous' => [
-                        'title' => 'Exception',
-                        'class' => 'Exception',
-                        'code' => 0,
-                        'message' => 'just to cover __string',
-                    ],
-                ],
-                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE
-            ),
-            $ex->getJson()
-        );
-    }
-}
-
-class TrackableMock2
-{
-    use NameTrait;
-    use TrackableTrait;
-}
-
-class ExceptionTestThrowError extends Exception
-{
-    #[\Override]
-    public function getCustomExceptionTitle(): string
-    {
-        throw new \Exception('just to cover __string');
     }
 }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -27,52 +27,20 @@ class ExceptionTest extends TestCase
 
         self::assertSame(['a1' => 222, 'a2' => 333], $m->getParams());
 
-        // get HTML
         $ret = $m->getHtml();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
 
-        // get colorful text
         $ret = $m->getColorfulText();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
 
-        // get JSON
         $ret = $m->getJson();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
-    }
-
-    public function testColorfulText(): void
-    {
-        // there are no format codes after last reset code
-        $reset_at_end = '~\e\[0m(?!.*\e\[[0-9;]*m)~s';
-
-        // every sequence of format codes are reset before using another format
-        $reset_every_format = '~(\e\[[0-9;]*m)+(?!\e\[0m)(?=\e\[[0-9;]*m)~s';
-
-        $m = new Exception('TestIt');
-
-        $ret = $m->getColorfulText();
-        self::assertStringContainsString("\e[", $ret);
-        self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression($reset_at_end, $ret);
-        self::assertMatchesRegularExpression($reset_every_format, $ret);
-
-        $m->addMoreInfo('a1', 111);
-        $ret = $m->getColorfulText();
-        self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression($reset_at_end, $ret);
-        self::assertMatchesRegularExpression($reset_every_format, $ret);
-
-        $m->addSolution('Simple solution');
-        $ret = $m->getColorfulText();
-        self::assertStringNotContainsString('\e[', $ret);
-        self::assertMatchesRegularExpression($reset_at_end, $ret);
-        self::assertMatchesRegularExpression($reset_every_format, $ret);
     }
 
     public function testToSafeString(): void

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -14,30 +14,30 @@ class ExceptionTest extends TestCase
 {
     public function testBasic(): void
     {
-        $m = (new Exception('TestIt'))
+        $ex = (new Exception('TestIt'))
             ->addMoreInfo('a1', 111)
             ->addMoreInfo('a2', 222);
 
-        self::assertSame(['a1' => 111, 'a2' => 222], $m->getParams());
+        self::assertSame(['a1' => 111, 'a2' => 222], $ex->getParams());
 
-        $m = new Exception('PreviousError');
-        $m = new Exception('TestIt', 123, $m);
-        $m->addMoreInfo('a1', 222);
-        $m->addMoreInfo('a2', 333);
+        $ex = new Exception('PreviousError');
+        $ex = new Exception('TestIt', 123, $ex);
+        $ex->addMoreInfo('a1', 222);
+        $ex->addMoreInfo('a2', 333);
 
-        self::assertSame(['a1' => 222, 'a2' => 333], $m->getParams());
+        self::assertSame(['a1' => 222, 'a2' => 333], $ex->getParams());
 
-        $ret = $m->getHtml();
+        $ret = $ex->getHtml();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
 
-        $ret = $m->getColorfulText();
+        $ret = $ex->getColorfulText();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
 
-        $ret = $m->getJson();
+        $ret = $ex->getJson();
         self::assertMatchesRegularExpression('~TestIt~', $ret);
         self::assertMatchesRegularExpression('~PreviousError~', $ret);
         self::assertMatchesRegularExpression('~333~', $ret);
@@ -78,59 +78,59 @@ class ExceptionTest extends TestCase
 
     public function testMore(): void
     {
-        $m = new \Exception('Classic Exception');
+        $ex = new \Exception('Classic Exception');
 
-        $m = new Exception('atk4 exception', 0, $m);
-        $m->setMessage('bumbum');
+        $ex = new Exception('atk4 exception', 0, $ex);
+        $ex->setMessage('bumbum');
 
-        $ret = $m->getHtml();
+        $ret = $ex->getHtml();
         self::assertMatchesRegularExpression('~Classic~', $ret);
         self::assertMatchesRegularExpression('~bumbum~', $ret);
 
-        $ret = $m->getColorfulText();
+        $ret = $ex->getColorfulText();
         self::assertMatchesRegularExpression('~Classic~', $ret);
         self::assertMatchesRegularExpression('~bumbum~', $ret);
 
-        $ret = $m->getJson();
+        $ret = $ex->getJson();
         self::assertMatchesRegularExpression('~Classic~', $ret);
         self::assertMatchesRegularExpression('~bumbum~', $ret);
     }
 
     public function testSolution(): void
     {
-        $m = new Exception('Exception with solution');
-        $m->addSolution('One Solution');
+        $ex = new Exception('Exception with solution');
+        $ex->addSolution('One Solution');
 
-        $ret = $m->getHtml();
+        $ret = $ex->getHtml();
         self::assertMatchesRegularExpression('~One Solution~', $ret);
 
-        $ret = $m->getColorfulText();
+        $ret = $ex->getColorfulText();
         self::assertMatchesRegularExpression('~One Solution~', $ret);
 
-        $ret = $m->getJson();
+        $ret = $ex->getJson();
         self::assertMatchesRegularExpression('~One Solution~', $ret);
     }
 
     public function testSolution2(): void
     {
-        $m = (new Exception('Exception with solution'))
+        $ex = (new Exception('Exception with solution'))
             ->addSolution('1st Solution');
 
-        $ret = $m->getColorfulText();
+        $ret = $ex->getColorfulText();
         self::assertMatchesRegularExpression('~1st Solution~', $ret);
 
-        $m = (new Exception('Exception with solution'))
+        $ex = (new Exception('Exception with solution'))
             ->addSolution('1st Solution')
             ->addSolution('2nd Solution');
 
-        $ret = $m->getColorfulText();
+        $ret = $ex->getColorfulText();
         self::assertMatchesRegularExpression('~1st Solution~', $ret);
         self::assertMatchesRegularExpression('~2nd Solution~', $ret);
     }
 
     public function testPhpunitSelfDescribing(): void
     {
-        $m = (new Exception('My exception', 0))
+        $ex = (new Exception('My exception', 0))
             ->addMoreInfo('x', 'foo')
             ->addMoreInfo('y', ['bar' => 2.4, [], [[1]]]);
 
@@ -147,17 +147,17 @@ class ExceptionTest extends TestCase
                     ]
 
                 EOF,
-            $m->toString()
+            $ex->toString()
         );
     }
 
     public function testExceptionFallback(): void
     {
-        $m = new ExceptionTestThrowError('test', 2);
+        $ex = new ExceptionTestThrowError('test', 2);
         $expectedFallbackText = '!! ATK4 CORE ERROR - EXCEPTION RENDER FAILED: '
             . ExceptionTestThrowError::class . '(2): test !!';
-        self::assertSame($expectedFallbackText, $m->getHtml());
-        self::assertSame($expectedFallbackText, $m->getColorfulText());
+        self::assertSame($expectedFallbackText, $ex->getHtml());
+        self::assertSame($expectedFallbackText, $ex->getColorfulText());
         self::assertSame(
             json_encode(
                 [
@@ -178,7 +178,7 @@ class ExceptionTest extends TestCase
                 ],
                 \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE
             ),
-            $m->getJson()
+            $ex->getJson()
         );
     }
 }


### PR DESCRIPTION
fix #420

* fix missing reset codes
* add all colors as constants
* use unified text styling method
* replace PHP_EOL with \n because it works nicely in Windows console too
* add additional tests
