### PR TITLE
Fix `DiContainerTrait::assertInstanceOf` if invoked with union

### DIFF
--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -83,7 +83,7 @@ trait DiContainerTrait
      * The best, typehinting-friendly, way to annotate object type if it not defined
      * at method header or strong typing in method header cannot be used.
      *
-     * @template T
+     * @template T of object = object
      *
      * @param T $object
      *

--- a/src/DiContainerTrait.php
+++ b/src/DiContainerTrait.php
@@ -83,7 +83,7 @@ trait DiContainerTrait
      * The best, typehinting-friendly, way to annotate object type if it not defined
      * at method header or strong typing in method header cannot be used.
      *
-     * @template T of object
+     * @template T
      *
      * @param T $object
      *

--- a/tests/ExceptionRendererTest.php
+++ b/tests/ExceptionRendererTest.php
@@ -155,7 +155,7 @@ class ExceptionRendererTest extends TestCase
         self::assertStringStartsWith("\e[0;", $e->getColorfulText());
         self::assertStringEndsWith("\n", $e->getColorfulText());
 
-        self::assertSame(str_replace("\e", '\e', <<<"EOF"
+        $expectedText = <<<"EOF"
             \e[0;1;41m--[ Critical Error ]\e[0m
             Atk4\\Core\\Exception: \e[1;30mMy exception for <a> tag\e[0m \e[31m[code: 5]\e[0m
             \e[91m                foo: 111\e[0m
@@ -165,7 +165,9 @@ class ExceptionRendererTest extends TestCase
                                          /a/text.php:\e[31m12345\e[0m  - \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest\e[0m \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest::\e[0;33mformatValue\e[0;33m(...)\e[0m
                                          /a/main.php:\e[31m  20\e[0m  \e[32mAtk4\\Core\\Tests\\ExceptionRendererTest::\e[0;33mmain\e[0;33m()\e[0m
 
-            EOF), str_replace("\e", '\e', $e->getColorfulText()));
+            EOF;
+        self::assertSame(str_replace("\e", '\e', $expectedText), str_replace("\e", '\e', $e->getColorfulText()));
+        self::assertSame($expectedText, $e->getColorfulText());
 
         self::assertStringNotContainsString('\e[', $e->getColorfulText());
 

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -90,7 +90,20 @@ class StaticAddToTest extends TestCase
         StdSat2::assertInstanceOf(new StdSat());
     }
 
-    private function createStdSat2(): \stdClass
+    private function createStdSat2AsParent(): \stdClass
+    {
+        return new StdSat2();
+    }
+
+    private function createStdSat2AsNullable(): ?StdSat2 // @phpstan-ignore return.unusedType
+    {
+        return new StdSat2();
+    }
+
+    /**
+     * @return mixed
+     */
+    private function createStdSat2AsMixed()
     {
         return new StdSat2();
     }
@@ -101,16 +114,22 @@ class StaticAddToTest extends TestCase
     #[DoesNotPerformAssertions]
     public function testAssertInstanceOfPhpstan(): void
     {
-        $o = $this->createStdSat2();
+        $o = $this->createStdSat2AsParent();
         $o->foo(); // @phpstan-ignore method.nonObject
 
-        $o = $this->createStdSat2();
+        $o = $this->createStdSat2AsParent();
         StdSat2::assertInstanceOf($o)->foo();
 
         $o = new StdSat2();
         StdSat::assertInstanceOf($o)->foo();
 
-        $o = $this->createStdSat2();
+        $o = $this->createStdSat2AsNullable();
+        StdSat2::assertInstanceOf($o)->foo(); // @phpstan-ignore argument.templateType (https://github.com/phpstan/phpstan/issues/12558)
+
+        $o = $this->createStdSat2AsMixed();
+        StdSat2::assertInstanceOf($o)->foo(); // @phpstan-ignore argument.templateType (https://github.com/phpstan/phpstan/issues/12558)
+
+        $o = $this->createStdSat2AsParent();
         StdSat2::assertInstanceOf($o);
         $o->foo(); // @phpstan-ignore method.nonObject (TODO remove once https://github.com/phpstan/phpstan/issues/12548 is fixed)
     }

--- a/tests/StaticAddToTest.php
+++ b/tests/StaticAddToTest.php
@@ -101,6 +101,14 @@ class StaticAddToTest extends TestCase
     }
 
     /**
+     * @return StdSat2|false
+     */
+    private function createStdSat2AsUnionWithFalse() // @phpstan-ignore return.unusedType
+    {
+        return new StdSat2();
+    }
+
+    /**
      * @return mixed
      */
     private function createStdSat2AsMixed()
@@ -124,10 +132,13 @@ class StaticAddToTest extends TestCase
         StdSat::assertInstanceOf($o)->foo();
 
         $o = $this->createStdSat2AsNullable();
-        StdSat2::assertInstanceOf($o)->foo(); // @phpstan-ignore argument.templateType (https://github.com/phpstan/phpstan/issues/12558)
+        StdSat2::assertInstanceOf($o)->foo();
+
+        $o = $this->createStdSat2AsUnionWithFalse();
+        StdSat2::assertInstanceOf($o)->foo();
 
         $o = $this->createStdSat2AsMixed();
-        StdSat2::assertInstanceOf($o)->foo(); // @phpstan-ignore argument.templateType (https://github.com/phpstan/phpstan/issues/12558)
+        StdSat2::assertInstanceOf($o)->foo();
 
         $o = $this->createStdSat2AsParent();
         StdSat2::assertInstanceOf($o);


### PR DESCRIPTION
related with https://github.com/phpstan/phpstan/issues/12558, but level 6 should not require the default union type